### PR TITLE
Do not use twice more threads than available virtual cores

### DIFF
--- a/build-cmssw-ib-with-patch
+++ b/build-cmssw-ib-with-patch
@@ -198,7 +198,7 @@ if [ `ls w/RPMS/${ARCHITECTURE} | wc -l` -gt 0 ] ; then
   $CMSBUILD_CMD `GetCmsBuildConfig $PKGTOOLS_TAG deprecate-local $TOOL_CONF_PACKAGES`
   echo DATE=`date`
 fi
-$CMSBUILD_CMD -k -j `echo "$BUILD_NPROC * 2" | bc` `GetCmsBuildConfig $PKGTOOLS_TAG build cmssw-ib`
+$CMSBUILD_CMD -k -j `echo "$BUILD_NPROC + 1" | bc` `GetCmsBuildConfig $PKGTOOLS_TAG build cmssw-ib`
 echo DATE=`date`
 $CMSBUILD_CMD --sync-back `GetCmsBuildConfig $PKGTOOLS_TAG upload cmssw-ib`
 echo DATE=`date`

--- a/build-release
+++ b/build-release
@@ -90,7 +90,7 @@ pushd $BUILD_DIR
     exit 0
   fi
 
-  $CMSBUILD_CMD -j `echo "$BUILD_NPROC * 2" | bc` build local-cern-siteconf cmssw$PATCH
+  $CMSBUILD_CMD -j `echo "$BUILD_NPROC + 1" | bc` build local-cern-siteconf cmssw$PATCH
   echo DATE=`date`
 popd
 echo DATE=`date`


### PR DESCRIPTION
After running several CMSSW compilation tests on ppc64le and x86_64 with
X and 2 * X threads (-j), where X is number of available virtual cores, I
have not detected any significant difference in elapsed time.

This is expected due to the nature of our heavy translation units and
a long debug information optimization step.

Thus moving to X + 1 should make sure we are not swapping while
compiling CMSSW while still maintaining same elapsed time.

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>