### PR TITLE
Report installation result and allow to generate the release notes more than once. 

### DIFF
--- a/process-build-release-request
+++ b/process-build-release-request
@@ -170,7 +170,7 @@ def create_properties_files_upload( release_name, arch, issue_number, machine_na
 # 
 def search_date_comment( comments, user_logins, pattern, first_line ):
 
-  for comment in comments:
+  for comment in reversed( comments ):
 
     if comment.user.login not in user_logins:
       continue
@@ -412,12 +412,13 @@ def add_label( issue , label ):
 #
 # posts a message to the issue in github
 # if dry-run is selected it doesn't post the message and just prints it
+# if you set checkIfRepeated to False, if will not check if the message has already been written. 
 #
-def post_message( issue , msg ):
+def post_message( issue , msg, checkIfRepeated=True ):
   if opts.dryRun:
     print 'Not posting message (dry-run):\n %s' % msg
     return
-  if search_in_comments( comments, [ 'cmsbuild', 'nclopezo' ], msg, False):
+  if checkIfRepeated and search_in_comments( comments, [ 'cmsbuild', 'nclopezo' ], msg, False):
     print 'Message already in the thread: \n %s' % msg
     return
   print 'Posting message:\n %s' % msg 
@@ -510,7 +511,7 @@ def fillDeatilsArchsLists( issue ):
   TOOL_CONF_OK.extend( [ x.split('-')[0] for x in labels if '-tool-conf-ok' in x ] )
   TOOL_CONF_ERROR.extend( [ x.split('-')[0] for x in labels if '-tool-conf-error' in x ] )
   TOOL_CONF_WAITING.extend( [ x.split('-')[0] for x in labels if '-tool-conf-waiting' in x ] )
-  TO_CLEANUP.extend( UPLOAD_OK + BUILD_ERROR + BUILD_OK )
+  TO_CLEANUP.extend( UPLOAD_OK + BUILD_ERROR + BUILD_OK + INSTALL_OK )
 
 #
 # Triggers the cleanup for the architectures in the list TO_CLEANUP 
@@ -545,6 +546,8 @@ def triggerCleanup( issue, comments, release_name ):
       post_message( issue, msg )
       remove_label( issue, arch + '-upload-ok' )
       remove_label( issue, arch + '-build-error' )
+      remove_label( issue, arch + '-build-ok' )
+      remove_label( issue, arch + '-installation-ok' )
       add_label( issue, arch + '-finished' )
 
 #
@@ -646,7 +649,7 @@ def check_if_prod_arch_ready( issue, prev_rel_name, production_architecture ):
     mailto = generate_announcement_link( announcement, release_name )
     msg = 'You can use this template for announcing the release:\n\n%s\n\n' \
           'You can also click %s to send the email.' % (announcement, mailto)
-    post_message( issue, msg )
+    post_message( issue, msg, checkIfRepeated=False )
     add_label( issue, ANNOUNCEMENT_GENERATED_LBL )
 
 #
@@ -971,6 +974,34 @@ if __name__ == "__main__":
     #upload archs as soon as they get ready
     check_archs_to_upload( release_name, issue )
 
+    print 'checking if someone asked again for the release notes'
+    release_notes_comments = search_in_comments( comments, APPROVE_BUILD_RELEASE, RELEASE_NOTES_COMMENT, True )
+    generating_release_notes_comments = search_in_comments( comments, ['cmsbuild'], 'Generating release notes', True )
+
+    if len( release_notes_comments ) > len( generating_release_notes_comments ):
+      print 'I need to generate the release notes again'
+      # check if this is beter if a function is added
+      comment = release_notes_comments[-1]
+      first_line = str(comment.encode("ascii", "ignore").split("\n")[0].strip("\n\t\r "))
+      comment_parts = first_line.strip().split(' ')
+
+      if len( comment_parts ) > 1:
+        prev_rel_name = comment_parts[ 2 ].rstrip()
+      else:
+        prev_rel_name = guess_prev_rel_name( release_name )
+        print prev_rel_name
+
+      rel_name_match = re.match( REL_NAME_REGEXP, prev_rel_name )
+      if not rel_name_match:
+        msg = WRONG_NOTES_RELEASE_MSG.format( previous_release=prev_rel_name )
+        post_message( issue, msg, checkIfRepeated=False )
+        exit( 0 )
+
+      create_properties_file_rel_notes( release_name, prev_rel_name, production_architecture, issue.number )
+      msg = GENERATING_RELEASE_NOTES_MSG.format( previous_release=prev_rel_name )
+      post_message( issue, msg, checkIfRepeated=False )
+      check_if_prod_arch_ready( issue, prev_rel_name, production_architecture )
+
     # check if the cleanup has been requested or if 2 days have passed since the release-notes were generated.
     print 'Checking if someone requested cleanup, or the issue is too old...' 
     date_rel_notes = search_date_comment( comments, APPROVE_BUILD_RELEASE, RELEASE_NOTES_COMMENT, True )
@@ -985,3 +1016,4 @@ if __name__ == "__main__":
       triggerCleanup( issue, comments, release_name )
       close_issue( issue )
       go_to_state( issue, status, PROCESS_COMPLETE )
+

--- a/process-build-release-request
+++ b/process-build-release-request
@@ -64,7 +64,7 @@ GENERATING_RELEASE_NOTES_MSG = 'Generating release notes since {previous_release
                                'I will generate an announcement template.\n'
 PROD_ARCH_NOT_READY_MSG = 'ATTENTION!!! The production architecture ({prod_arch}) is not ready yet. '\
                           'This needs to be checked before asking me to generate the release notes.\n'\
-                          'When the production architecture is uploaded successfully, I will generate the release notes.'\
+                          'When the production architecture is installed successfully, I will generate the release notes.'\
                           ' You don\'t need to write the command again.'
 REL_NAME_REGEXP="(CMSSW_[0-9]+_[0-9]+)_[0-9]+(_SLHC[0-9]*|)(_pre[0-9]+|_[a-zA-Z]*patch[0-9]+|)(_[^_]*|)"
 UPLOAD_COMMENT = 'upload %s'
@@ -503,6 +503,7 @@ def fillDeatilsArchsLists( issue ):
   labels = [ l.name for l in issue.get_labels() ]
   BUILD_OK.extend( [ x.split('-')[0] for x in labels if '-build-ok' in x ] )
   UPLOAD_OK.extend( [ x.split('-')[0] for x in labels if '-upload-ok' in x ] )
+  INSTALL_OK.extend( [ x.split('-')[0] for x in labels if '-installation-ok' in x ] )
   UPLOADING.extend( [ x.split('-')[0] for x in labels if '-uploading' in x ] )
   BUILD_ERROR.extend( [ x.split('-')[0] for x in labels if '-build-error' in x ] )
   TOOL_CONF_BUILDING.extend( [ x.split('-')[0] for x in labels if '-tool-conf-building' in x ] )
@@ -638,10 +639,10 @@ def generate_announcement_link( announcement, release_name ):
 # checks if the production architecture is ready, if so, it generates a template for the announcement
 #
 def check_if_prod_arch_ready( issue, prev_rel_name, production_architecture ):
-  if ( production_architecture in UPLOAD_OK ):
-    print 'Production architecture successfully uploaded..'
+  if ( production_architecture in INSTALL_OK ):
+    print 'Production architecture successfully installed..'
     #For now, it assumes that the release is being installed and it will be installed successfully
-    announcement = generate_announcement( release_name, prev_rel_name, production_architecture, UPLOAD_OK )
+    announcement = generate_announcement( release_name, prev_rel_name, production_architecture, INSTALL_OK )
     mailto = generate_announcement_link( announcement, release_name )
     msg = 'You can use this template for announcing the release:\n\n%s\n\n' \
           'You can also click %s to send the email.' % (announcement, mailto)
@@ -804,6 +805,7 @@ if __name__ == "__main__":
 
   BUILD_OK = []
   UPLOAD_OK = []
+  INSTALL_OK = []
   UPLOADING = []
   BUILD_ERROR = []
   TO_CLEANUP = []
@@ -929,8 +931,8 @@ if __name__ == "__main__":
     check_archs_to_upload( release_name, issue )
 
     #Check if someone asked for release notes, go to next state after generating notes.
-    #At least one architecture must have been successfully uploaded
-    if UPLOAD_OK and ( RELEASE_NOTES_GENERATED_LBL not in labels ):
+    #At least one architecture must have been successfully installed
+    if INSTALL_OK and ( RELEASE_NOTES_GENERATED_LBL not in labels ):
       print 'checking if someone asked for the release notes'
       release_notes_comments = search_in_comments( comments, APPROVE_BUILD_RELEASE, RELEASE_NOTES_COMMENT, True )
 
@@ -951,7 +953,7 @@ if __name__ == "__main__":
           post_message( issue, msg )
           exit( 0 )
 
-        if ( production_architecture not in UPLOAD_OK ):
+        if ( production_architecture not in INSTALL_OK  ):
           msg = PROD_ARCH_NOT_READY_MSG.format( prod_arch=production_architecture )
           post_message( issue, msg )
           exit( 0 )

--- a/release-deploy-afs
+++ b/release-deploy-afs
@@ -69,3 +69,7 @@ pushd cms-bot
     echo "Release already announced."
   fi
 popd
+
+# If it reaches here it is because there were no errors
+echo 'ALL_OK'
+

--- a/report-build-release-status
+++ b/report-build-release-status
@@ -28,6 +28,8 @@ CLEANUP_ERROR='CLEANUP_ERROR'
 TESTS_OK='TESTS_OK'
 RELEASE_NOTES_OK='RELEASE_NOTES_OK'
 RELEASE_NOTES_ERROR='RELEASE_NOTES_ERROR'
+INSTALLATION_OK='INSTALLATION_OK'
+INSTALLATION_ERROR='INSTALLATION_ERROR'
 # this means that there was an error in the script that excecutes the tests,
 # it is independent from the tests results
 TESTS_ERROR='TESTS_ERROR'
@@ -53,12 +55,14 @@ UPLOADING_MSG='The upload has started for {architecture} in {machine}. \n' \
               'You can see the progress here: https://cmssdt.cern.ch/jenkins/job/upload-release/{jk_build_number}/console'
 UPLOAD_OK_MSG='The upload has successfully finished for {architecture} \n You can see the log here: \n {log_url} \n' \
               'The release is now being installed, you can see the progress here: \n ' \
-              'https://cmssdt.cern.ch/jenkins/job/release-deploy-afs/ \n' \
+              'https://cmssdt.cern.ch/jenkins/job/release-deploy-afs/ \n' 
+INSTALLATION_OK_MSG='The installation has successfully finished for {architecture} \n You can see the log here: \n {log_url} \n' \
               'To generate the release notes for the release write "release-notes since \\<previous-release\\>", in the first line of your comment.\n ' \
               'I will generate the release notes based on the release that you provide. You don\'t need to provide the architectue ' \
               'I will use the production architecture to infer the cmsdist tag.\n' \
-              'Alternatively, you can just write "release-notes", I will try to guess the previous release.' 
+              'Alternatively, you can just write "release-notes", I will try to guess the previous release.'
 UPLOAD_ERROR_MSG='The was error uploading {architecture}. \n You can see the log here: \n {log_url}'
+INSTALLATION_ERROR_MSG='The was error installing {architecture}. \n You can see the log here: \n {log_url}'
 CLEANUP_OK_MSG='The workspace for {architecture} has been deleted \n You can see the log here: \n {log_url} \n'
 CLEANUP_ERROR_MSG='There was an error deletng the workspace for {architecture} \n You can see the log here: \n {log_url} \n'
 TESTS_OK_MSG='The tests have finished for {architecture} \n You can see the log here: \n {log_url} \n'
@@ -71,6 +75,7 @@ BUILD_STARTED = 'build-release-started'
 BASE_BUILD_LOG_URL = 'https://cmssdt.cern.ch/SDT/jenkins-artifacts/auto-build-release/%s-%s/%d'
 BASE_UPLOAD_LOG_URL = 'https://cmssdt.cern.ch/SDT/jenkins-artifacts/auto-upload-release/%s-%s/%d'
 BASE_CLEANUP_LOG_URL = 'https://cmssdt.cern.ch/SDT/jenkins-artifacts/cleanup-auto-build/%s-%s/%d'
+BASE_INSTALLATION_URL = 'https://cmssdt.cern.ch/SDT/jenkins-artifacts/deploy-release-afs/{rel_name}/{architecture}/{job_id}/'
 
 # -------------------------------------------------------------------------------
 # Functions
@@ -127,7 +132,7 @@ def remove_labels( issue ):
 if __name__ == "__main__":
   parser = OptionParser( usage="%prog <jenkins-build-number> <hostname> <issue-id> <arch> <release-name> <message-type> [ options ] \n "
                                "message-type = BUILDING | BUILD_OK | BUILD_ERROR | UPLOADING | UPLOAD_OK | UPLOAD_ERROR | CLEANUP_OK | CLEANUP_ERROR | TESTS_OK | TESTS_ERROR " 
-                               "| RELEASE_NOTES_OK | RELEASE_NOTES_ERROR ")
+                               "| RELEASE_NOTES_OK | RELEASE_NOTES_ERROR | INSTALLATION_OK | INSTALLATION_ERROR")
   parser.add_option( "-n" , "--dry-run" , dest="dryRun" , action="store_true", help="Do not post on Github", default=False )
   parser.add_option( "-d" , "--details" , dest="details" , action="store", help="Add aditional details to the message", default=False )
 
