### PR TITLE
auto-update-git-branches: merge CMSSW_7_2_X stable into gcc491

### DIFF
--- a/auto-update-git-branches
+++ b/auto-update-git-branches
@@ -71,4 +71,5 @@ updateBranch IB/CMSSW_7_1_X/stable IB/CMSSW_7_2_X/stable
 updateBranch IB/CMSSW_7_2_X/stable IB/CMSSW_7_2_X/root6
 updateBranch IB/CMSSW_7_2_X/stable IB/CMSSW_7_2_X/geant10
 updateBranch IB/CMSSW_7_2_X/stable IB/CMSSW_7_2_X/gcc490
+updateBranch IB/CMSSW_7_2_X/stable IB/CMSSW_7_2_X/gcc491
 updateBranch IB/CMSSW_7_2_X/stable IB/CMSSW_7_2_X/next


### PR DESCRIPTION
CMSDIST for `stable' and`gcc491' are out of sync. Merge `stable'
into`gcc491'.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
