### PR TITLE
Adding HI software contacts to watch specific packages

### DIFF
--- a/watchers.py
+++ b/watchers.py
@@ -105,6 +105,7 @@ WATCHERS = {
   "yetkinyilmaz": ["RecoHI", "HeavyIonsAnalysis", "DataFormats/HeavyIonEvent"],
   "richard-cms": ["RecoHI", "Validation/RecoHI", "Validation/RecoEgamma"],
   "kkrajczar": ["Validation/RecoHI"],
+  "rylanC24": ["Validation/RecoHI"],
   "yenjie": ["RecoHI"],
   "yslai": ["RecoHI/HiJetAlgos", "RecoJets/JetProducers", "DataFormats/HeavyIonEvent"],
   "cbaus": [


### PR DESCRIPTION
This is a follow-up on https://github.com/cms-sw/cmssw/issues/1633

P.S. this file is somehow starting to take place of the earlier .admin/developers thing. I observe that the HI people are the ones who first insisted on having this much detailed watching set-up, however, other people may ask for that too. Is it possible to factorize this script into smaller groups, in case other groups in CMS realize by time they may need this feature?
