### PR TITLE
reco comparisons: remove packed vx,y,z plots (found to be non-reproducible in jenkins)

### DIFF
--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -709,9 +709,9 @@ void packedCand(TString cName = "packedPFCandidates_", TString tName = "patPacke
   packedCandVar("status",cName,tName);
   packedCandVar("vertexChi2",cName,tName);
   packedCandVar("vertexNdof",cName,tName);
-  packedCandVar("vx",cName,tName);
-  packedCandVar("vy",cName,tName);
-  packedCandVar("vz",cName,tName);
+  //  packedCandVar("vx",cName,tName);
+  //  packedCandVar("vy",cName,tName);
+  //  packedCandVar("vz",cName,tName);
   
 
 }


### PR DESCRIPTION
I wasn't able to get these both plot (not throw) and show different results in local environment.
To be fixed later, maybe.

This is hopefully the last PR on the subject of the packed cands set of plots.