### PR TITLE
Automatically build a release when requested in the github issues

### DIFF
--- a/build-release
+++ b/build-release
@@ -1,0 +1,38 @@
+#!/bin/sh -ex
+
+# The release should have been already created in Github
+# CMSSW_X_Y_Z: the release to build
+# ARCH: architecture for the build
+
+HERE=$WORKSPACE/build
+BUILD_DIR=$HERE/$CMSSW_X_Y_Z-build
+mkdir -p BUILD_DIR
+QUEUE=`echo $CMSSW_X_Y_Z | sed -e 's/\(CMSSW_[0-9][0-9]*_[0-9][0-9]*\).*/\1_X/'`
+git clone git@github.com:cms-sw/cmsdist.git $BUILD_DIR/CMSDIST
+pushd $BUILD_DIR/CMSDIST
+  eval $(cat config.map | grep "SCRAM_ARCH=$ARCH;" | grep "RELEASE_QUEUE=$QUEUE;")
+
+  # a patch release uses the same cmsdist tag as its base release
+  case $CMSSW_X_Y_Z in
+    *patch*)
+    BASE_RELEASE=`echo $CMSSW_X_Y_Z | sed 's/_patch[0-9]*//g'`
+    CMSDIST_TAG=REL/$BASE_RELEASE/$ARCH
+  ;;
+  esac
+
+  git checkout $CMSDIST_TAG
+popd
+
+git clone -b $PKGTOOLS_TAG git@github.com:cms-sw/pkgtools.git $BUILD_DIR/PKGTOOLS
+
+pushd $BUILD_DIR
+  # prepare cmssw.spec
+  sh -e PKGTOOLS/scripts/prepare-cmsdist $CMSSW_X_Y_Z $ARCH 2>&1 | tee -a $WORKSPACE/prepare-cmsdist.log
+  PKGTOOLS/cmsBuild --architecture=$ARCH --builders 4 -j 16 build cmssw 2>&1 | tee -a $WORKSPACE/build.log
+popd
+
+if grep "RPM build errors" $WORKSPACE/build.log; then
+  echo "The build had errors"
+else
+  echo "The build ran ok"
+fi

--- a/categories.py
+++ b/categories.py
@@ -1,6 +1,8 @@
 # A ridicously long mapping for categories. Good enough for now.
 import re
 
