### PR TITLE
add RecoLocalTracker/Phase2ITPixelClusterizer package to category

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -249,6 +249,7 @@ CMSSW_CATEGORIES={
    "RecoLocalMuon/GEMCSCSegment",
    "RecoLocalTracker/ClusterParameterEstimator",
    "RecoLocalTracker/Configuration",
+   "RecoLocalTracker/Phase2ITPixelClusterizer",
    "RecoLocalTracker/Phase2TrackerRecHits",
    "RecoLocalTracker/Records",
    "RecoLocalTracker/SiPhase2Clusterizer",


### PR DESCRIPTION
I didn't realize that there were two packages needed by cms-sw/cmssw#14885. This is the second one.