@@ -216,6 +221,7 @@ if __name__ == "__main__":
     msg = UPLOAD_OK_MSG.format( architecture=arch , log_url=results_url )
     post_message( issue , msg )
     remove_label( issue, arch+'-uploading' )
+    remove_label( issue, arch+'-upload-error' )
     add_label( issue,  arch+'-upload-ok' )
 
   elif action == UPLOAD_ERROR:
@@ -259,6 +265,27 @@ if __name__ == "__main__":
 
     msg = RELEASE_NOTES_ERROR_MSG.format( rel_name=release_name )
     post_message( issue, msg)
+
+  elif action == INSTALLATION_OK:
+
+    results_url = BASE_INSTALLATION_URL.format( rel_name=release_name,
+                                                     architecture=arch,
+                                                     job_id=jenkins_build_number )
+    msg = INSTALLATION_OK_MSG.format( architecture=arch , log_url=results_url )
+    post_message( issue, msg )
+    remove_label( issue, arch+'-upload-ok' )
+    remove_label( issue, arch+'-installation-error' )
+    add_label( issue,  arch+'-installation-ok' )
+
+  elif action == INSTALLATION_ERROR:
+
+    results_url = BASE_INSTALLATION_URL.format( rel_name=release_name,
+                                                     architecture=arch,
+                                                     job_id=jenkins_build_number )
+    msg = INSTALLATION_ERROR_MSG.format( architecture=arch , log_url=results_url )
+    post_message( issue, msg )
+    remove_label( issue, arch+'-upload-ok' )
+    add_label( issue,  arch+'-installation-error' )
 
   else:
     parser.error( "Message type not recognized" )


### PR DESCRIPTION
For each architecture, now after the upload-ok label, a installation-ok label will be assigned when the AFS installation job succeeds. This will make sure that when the announcement is generated, the AFS installation job ran successfully in Jenkins. 
Also, after generating the release notes for the first time, now they can be generated using the "release notes" comment again if needed. 