+AUTO_BUILD_RELEASE = [ "nclopezo" , "ktf" ]
+
 CMSSW_L2 = {
   "Martin-Grunewald": ["hlt"],
   "perrotta": ["hlt"],

--- a/process-build-release-request
+++ b/process-build-release-request
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+from optparse import OptionParser
+from github import Github
+from os.path import expanduser
+from categories import AUTO_BUILD_RELEASE
+import re
+import json
+import urllib2
+
+# 
+# Processes a github issue to check if it is requesting the build of a new release
+# If the issue is not requesting any release, it ignores it. 
+#
+
+# -------------------------------------------------------------------------------
+# Global Variables
+# --------------------------------------------------------------------------------
+GH_CMSSW_ORGANIZATION = 'cms-sw'
+GH_CMSSW_REPO = 'cmssw'
+BUILD_REL = 'Build'
+NOT_AUTHORIZED_MSG = 'You are not authorized to trigger the build of a release.'
+CONFIG_MAP_FILE = 'config.map'
+NO_ARCHS_FOUND_MSG = 'No architecures to build found for %s. Please check that you entered a ' \
+                     'valid release name or that the IBs are currently enabled for that release queue'
+RELEASE_BASE_URL = 'https://github.com/cms-sw/cmssw/releases/tag/%s'
+RELEASE_CREATED_MSG = 'Release created: %s'
+QUEUING_BUILDS_MSG = 'Queuing Jenkins build for the following architectures: %s ' 
+BUILD_QUEUED_LABEL = 'build-release-queued'
+JENKINS_CMSSW_X_Y_Z = 'CMSSW_X_Y_Z'
+JENKINS_ARCH = 'ARCH'
+JENKINS_ISSUE_NUMBER = 'ISSUE_NUMBER'
+
+#
+#  Creates the properties files to trigger the build in Jenkins
+#
+def create_properties_files( release_name , architectures , issue_number ):
+  for arch in architectures:
+    print 'Creating properties file for %s' % arch
+    out_file_name = '%s-%s.properties' % ( release_name , arch )
+    out_file = open( out_file_name , 'w' )
+    out_file.write( '%s=%s\n' % ( JENKINS_CMSSW_X_Y_Z , release_name ) )
+    out_file.write( '%s=%s\n' % ( JENKINS_ARCH , arch ) )
+    out_file.write( '%s=%s\n' % ( JENKINS_ISSUE_NUMBER , issue_number ) )
+
+    
+#
+# Creates a release in github
+# If dry-run is selected it doesn't create the release and just prints that
+#
+def create_release_github( repository , release_name , release_queue ):
+  if opts.dryRun:
+    print 'Not creating release (dry-run):\n %s' % release_name
+  else:
+    print 'Creating release:\n %s' % release_name
+    # creating releases will be available in the next version of pyGithub
+    params = { "tag_name" : release_name, 
+             "target_commitish" : release_queue,
+             "name" : release_name,
+             "body" : 'cms-bot is going to build this release',
+             "draft" : False, 
+             "prerelease" : False }
+
+    token = open(expanduser("~/.github-token")).read().strip()
+    request = urllib2.Request("https://api.github.com/repos/cms-sw/cmssw/releases",
+    headers={"Authorization" : "token " + token})
+    request.get_method = lambda: 'POST'
+    print '--'
+    print urllib2.urlopen( request, json.dumps( params  ) ).read()
+    print
+
+
+#
+# Reads config.map and returns a list of the architectures for which a release needs to be built.
+# If the list is empty it means that it didn't find any architecture for that release queue, or 
+# that the IBs are disabled.
+#
+def get_archs_config_map( release_queue ):
+  architectures = []
+  f = open( CONFIG_MAP_FILE , 'r' )
+  for line in f.readlines():
+    if ('%s;'%release_queue in line ) and ( 'DISABLED' not in line ):
+      arch = line.split( 'SCRAM_ARCH=' )[ 1 ].split( ';' )[ 0 ]
+      architectures.append( arch )
+  f.close()
+  return architectures
+#
+# Adds a label to the issue in github
+# if dry-run is selected it doesn't add the label and just prints it
+def add_label( issue , label ):
+  if opts.dryRun:
+    print 'Not adding label (dry-run):\n %s' % label
+  else:
+    print 'Adding label:\n %s' % label
+    issue.add_to_labels( label )
+
+#
+# posts a message to the issue in github
+# if dry-run is selected it doesn't post the message and just prints it
+#
+def post_message( issue , msg ):
+  if opts.dryRun:
+    print 'Not posting message (dry-run):\n %s' % msg
+  else:
+    print 'Posting message:\n %s' % msg 
+    issue.create_comment( msg )
+
+# -------------------------------------------------------------------------------
+# Start of execution 
+# --------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+  parser = OptionParser( usage="%prog <issue-id>" )
+  parser.add_option( "-n" , "--dry-run" , dest="dryRun" , action="store_true", help="Do not post on Github", default=False )
+  parser.add_option( "-f" , "--force" , dest="force" , action="store_true", help="Ignore previous issue labels", default=False )
+  opts, args = parser.parse_args( )
+
+  if len( args ) != 1:
+    parser.error( "Too many arguments" )
+  
+  issue_id  = int( args[ 0 ] )
+  gh = Github( login_or_token=open( expanduser( "~/.github-token" ) ).read( ).strip( ) )
+  issue = gh.get_organization( GH_CMSSW_ORGANIZATION ).get_repo( GH_CMSSW_REPO ).get_issue( issue_id )
+
+  if not opts.force:
+    labels = [ l.name for l in issue.get_labels() ]
+    if BUILD_QUEUED_LABEL in labels:
+      print 'Build already queued, ignoring' 
+      exit( 0 )
+
+  if issue.pull_request:
+    print 'This is a pull request, ignoring.'
+    exit( 0 )
+  if not issue.title.startswith( BUILD_REL ):
+    print 'This issue is not for building a release, ignoring.'
+    exit( 0 )
+  if not issue.user.login in AUTO_BUILD_RELEASE:
+    print 'User not authorized'
+    post_message( issue , NOT_AUTHORIZED_MSG )
+    exit( 0 )
+
+  release_name = issue.title.split( BUILD_REL )[ 1 ].strip()
+  isPatch = 'patch' in release_name
+  release_queue = ''
+  if isPatch:
+    release_queue = re.sub( '[0-9]+$' , 'X' , release_name.split( '_patch' )[ 0 ] )
+  else:
+    release_queue = re.sub( '[0-9]+$' , 'X' , release_name )
+
+  architectures =  get_archs_config_map( release_queue )
+  if not architectures:
+    print 'no archs found'
+    post_message( issue , NO_ARCHS_FOUND_MSG % release_queue )
+    # here the issue should be labeled or something to mark that the release name is wrong and not check it again
+    exit( 0 )
+  else:
+    cmssw_repo = gh.get_organization( GH_CMSSW_ORGANIZATION ).get_repo( GH_CMSSW_REPO )
+    create_release_github( cmssw_repo , release_name , release_queue )
+    msg = RELEASE_CREATED_MSG % ( RELEASE_BASE_URL % release_name )
+    post_message( issue , msg )
+
+    create_properties_files( release_name , architectures , issue_id )
+
+    msg = QUEUING_BUILDS_MSG % ', '.join( architectures )
+    post_message( issue , msg )
+    add_label( issue, BUILD_QUEUED_LABEL )
+
+


### PR DESCRIPTION
For now, It only considers the basic case and it only builds the release, doesn't upload. 
There should be the option to make it hold the upload and installation. So the release can be built and the person who triggered the build can wait until the IB validation is available.
