### PR TITLE
adding L1T on kreczko watchlist

### DIFF
--- a/watchers.yaml
+++ b/watchers.yaml
@@ -903,7 +903,19 @@ jdolen:
 - CommonTools/RecoAlgos
 kreczko:
 - AnalysisDataFormats/TopObjects
+- CondCore/L1TPlugins
+- CondFormats/L1TObjects
+- CondTools/L1Trigger
+- DataFormats/L1Trigger
+- DQM/L1TMonitorClient
+- DQM/L1TMonitor
+- DQMOffline/L1Trigger
+- EventFilter/L1TRawToDigi
+- L1Trigger
+- L1TriggerConfig
+- L1TriggerOffline
 - TopQuarkAnalysis
+- Validation/L1T
 pfs:
 - SimCalorimetry/HGCalSimProducers
 - DataFormats/HGCDigi


### PR DESCRIPTION
Request to watch L1Trigger related projects.
Edited `watchers.yaml` instead of `category-watchers.yaml` since the latter is too inclusive.