### PR TITLE
Add DataFormats/Phase2TrackerCluster to reco

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -158,6 +158,7 @@ CMSSW_CATEGORIES={
    "DataFormats/ParticleFlowCandidate",
    "DataFormats/ParticleFlowReco",
    "DataFormats/PixelMatchTrackReco",
+   "DataFormats/Phase2TrackerCluster",
    "DataFormats/Phase2TrackerDigi",
    "DataFormats/RPCRecHit",
    "DataFormats/RecoCandidate", "DataFormats/Scalers",


### PR DESCRIPTION
Pull request cms-sw/cmssw#7305 adds a package for a new Phase2 tracker cluster.  As suggested in the comments on that pull request the package should be categorised under reconstruction.

Note that this package is only available in the CMSSW_6_2_X_SLHC branch.