### PR TITLE
Switch production arch in CMSSW_7_3_0_pre1

### DIFF
--- a/releases.map
+++ b/releases.map
@@ -1100,8 +1100,8 @@ architecture=slc6_amd64_gcc472;label=CMSSW_6_2_0_SLHC19;type=Production;state=An
 architecture=slc5_amd64_gcc472;label=CMSSW_6_2_0_SLHC19;type=Production;state=Announced;prodarch=0;
 architecture=slc6_amd64_gcc472;label=CMSSW_5_3_22;type=Production;state=Announced;prodarch=1;
 architecture=slc5_amd64_gcc462;label=CMSSW_5_3_22;type=Production;state=Announced;prodarch=0;
-architecture=slc6_amd64_gcc481;label=CMSSW_7_3_0_pre1;type=Development;state=Announced;prodarch=1;
-architecture=slc6_amd64_gcc491;label=CMSSW_7_3_0_pre1;type=Development;state=Announced;prodarch=0;
+architecture=slc6_amd64_gcc481;label=CMSSW_7_3_0_pre1;type=Development;state=Announced;prodarch=0;
+architecture=slc6_amd64_gcc491;label=CMSSW_7_3_0_pre1;type=Development;state=Announced;prodarch=1;
 architecture=slc6_amd64_gcc481;label=CMSSW_7_1_11;type=Production;state=Announced;prodarch=1;
 architecture=slc6_amd64_gcc481;label=CMSSW_7_0_9_patch2;type=Production;state=Announced;prodarch=1;
 architecture=slc6_amd64_gcc481;label=CMSSW_7_2_0;type=Production;state=Announced;prodarch=1;


### PR DESCRIPTION
This is required to be able to run validation on both architecture for comparison.
