### PR TITLE
makeDiff.sh to return exit 0 after root .qqqqqq

### DIFF
--- a/comparisons/makeDiff.sh
+++ b/comparisons/makeDiff.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 f1=${1}
 f2=${2}
 fO=${3}
@@ -7,4 +8,5 @@ dirPattern=${6}
 echo -e "gROOT->SetStyle(\"Plain\");\n .L compareValHists.C+ \n\
  f1=new TFile(\"${f1}\");\n f2 = new TFile(\"${f2}\");\n compareAll(f1,f2,${lMod},${dOpt}, \"${dirPattern}\");\n\
 .qqqqqq" | root -l -b
-
+# this is normal for .qqqqqq. Do not pass it downstream.
+[ "$?" == "6" ] && exit 0


### PR DESCRIPTION
this should fix issues with recent issues in jenkins comparison jobs