### PR TITLE
Add Rafael as watcher for EGM-related packages

### DIFF
--- a/watchers.yaml
+++ b/watchers.yaml
@@ -886,3 +886,12 @@ agrohsje:
 - GeneratorInterface
 mverzett:
 - CalibTracker/SiStripCommon
+rafaellopesdesa:
+- EgammaAnalysis
+- RecoEcal
+- RecoEgamma
+- RecoParticleFlow
+- DataFormats/ParticleFlowReco
+- DataFormats/ParticleFlowCandidate
+- DataFormats/EgammaCandidate
+- DataFormats/EgammaReco


### PR DESCRIPTION
I am adding my user as watcher for EGM-related packages to make it easier to follow the modifications in the code. I am adding my user as watcher for the following packages:

+- EgammaAnalysis
+- RecoEcal
+- RecoEgamma
+- RecoParticleFlow
+- DataFormats/ParticleFlowReco
+- DataFormats/ParticleFlowCandidate
+- DataFormats/EgammaCandidate
+- DataFormats/EgammaReco

I also add some PF packages, since I am interested to follow their modification and possible interplay with EG PF. Let me know if this is not acceptable.

Best.