### PR TITLE
deprecate-local and --tag options for release build

### DIFF
--- a/build-cmssw-ib-with-patch
+++ b/build-cmssw-ib-with-patch
@@ -173,7 +173,9 @@ pushd CMSDIST
   perl -p -i -e "s/### RPM cms cmssw-patch.*/### RPM cms cmssw-patch $RELEASE_NAME/" cmssw-patch.spec
 popd
 
-TOOL_CONF_PACKAGES="$CMSSW_TOOL_CONF local-cern-siteconf cms-git-tools"
+#FIXME: Fix --specs-only option which is not available for PKGTOOLS V00-16.
+$CMSBUILD_CMD --specs-only `GetCmsBuildConfig $PKGTOOLS_TAG build $PACKAGE_NAME`
+TOOL_CONF_PACKAGES="local-cern-siteconf `grep '^%define \(build\|\)directpkgreqs' SPECS/cms/$PACKAGE_NAME/*/spec | grep -v '%{nil}' | sed 's|.*directpkgreqs[ \t]*||' | tr ' ' '\n' | cut -f2 -d/ | sort | uniq | tr '\n' ' '`"
 $CMSBUILD_CMD `GetCmsBuildConfig $PKGTOOLS_TAG build coral`
 $CMSBUILD_CMD `GetCmsBuildConfig $PKGTOOLS_TAG build $TOOL_CONF_PACKAGES`
 $CMSBUILD_CMD --sync-back `GetCmsBuildConfig $PKGTOOLS_TAG upload $TOOL_CONF_PACKAGES`

--- a/build-release
+++ b/build-release
@@ -49,7 +49,8 @@ pushd $BUILD_DIR
     CMS_TAG="--tag `echo $QUEUE | $MD5_CMD |  tr '0123456789' 'ghijklmnop' | cut -b1-6`"
   fi
   CMSBUILD_CMD="PKGTOOLS/cmsBuild --architecture=$ARCHITECTURE --builders 4 -j $(getconf _NPROCESSORS_ONLN) $CMS_TAG"
-  TOOL_CONF_PACKAGES="cmssw$PATCH-tool-conf local-cern-siteconf cms-git-tools"
+  $CMSBUILD_CMD --specs-only build cmssw$PATCH
+  TOOL_CONF_PACKAGES=`grep '^%define \(build\|\)directpkgreqs' SPECS/cms/cmssw$PATCH/*/spec | grep -v '%{nil}' | sed 's|.*directpkgreqs[ \t]*||' | tr ' ' '\n' | cut -f2 -d/ | sort | uniq | tr '\n' ' '`
   $CMSBUILD_CMD build $TOOL_CONF_PACKAGES
   $CMSBUILD_CMD --sync-back upload $TOOL_CONF_PACKAGES
   $CMSBUILD_CMD deprecate-local $TOOL_CONF_PACKAGES

--- a/build-release
+++ b/build-release
@@ -40,7 +40,20 @@ pushd $BUILD_DIR
     (cd CMSDIST ; git commit -m 'Coherent debug package setup.' cmssw.spec cmssw-patch.spec coral.spec)
   fi
   sh -e PKGTOOLS/scripts/prepare-cmsdist $CMSSW_X_Y_Z $ARCHITECTURE 2>&1 | tee -a $WORKSPACE/prepare-cmsdist.log
-  PKGTOOLS/cmsBuild --architecture=$ARCHITECTURE --builders 4 -j $(getconf _NPROCESSORS_ONLN) build cmssw$PATCH
+  CMS_TAG=""
+  if [ "X`PKGTOOLS/cmsBuild --help | grep tag=NAME`" != "X" ] ; then
+    case `uname -s` in
+      Darwin ) MD5_CMD=md5;;
+      * )      MD5_CMD=md5sum;;
+    esac
+    CMS_TAG="--tag `echo $QUEUE | $MD5_CMD |  tr '0123456789' 'ghijklmnop' | cut -b1-6`"
+  fi
+  CMSBUILD_CMD="PKGTOOLS/cmsBuild --architecture=$ARCHITECTURE --builders 4 -j $(getconf _NPROCESSORS_ONLN) $CMS_TAG"
+  TOOL_CONF_PACKAGES="cmssw$PATCH-tool-conf local-cern-siteconf cms-git-tools"
+  $CMSBUILD_CMD build $TOOL_CONF_PACKAGES
+  $CMSBUILD_CMD --sync-back upload $TOOL_CONF_PACKAGES
+  $CMSBUILD_CMD deprecate-local $TOOL_CONF_PACKAGES
+  $CMSBUILD_CMD build cmssw$PATCH
 popd
 
   


### PR DESCRIPTION
first build, upload and deprecate-local the *-tool-conf and then build release; use --tag option to avoid conflict b/w two build of same arch