### PR TITLE
fixes for build area reuse

### DIFF
--- a/build-cmssw-ib-with-patch
+++ b/build-cmssw-ib-with-patch
@@ -50,6 +50,7 @@ else
 fi
 mkdir -p $WORKDIR
 cd $WORKDIR
+rm -rf w/SPECS
 
 BUILD_JOBS=2
 BUILD_NPROC=$(getconf _NPROCESSORS_ONLN)
@@ -108,6 +109,7 @@ for x in $PKGTOOLS_REPO/pkgtools@$PKGTOOLS_TAG $CMSDIST_REPO/cmsdist@$CMSDIST_TA
     git fetch
     git clean -fxd ; git reset --hard HEAD
     git checkout $T
+    git merge --ff-only origin/$T
     eval "${P}_HASH=`git rev-parse HEAD`"
   popd
 done


### PR DESCRIPTION
- make sure we delete the previously generated SPECs
- fast-forward the cmsdist/pkgtools braches to origin 