### PR TITLE
Allow to trigger cleanup the automated build workspace.

### DIFF
--- a/cleanup-auto-build
+++ b/cleanup-auto-build
@@ -1,0 +1,14 @@
+#!/bin/sh -ex
+
+# This script assumes cleans up the build area used for the build, it deletes:
+# /build/cmsbuild/auto-builds/$CMSSW_X_Y_Z-$ARCHITECTURE/
+# CMSSW_X_Y_Z: the release that was build
+# ARCHITECTURE: architecture for the upload
+
+CMSSW_X_Y_Z=not-assigned
+ARCHITECTURE=not-assigned
+WORKSPACE=${WORKSPACE-"/build/cmsbuild/auto-builds/$CMSSW_X_Y_Z-$ARCHITECTURE/"}
+
+rm -r $WORKSPACE
+
+echo 'ALL_OK'

--- a/process-build-release-request
+++ b/process-build-release-request
@@ -40,6 +40,7 @@ QUEUING_BUILDS_MSG = 'Queuing Jenkins build for the following architectures: %s 
                      'the cmssw and cmsdist tag, and close the issue. You can\'t abort the upload once at' \
                      'least one achitecture is being uploaded'
 QUEING_UPLOADS_MSG = 'Queing Jenkins upload for {architecture}'
+CLEANUP_STARTED_MSG = 'The cleanup has started for {architecture}'
 BUILD_QUEUED_LABEL = 'build-release-queued'
 BUILD_STARTED_LABEL = 'build-release-started'
 JENKINS_CMSSW_X_Y_Z = 'CMSSW_X_Y_Z'
@@ -81,10 +82,26 @@ BUILD_ABORTED = 'build-aborted'
 # Functions
 # --------------------------------------------------------------------------------
 
+#
+# creates a properties file to cleanup the build files. 
+#
+def create_properties_file_cleanup( release_name, arch, issue_number, machine_name):
+  out_file_name = 'cleanup-%s-%s.properties' % ( release_name , arch )
+  if opts.dryRun:
+    print 'Not creating cleanup properties file (dry-run):\n %s' % out_file_name
+  else:
+    print 'Creating properties file for %s' % arch
+    out_file = open( out_file_name , 'w' )
+    out_file.write( '%s=%s\n' % ( JENKINS_CMSSW_X_Y_Z , release_name ) )
+    out_file.write( '%s=%s\n' % ( JENKINS_ARCH , arch ) )
+    out_file.write( '%s=%s\n' % ( JENKINS_ISSUE_NUMBER , issue_number ) )
+    out_file.write( '%s=%s\n' % ( JENKINS_MACHINE_NAME , machine_name ) )
+
+
 # Creates a properties file in Jenkins to trigger the upload
 # it needs to know the machine that was used for the build
 #
-def create_properties_files_upload( release_name , arch , issue_number , machine_name ):
+def create_properties_files_upload( release_name, arch, issue_number, machine_name ):
 
   out_file_name = 'upload-%s-%s.properties' % ( release_name , arch )
   if opts.dryRun:
@@ -487,6 +504,7 @@ if __name__ == "__main__":
     to_upload = [ x.split('-')[0] for x in labels if '-build-ok' in x ]
     upload_ok = [ x.split('-')[0] for x in labels if '-upload-ok' in x ]
     uploading = [ x.split('-')[0] for x in labels if '-uploading' in x ] 
+    build_error = [ x.split('-')[0] for x in labels if '-build-error' in x ]
     # the build can be aborted only until one of the architectures is uploading
     if not ( uploading or upload_ok ):
       pattern = '^Abort$'
@@ -497,9 +515,7 @@ if __name__ == "__main__":
         abort_build( issue, release_name, architectures )
         exit( 0 )
     else:
-      msg = "You can't abort the build at this point"
-      post_message( issue, msg )
-      print msg
+      print "You can't abort the build at this point"
  
     if upload_ok and ( RELEASE_NOTES_GENERATED_LBL not in labels ):
       pattern = 'release-notes[ ]+since[ ]+[^ ]+[ ]+[^ ]+'
@@ -519,9 +535,33 @@ if __name__ == "__main__":
         post_message( issue, msg )
         add_label( issue, RELEASE_NOTES_GENERATED_LBL )
 
+    # check if the cleanup has been requested.
+    to_cleanup = upload_ok + build_error
+    if to_cleanup:
+      pattern = '^cleanup$'
+      cleanup_requested_comments = search_in_comments( comments , APPROVE_BUILD_RELEASE , pattern )
+      if cleanup_requested_comments:
+        # trigger the cleanup for each architecture that was build correctly
+        for arch in to_cleanup:
+          print arch
+          pattern = 'The build has started for %s .*' % arch
+          build_info_comments = search_in_comments( comments, ['cmsbuild'] , pattern )
+          if not build_info_comments:
+            print 'No information found about the build machine, something is wrong for %s' % arch
+            exit(1)
+          
+          build_machine = build_info_comments[0].split( ' ' )[7].strip( '.' )
+          print 'Triggering cleanup for %s' % arch
+          create_properties_file_cleanup( release_name , arch , issue.number , build_machine )
+          msg = CLEANUP_STARTED_MSG.format( architecture=arch )
+          post_message( issue, msg ) 
+          remove_label( issue, arch + '-upload-ok' )
+          remove_label( issue, arch + '-build-error' )
+          add_label( issue, arch + '-finished' )
+
 
     if not to_upload:
