### PR TITLE
Always create a tag in cmsdist per IB

### DIFF
--- a/build-cmssw-ib-with-patch
+++ b/build-cmssw-ib-with-patch
@@ -181,17 +181,21 @@ $CMSBUILD_CMD `GetCmsBuildConfig $PKGTOOLS_TAG deprecate-local $TOOL_CONF_PACKAG
 $CMSBUILD_CMD -k -j `echo "$BUILD_NPROC * 2" | bc` `GetCmsBuildConfig $PKGTOOLS_TAG build cmssw-ib`
 $CMSBUILD_CMD --sync-back `GetCmsBuildConfig $PKGTOOLS_TAG upload cmssw-ib`
 
-if [ "X$ALWAYS_TAG_CMSSW" != "X" ] || [ ! -e w/$ARCHITECTURE/cms/cmssw/$RELEASE_NAME/build-errors ]; then
-  pushd CMSDIST
-    git remote add originrw git@github.com:$CMSDIST_REPO/cmsdist.git
+pushd CMSDIST
+  git remote add originrw git@github.com:$CMSDIST_REPO/cmsdist.git
+  git tag DEF/$RELEASE_NAME/$ARCHITECTURE $CMSDIST_HASH
+  git push originrw DEF/$RELEASE_NAME/$ARCHITECTURE || true
+  
+  if [ "X$ALWAYS_TAG_CMSSW" != "X" ] || [ ! -e w/$ARCHITECTURE/cms/cmssw/$RELEASE_NAME/build-errors ]; then
     git tag ALL/$RELEASE_NAME/$ARCHITECTURE $CMSDIST_HASH
     git push originrw ALL/$RELEASE_NAME/$ARCHITECTURE || true
     if [ X$CMSSW_RELEASE_BASE = X$RELEASE_NAME ]; then
         git tag IB/$RELEASE_NAME/$ARCHITECTURE $CMSDIST_HASH
         git push originrw IB/$RELEASE_NAME/$ARCHITECTURE || true
     fi
-  popd
-fi
+  fi
+
+popd
 
 echo CMSDIST_HASH=$CMSDIST_HASH > $WORKSPACE/buildprops
 echo PKGTOOLS_HASH=$PKGTOOLS_HASH >> $WORKSPACE/buildprops

--- a/cleanup-tags
+++ b/cleanup-tags
@@ -41,7 +41,7 @@ else
   cd cmsdist
 fi
 
-CMSDIST_QUEUES=`git ls-remote --tags origin "*/CMSSW_*X*" | grep refs/tags | grep "\(IB\|ALL\)" | sed -e 's|.*refs/tags/||;s|20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]|2*|' | sort -u`
+CMSDIST_QUEUES=`git ls-remote --tags origin "*/CMSSW_*X*" | grep refs/tags | grep "\(IB\|ALL|DEF\)" | sed -e 's|.*refs/tags/||;s|20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]|2*|' | sort -u`
 
 for QUEUE in $CMSDIST_QUEUES; do
   # List the tags we are going to delete. This will stay in the


### PR DESCRIPTION
Right now, if there are errors in the build and there release queue has not set ALWAYS_TAG_CMSSW then no tag in cmsdist will be created. 

This is why when there are failures in the build the cmsdist tags can't be seen. (https://cmssdt.cern.ch/SDT/html/showIB.html#CMSSW_7_2_X_2015-02-11-1400) This should always create a "default" tag per IB. 