### PR TITLE
Revert "Flag "tests-started" when starting tests for a PR."

### DIFF
--- a/process-pull-request
+++ b/process-pull-request
@@ -287,7 +287,6 @@ if __name__ == "__main__":
     create_properties_file_tests( prId )
     if not opts.dryRun:
       pr.create_issue_comment( TRIGERING_TESTS_MSG )
-      labels.append("tests-started")
 
   # Do not complain about tests
   requiresTestMessage = "or unless it breaks tests."


### PR DESCRIPTION
Reverts cms-sw/cms-bot#298