### PR TITLE
Updating run-material-budget script 

### DIFF
--- a/run-material-budget
+++ b/run-material-budget
@@ -3,20 +3,12 @@
 cmsRun $CMSSW_RELEASE_BASE/src/Validation/Geometry/python/single_neutrino_cfg.py >$LOCALRT/single_neutrino_cfg.log 2>&1
 #Remove big plugin paths
 export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | tr ':' '\n' | grep -v /biglib/$SCRAM_ARCH | tr '\n' ':' | sed 's|:$||')
+
 cmsRun $CMSSW_RELEASE_BASE/src/Validation/Geometry/test/runP_Tracker_cfg.py >$LOCALRT/runP_Tracker_cfg.log 2>&1
 mkdir Images
 
-if [[ $(ls ${CMSSW_RELEASE_BASE}/src/Validation/Geometry/test/ | grep MaterialBudget | wc -l) -gt 0 ]]  ; then
-  cp $CMSSW_RELEASE_BASE/src/Validation/Geometry/test/MaterialBudget* .
-  if [ -e MaterialBudget.C ] ; then
-    root -b -q 'MaterialBudget.C("Tracker")' || true
-  elif [ -e MaterialBudget.py ] ; then
-    python MaterialBudget.py -s -d Tracker || true
-  else
-    echo "MaterialBudget script is neither .C nor .py, exit"
-    exit 1
-  fi
+cp $CMSSW_RELEASE_BASE/src/Validation/Geometry/test/MaterialBudget* .
+if [ -e $CMSSW_RELEASE_BASE/src/Validation/Geometry/test/MaterialBudget.C ] ; then
+  root -b -q 'MaterialBudget.C("Tracker")' || true
 else
-  echo "Script ${CMSSW_RELEASE_BASE}/src/Validation/Geometry/test/MaterialBudget does not exist, exit"
-  exit 1
-fi
+  python MaterialBudget.py -s -d Tracker || true

--- a/run-material-budget
+++ b/run-material-budget
@@ -3,9 +3,20 @@
 cmsRun $CMSSW_RELEASE_BASE/src/Validation/Geometry/python/single_neutrino_cfg.py >$LOCALRT/single_neutrino_cfg.log 2>&1
 #Remove big plugin paths
 export LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | tr ':' '\n' | grep -v /biglib/$SCRAM_ARCH | tr '\n' ':' | sed 's|:$||')
-
 cmsRun $CMSSW_RELEASE_BASE/src/Validation/Geometry/test/runP_Tracker_cfg.py >$LOCALRT/runP_Tracker_cfg.log 2>&1
 mkdir Images
-cp $CMSSW_RELEASE_BASE/src/Validation/Geometry/test/MaterialBudget.C .
-root -b -q 'MaterialBudget.C("Tracker")' || true
 
+if [[ $(ls ${CMSSW_RELEASE_BASE}/src/Validation/Geometry/test/ | grep MaterialBudget | wc -l) -gt 0 ]]  ; then
+  cp $CMSSW_RELEASE_BASE/src/Validation/Geometry/test/MaterialBudget* .
+  if [ -e MaterialBudget.C ] ; then
+    root -b -q 'MaterialBudget.C("Tracker")' || true
+  elif [ -e MaterialBudget.py ] ; then
+    python MaterialBudget.py -s -d Tracker || true
+  else
+    echo "MaterialBudget script is neither .C nor .py, exit"
+    exit 1
+  fi
+else
+  echo "Script ${CMSSW_RELEASE_BASE}/src/Validation/Geometry/test/MaterialBudget does not exist, exit"
+  exit 1
+fi


### PR DESCRIPTION
Changing the script to work with either the .C script or the .py regardless if the .py script will be backported to older releases