### PR TITLE
Update validate.C readability

### DIFF
--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <fstream>
 #include "TLegend.h"
+#include "TPaveText.h"
 #include "TCut.h"
 #include <cmath>
 
@@ -68,7 +69,7 @@ double plotvar(TString v,TString cut=""){
   if (cut!="") cn+=count;
   TCanvas * c = new TCanvas(cn,"plot of "+v);
   c->SetGrid();
-  c->SetTopMargin(0.06);
+  c->SetTopMargin(0.12);
   c->SetLeftMargin(0.06);
   c->SetRightMargin(0.01);
   c->SetBottomMargin(0.06);
@@ -80,10 +81,11 @@ double plotvar(TString v,TString cut=""){
   if (refv!=v)
     std::cout<<" changing reference variable to:"<<refv<<std::endl;
 
-  gStyle->SetTitleX(0.3);
+  gStyle->SetTitleX(0.5);
   gStyle->SetTitleY(1);
-  gStyle->SetTitleW(0.6);
+  gStyle->SetTitleW(1);
   gStyle->SetTitleH(0.06);
+
   
   double refplotEntries = -1;
   double plotEntries = -1;
@@ -165,13 +167,25 @@ double plotvar(TString v,TString cut=""){
     for (int ib=1;ib<=diff->GetNbinsX();++ib){
       countDiff+=std::abs(diff->GetBinContent(ib));
     }
+
+    double ksscore = refplot->KolmogorovTest(plot);
+    int refentries = refplot->GetEntries();
+    int newentries = plot->GetEntries();
+
+    TString outtext;
+    outtext.Form("Ref: %i, New: %i, Diff: %g, 1-KS: %6.4g",refentries,newentries,countDiff,1-ksscore);
+
+    TPaveText * pt = new TPaveText(0.01,0.89,0.71,0.93,"NDC");
+    pt->AddText(outtext);
+    pt->SetBorderSize(0);
+    pt->SetFillStyle(0);
+    pt->Draw();
     
-    TLegend * leg = new TLegend(0.61,0.95,0.99,0.99);
+    TLegend * leg = new TLegend(0.72,0.89,0.99,0.93);
     leg->SetNColumns(3);
-    leg->SetMargin(0.15);
-    leg->AddEntry(refplot,"Reference","l");
-    leg->AddEntry(plot,"New Version","l");
-    leg->AddEntry(diff,"New - Reference","p");
+    leg->AddEntry(refplot,"Ref.","l");
+    leg->AddEntry(plot,"New","l");
+    leg->AddEntry(diff,"New - Ref.","p");
     leg->Draw();
 
     


### PR DESCRIPTION
This is an update to the readability of the plot outputs from validate.C. 

In addition, it adds some statistics to the plot.

An example of the output can be see below.
![all_oldvnew_zmm13tevwf1330p0c_recotracks_standalonemuons_updatedatvtx_reco_obj_chi2](https://cloud.githubusercontent.com/assets/4513541/8700867/bd2abd44-2b0e-11e5-95dd-cd0f539a87c6.png)
