### PR TITLE
add PhysicsTools/PatUtils to reco

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -213,6 +213,7 @@ CMSSW_CATEGORIES={
    "DataFormats/CaloTowers", "DataFormats/CastorReco",
    "DataFormats/PatCandidates",
    "PhysicsTools/PatAlgos",
+   "PhysicsTools/PatUtils",
    "RecoLocalCalo/CaloRecCandCreator",
    "RecoLocalCalo/CaloTowersCreator",
    "RecoLocalCalo/Castor",


### PR DESCRIPTION
functions used in PatUtils are actively used in miniAOD and related sequence definitions. Reco L2 is responsible for miniAOD maintenance.