### PR TITLE
Fail when a pull request is not found

### DIFF
--- a/get-pr-branch
+++ b/get-pr-branch
@@ -16,6 +16,6 @@ if __name__ == "__main__":
     pr = gh.get_organization("cms-sw").get_repo("cmssw").get_pull(prId)
   except:
     print "Could not find pull request. Maybe this is an issue"
-    exit(0)
+    exit(1)
 
   print pr.base.ref


### PR DESCRIPTION
When it doesn't find a branch for a pull request it doesn't fail, so it is more difficult to tell if there is something wrong in the other scripts that use this one.