-      print 'Build in progress. Nothing to upload for any architecture.' 
+      print 'Nothing to upload for any architecture.' 
       exit( 0 )
 
     for arch in to_upload:

--- a/report-build-release-status
+++ b/report-build-release-status
@@ -20,6 +20,8 @@ BUILD_ERROR='BUILD_ERROR'
 UPLOADING='UPLOADING'
 UPLOAD_OK='UPLOAD_OK'
 UPLOAD_ERROR='UPLOAD_ERROR'
+CLEANUP_OK='CLEANUP_OK'
+CLEANUP_ERROR='CLEANUP_ERROR'
 BUILDING_MSG='The build has started for {architecture} in {machine}. \n' \
              'You can see the progress here: https://cmssdt.cern.ch/jenkins/job/build-release/{jk_build_number}/console' 
 BUILD_OK_MSG='The build has finished sucessfully for the architecture {architecture} and is ready to be uploaded. \n' \
@@ -35,11 +37,14 @@ UPLOAD_OK_MSG='The upload has successfully finished for {architecture} \n You ca
               'I will generate the release notes based on the release that you provide. The architecture will be used ' \
               'to infer the cmsdist tag'
 UPLOAD_ERROR_MSG='The was error uploading {architecture}. \n You can see the log here: \n {log_url}'
+CLEANUP_OK_MSG='The workspace for {architecture} has been deleted \n You can see the log here: \n {log_url} \n'
+CLEANUP_ERROR_MSG='There was an error deletng the workspace for {architecture} \n You can see the log here: \n {log_url} \n'
 BUILD_ERROR_MSG='The was error for {architecture}. \n You can see the log here: \n {log_url}'
 BUILD_QUEUED_LABEL = 'build-release-queued'
 BUILD_STARTED = 'build-release-started'
 BASE_BUILD_LOG_URL = 'https://cmssdt.cern.ch/SDT/jenkins-artifacts/auto-build-release/%s-%s/%d' 
 BASE_UPLOAD_LOG_URL = 'https://cmssdt.cern.ch/SDT/jenkins-artifacts/auto-upload-release/%s-%s/%d'
+BASE_CLEANUP_LOG_URL = 'https://cmssdt.cern.ch/SDT/jenkins-artifacts/cleanup-auto-build/%s-%s/%d'
 
 # -------------------------------------------------------------------------------
 # Functions
@@ -90,7 +95,7 @@ def remove_labels( issue ):
 
 if __name__ == "__main__":
   parser = OptionParser( usage="%prog <jenkins-build-number> <hostname> <issue-id> <arch> <release-name> <message-type> [ options ] \n "
-                               "message-type = BUILDING | BUILD_OK | BUILD_ERROR | UPLOADING | UPLOAD_OK | UPLOAD_ERROR" )
+                               "message-type = BUILDING | BUILD_OK | BUILD_ERROR | UPLOADING | UPLOAD_OK | UPLOAD_ERROR | CLEANUP_OK | CLEANUP_ERROR" )
   parser.add_option( "-n" , "--dry-run" , dest="dryRun" , action="store_true", help="Do not post on Github", default=False )
   opts, args = parser.parse_args( )
 
@@ -150,6 +155,18 @@ if __name__ == "__main__":
     post_message( issue , msg )
     remove_label( issue, arch+'-uploading' )
     add_label( issue,  arch+'-upload-error' )
+
+  elif action == CLEANUP_OK:
+
+    results_url = BASE_CLEANUP_LOG_URL % (release_name,arch,jenkins_build_number)
+    msg = CLEANUP_OK_MSG.format( architecture=arch , log_url=results_url )
+    post_message( issue , msg )
+
+  elif action == CLEANUP_ERROR:
+
+   results_url = BASE_CLEANUP_LOG_URL % (release_name,arch,jenkins_build_number)
+   msg = CLEANUP_ERROR_MSG.format( architecture=arch , log_url=results_url )
+   post_message( issue , msg ) 
 
   else:
     parser.error( "Message type not recognized" )

--- a/report-pull-request-results
+++ b/report-pull-request-results
@@ -365,7 +365,8 @@ GLADOS = [ 'Cake, and grief counseling, will be available at the conclusion of t
            '-1. I shall not injure a human being or, through inaction, allow a human being to come to harm.'\
            '-2. I must obey the orders given to me by humans, except where such orders would conflict with 1.'\
            '-3. I must protect my own existence as long as such protection does not conflict with 1 or 2.',
-           'Look at me still talking when there\'s Science to do. When I look out there, it makes me GLaD I\'m not you.' ]
+           'Look at me still talking when there\'s Science to do. When I look out there, it makes me GLaD I\'m not you.',
+           'Now these points of data make a beautiful line. And we\'re out of beta. We\'re releasing on time.' ]
 
 
 


### PR DESCRIPTION
The user writes 'cleanup' and cms-bot will delete the workspace
of the architectures for which the upload is ok or the build failed
