### PR TITLE
Avoid tagging on commits brought by automatic forward ports.

### DIFF
--- a/tag-and-schedule-ibs
+++ b/tag-and-schedule-ibs
@@ -26,7 +26,7 @@ for QUEUE in $RELEASE_QUEUES; do
   HOUR=`echo $RELEASE_NAME | sed -e's|.*-\([0-9][0-9]\)00|\1|'`
   # find old tag, if any
   OLD_HASH=`git show-ref $RELEASE_NAME | cut -f1 -d\ `  
-  NEW_HASH=`git rev-list -n 1 --before="$DAY $HOUR:00" $RELEASE_BRANCH`
+  NEW_HASH=`git rev-list -n 1 --before="$DAY $HOUR:00" --first-parent $RELEASE_BRANCH`
   # If there is no new hash, we have a problem.
   # If there is no old hash, we simply tag.
   # If there is an old hash, we use the old one.


### PR DESCRIPTION
As you can see in the IB Pages for [CMSSW_7_5_ROOT5_X](https://cmssdt.cern.ch/SDT/html/showIB.html#CMSSW_7_5_ROOT5_X), some of the IBs look like there were many pull requests included and these pull requests were already merged some time ago. This has also affected 7_5_X. For example, for [CMSSW_7_5_ROOT5_X_2015-05-04-2300](https://cmssdt.cern.ch/SDT/html/showIB.html#CMSSW_7_5_ROOT5_X_2015-05-04-2300) you can see that https://github.com/cms-sw/cmssw/pull/8502 and https://github.com/cms-sw/cmssw/pull/8487 "were included" but they were merged more than a month ago. The pages also show many merges commits from the automatic forward ports. 

I did the following command on the CMSSW_7_5_ROOT5_X branch:
<pre>git log --graph --merges --pretty="%h,%s,%cd,%d"</pre>

And I noticed that the tags are sometimes being done on a commit that comes from the automatic merges, but not on the merge commit that brought that one. 
You can see it for CMSSW_7_5_ROOT5_X_2015-05-05-1100

<pre>
| * | | | 3db0ffe,Merge pull request #8951 from rovere/recoMaterialEffectsCleaned,Tue May 5 12:27:14 2015 +0200,
* | | | |   4a07d55,Merge CMSSW_7_5_X into CMSSW_7_5_ROOT5_X.,Tue May 5 11:01:50 2015 +0200,
|\ \ \ \ \  
| |/ / / /  
| * | | | c8e0695,Merge pull request #8956 from Martin-Grunewald/HLTFastSimCeanUp,Tue May 5 09:46:38 2015 +0200, (CMSSW_7_5_X_2015-05-05-1100, CMSSW_7_5_THREADED_X_2015-05-05-1100, CMSSW_7_5_ROOT5_X_2015-05-05-1100, CMSSW_7_5_ICC_X_2015-
* | | | |   e21d102,Merge CMSSW_7_5_X into CMSSW_7_5_ROOT5_X.,Tue May 5 09:02:42 2015 +0200,
|\ \ \ \ \  
| |/ / / /  
| * | | | 6ca740a,Merge pull request #8811 from apfeiffer1/conddb-nocol,Tue May 5 08:35:07 2015 +0200,
| * | | | 2f51210,Merge pull request #8907 from smorovic/FRD-75X,Tue May 5 08:34:58 2015 +0200,
| * | | | 5b137e3,Merge pull request #8944 from capalmer85/pcc-ntupler-75X-v1,Tue May 5 08:34:48 2015 +0200,
| * | | | fff27f3,Merge pull request #8954 from fojensen/V0Branch,Tue May 5 08:34:29 2015 +0200,
* | | | |   81eeecd,Merge CMSSW_7_5_X into CMSSW_7_5_ROOT5_X.,Mon May 4 19:04:30 2015 +0200, (CMSSW_7_5_ROOT5_X_2015-05-04-2300)
|\ \ \ \ \  
</pre>

This is the reason why the tag is not in the "main lane" and it doesn't have the pull requests that are appearing again as included. 
https://github.com/cms-sw/cmssw/commit/c8e0695 was merged by https://github.com/cms-sw/cmssw/commit/4a07d55, which was committed by the forward ports job at 11:01:50, before the tagging job started. 

The tagging job did 
<pre>git rev-list -n 1 '--before=2015-05-05 11:00' CMSSW_7_5_ROOT5_X</pre>
And the command returned: https://github.com/cms-sw/cmssw/commit/c8e0695

If it now does 
<pre>git rev-list -n 1 '--before=2015-05-05 11:00' --first-parent CMSSW_7_5_ROOT5_X</pre>
It will return https://github.com/cms-sw/cmssw/commit/e21d102 which is in the "main lane"