### PR TITLE
Changed the performance summary plots to use cmsgraph.cern.ch

### DIFF
--- a/generate-json-performance-charts
+++ b/generate-json-performance-charts
@@ -5,6 +5,11 @@ from os import path
 import re
 import json
 
+#------------------------------------------------------------------------------------------------------------
+# This script reads a list of the workflows, steps and parameters for which you want to see the graphs
+# It generates a json file with the correct structure and links to each graph, this json file is used
+# to create the visualization
+#------------------------------------------------------------------------------------------------------------
 
 def get_wfs_ordered(base_dir):
 	workflows={}
@@ -59,10 +64,55 @@ def print_workflows(wfs):
       for img in step['imgs']:
         print img
 
+def add_workflow(results,wf_name):
+  for wf in results['wfs']:
+    if wf['wf_name'] == wf_name:
+      return wf
+  
+  new_wf = {}
+  new_wf['wf_name'] = wf_name
+  results['wfs'].append(new_wf)
+  return new_wf
+
+def add_step(workflow,step_name):
+
+  if not workflow.get('steps'):
+    workflow['steps'] = []
+
+  for step in workflow['steps']:
+    if step['step_name'] == step_name:
+      return step
+  
+  new_step = {}
+  new_step['step_name'] = step_name
+  workflow['steps'].append(new_step)
+  return new_step
+
+def add_param(step,param_name):
+
+  if not step.get('imgs'):
+    step['imgs'] = []
+
+  for p in step['imgs']:
+    if p['name'] == param_name:
+      return p
+
+  new_param = {}
+  new_param['name'] = param_name
+  step['imgs'].append(new_param)
+  return new_param
+
+def add_url_to_param(workflow,step,param):
+  step_number = step['step_name'].split('_')[0]
+  url = BASE_URL.replace('WORKFLOW',workflow['wf_name']).replace('STEP',step_number).replace('PARAM',param['name'])
+  url = url.replace('+','%2B')
+  print url
+  param['url'] = url
+
 #-----------------------------------------------------------------------------------
 #---- Parser Options
 #-----------------------------------------------------------------------------------
-parser = OptionParser(usage="usage: %prog RELEASE_NAME BASE_DIR \n RELEASE_NAME \t release for which the summary will be generated.\n BASE_DIR \t the files where the results are")
+parser = OptionParser(usage="usage: %prog PLOTS_LIST \n PLOTS_LIST list of plots that you want to visualize")
 
 (options, args) = parser.parse_args()
 
