### PR TITLE
Assign a milestone for CMSDIST requests.

### DIFF
--- a/process-cmsdist-request
+++ b/process-cmsdist-request
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+from github import Github
+from os.path import expanduser
+from optparse import OptionParser
+import yaml
+
+import re
+from sys import exit
+
+RELEASE_BRANCH_MILESTONE=yaml.load("cmsdist-milestones.yaml")
+
+# Prepare various comments regardless of whether they will be made or not.
+def format(s, **kwds):
+  return s % kwds
+
+# Update the milestone for a given issue.
+# - If the issue already has a milestone, do not bother.
+# - Get the name of the release queue and construct a milestone name
+# - Get the list of all milestones and check if the milestone name is already there.
+#   - If not create a milestone
+#   - If yes assign the issue to the milestone.
+def updateMilestone(repo, issue, pr):
+  if issue.milestone:
+    return
+  branch = pr.base.label.split(":")[1]
+  IS_CMSDIST_RE="IB/(CMSSW[^/]*)/[^/]+$"
+  m = re.match(IS_CMSDIST_RE, branch)
+  if not m:
+    return
+  milestoneName = "Next " + m.group(1)
+
+  milestones = repo.get_milestones(state="open")
+
+  for milestone in milestones:
+    if milestone.title == milestoneName:
+      print "Assign to milestone " + str(milestone.number)
+      issue.edit(milestone=milestone)
+      return
+
+  print "Create milestone " + milestoneName
+  milestone = repo.create_milestone(title=milestoneName)
+  issue.edit(milestone=milestone)
+
+IS_CMSDIST_RE="IB/(CMSSW[^/]*)/[^/]+$"
+
+if __name__ == "__main__":
+  parser = OptionParser(usage="%prog <pull-request-id>")
+  parser.add_option("-n", "--dry-run", dest="dryRun", action="store_true", help="Do not modify Github", default=False)
+  opts, args = parser.parse_args()
+
+  if len(args) != 1:
+    parser.error("Too many arguments")
+  prId = int(args[0])
+  gh = Github(login_or_token=open(expanduser("~/.github-token")).read().strip())
+  try:
+    pr = gh.get_organization("cms-sw").get_repo("cmsdist").get_pull(prId)
+  except:
+    print "Could not find pull request. Maybe this is an issue"
+    exit(0)
+
+  repo = gh.get_organization("cms-sw").get_repo("cmsdist")
+  issue = repo.get_issue(prId)
+
+  updateMilestone(repo, issue, pr)

--- a/query-new-pull-requests
+++ b/query-new-pull-requests
@@ -1,4 +1,4 @@
-#!/usr/bin/env python                                                                                                                                                                                                  
+#!/usr/bin/env python
 from github import Github
 from os.path import expanduser
 from optparse import OptionParser
@@ -8,11 +8,13 @@ import re
 
 if __name__ == "__main__":
   parser = OptionParser(usage="%prog <since-n-seconds>")
+  parser.add_option("--repository", "-r", dest="repository", type=str, default="cmssw")
   opts, args = parser.parse_args()
   if not len(args):
     parser.error("Please specify the number of seconds since you want updates")
 
   since = datetime.utcnow() - timedelta(seconds=int(args[0]))
   gh = Github(login_or_token=open(expanduser("~/.github-token")).read().strip())
-  issues = gh.get_organization("cms-sw").get_repo("cmssw").get_issues(state="open", sort="updated", since=since)
+  repo = gh.get_organization("cms-sw").get_repo(opts.repository)
+  issues = repo.get_issues(state="open", sort="updated", since=since)
   print " ".join([str(x.number) for x in issues])


### PR DESCRIPTION
- Add new script process-cmsdist-request which implements the logic for
  assigning milestones.
- modify query new pull requests so that it can return recent requests
  from any repository (default cmssw).
