### PR TITLE
Fixing missing env var for slc7

### DIFF
--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -25,6 +25,7 @@ if [ "X$DOCKER_IMG" != X -a "X$RUN_NATIVE" = "X" ]; then
     -v /cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security \
     -v /tmp:/tmp \
     -e WORKSPACE=$WORKSPACE \
+    -e USER=$USER \
     -e BUILD_NUMBER=$BUILD_NUMBER \
     $DOCKER_IMG sh -c "$DOCK_ARGS"
 else


### PR DESCRIPTION
Unit test was failing for build on slc7 (which runs on docker container), listed here, complaining about environmental variable. 
https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc7_aarch64_gcc700/CMSSW_9_2_X_2017-05-21-1100/unitTestLogs/Alignment/MillePedeAlignmentAlgorithm