### PR TITLE
Add DryRun to watchers.yaml

### DIFF
--- a/watchers.yaml
+++ b/watchers.yaml
@@ -1167,3 +1167,6 @@ seemasharmafnal:
 - RecoMET/
 - Validation/RecoJets
 - Validation/RecoMET
+DryRun:
+- DQM/HcalCommon
+- DQM/HcalTasks


### PR DESCRIPTION
Add DryRun to watchers.yaml for DQM/HcalTasks and DQM/HcalCommon.