@@ -70,27 +120,39 @@ parser = OptionParser(usage="usage: %prog RELEASE_NAME BASE_DIR \n RELEASE_NAME 
 #---- Start
 #-----------------------------------------------------------------------------------
 
-if (len(args)<2):
-        print 'you need to specify a release name and a base directory'
+if (len(args)<1):
+        print 'you need to specify a list of plots'
         parser.print_help()
         exit()
 
-release = args[0]
-BASE_DIR = args[1]
+WF_LIST = args[0]
 
-BASE_URL = 'https://cmssdt.cern.ch/SDT/jenkins-artifacts/performance/summary/'
-RESULT_FILE_NAMES = ['maximum_rss_histo.png', 'average_cpu_histo.png']
+GRAPH_PARAMS = '&from=-15days&fontBold=true&fontSize=12&lineWidth=5&title=PARAM'
 
-print 'I will generate the results page for %s \n' % release
+BASE_URL = 'https://cmsgraph.cern.ch/render?target=IBRelVals.slc6_amd64_gcc481.CMSSW_7_1_X.WORKFLOW.STEP.PARAM&height=800&width=800%s'%GRAPH_PARAMS
 
 result = {}
 
-workflows = get_workflows()
+lines = open(WF_LIST, "r").readlines()
 
-print_workflows(workflows)
+result['wfs'] = []
 
-result['wfs'] = workflows
-result['last_release'] = release
+for l in lines:
+  if l.startswith("#"):
+    continue
+  else:
+    l = l.replace('\n','')
+    parts = l.split(' ')
+    wf_name = parts[0]
+    step_name = parts[1]
+    param_name = parts[2]
+
+    workflow = add_workflow(result,wf_name)
+    step = add_step(workflow,step_name)
+    param = add_param(step,param_name)
+    add_url_to_param(workflow,step,param)
+
+print result
 
 out_json = open("plots_summary.json", "w")
 json.dump(result,out_json,indent=4)

--- a/templates/performance-summary-plots-list
+++ b/templates/performance-summary-plots-list
@@ -1,0 +1,12 @@
+# This is a list that contains the workflows,steps, and
+# parameter to be reported on the webpage. When read, 
+# it will be used to generate the json file with the 
+# urls of the results on graphite.
+5_1_TTbar+TTbarFS+HARVESTFS step1_TTbar+TTbarFS+HARVESTFS AvgEventCPU
+5_1_TTbar+TTbarFS+HARVESTFS step1_TTbar+TTbarFS+HARVESTFS PeakValueRss
+202_0_TTbar+TTbarINPUT+DIGIPU1+RECOPU1+HARVEST step2_TTbar+TTbar+DIGIPU1+RECOPU1+HARVEST AvgEventCPU
+202_0_TTbar+TTbarINPUT+DIGIPU1+RECOPU1+HARVEST step2_TTbar+TTbar+DIGIPU1+RECOPU1+HARVEST PeakValueRss
+202_0_TTbar+TTbarINPUT+DIGIPU1+RECOPU1+HARVEST step3_TTbar+TTbar+DIGIPU1+RECOPU1+HARVEST AvgEventCPU
+202_0_TTbar+TTbarINPUT+DIGIPU1+RECOPU1+HARVEST step3_TTbar+TTbar+DIGIPU1+RECOPU1+HARVEST PeakValueRss
+400_0_TTbar+TTbarFSPU+HARVESTFS step1_TTbar+TTbarFSPU+HARVESTFS AvgEventCPU
+400_0_TTbar+TTbarFSPU+HARVESTFS step1_TTbar+TTbarFSPU+HARVESTFS PeakValueRss

--- a/templates/performanceSummaryOut.html
+++ b/templates/performanceSummaryOut.html
@@ -23,11 +23,11 @@
         
 	$(document).ready(function () {
 
-		create_header_table = function(last_release,table){
+		create_header_table = function(table){
 
 			var header = $('<thead>')
 			var h_row = $('<tr>')
-			var last_rel = $('<h2>').text('Last Release Evaulated: ' + last_release)
+			var last_rel = $('<h2>').text('Performance Plots Summary')
 			
 			h_row.append($('<td>').append(last_rel))
 			
@@ -71,7 +71,7 @@
 
 		}
 
-		addImgsRow = function(imgs,tbody){
+		addImgsRows = function(imgs,tbody){
 			var row = $('<tr>')
 			
 			for( var i = 0 ; i < imgs.length ; i++){
@@ -94,7 +94,22 @@
 				row.append(cell)
 
 			}
+
                         tbody.append(row)
+
+			var rowTittles = $('<tr>')
+
+			for( var i = 0 ; i < imgs.length ; i++){
+                                var cell = $('<td>')
+				var title = imgs[i].name
+
+                                cell.append($('<center>').text(title))
+                                rowTittles.append(cell)
+
+                        }
+
+
+			tbody.append(rowTittles)
 
 		}
 
@@ -111,7 +126,7 @@
 				var steps = wf.steps
 				for (var j =  0; j < steps.length; j++){
 					addStepRow(steps[j],tbody)
-					addImgsRow(steps[j].imgs,tbody)
+					addImgsRows(steps[j].imgs,tbody)
 
 				}
 
@@ -125,7 +140,7 @@
 			
 			var table = $('<table class="table"></table>')
 
-			create_header_table(data.last_release,table)
+			create_header_table(table)
 			addResultsTable(data.wfs,table)
 
 			$("#results").append(table)


### PR DESCRIPTION
Now the graphs are generated from the information stored in
graphite. They don't need jenkins anymore.

The file performance-summary-plots-list contains a list of the
workfows, steps and parameters that we want to show.

The script generate-json-performance-charts reads this list and
generates a json file with the correct structure and urls for
their visualizations.
