### PR TITLE
replacing Dinko with the cms-btv-pog organization

### DIFF
--- a/watchers.py
+++ b/watchers.py
@@ -60,10 +60,19 @@ WATCHERS = {
   "valuev": [
     "L1Trigger/CSCTriggerPrimitives",
   ],
-  "ferencek": [
-    "RecoJets",
-    "RecoBTag",
-    "RecoBTau",
+  "cms-btv-pog": [
+    "DataFormats/BTauReco",
+    "DQMOffline/RecoB",
+    "SimDataFormats/JetMatching",
+    "HLTriggerOffline/Btag",
+    "HLTrigger/btau",
+    "PhysicsTools/JetMCAlgos",
+    "PhysicsTools/JetMCUtils",
+    "RecoJets/JetAssociationAlgorithms",
+    "RecoJets/JetAssociationProducers",
+    "RecoVertex/AdaptiveVertexFinder",
+    "RecoVertex/AdaptiveVertexFit",
+    "Validation/RecoB",
   ],
   "jpavel": [
     "RecoTautag",


### PR DESCRIPTION
Replacing Dinko with the cms-btv-pog organization as a new watcher of the BTV-related packages
