### PR TITLE
Adding Kaori and Virginia as L2 for DQM

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -60,6 +60,8 @@ CMSSW_L2 = {
   "davidlange6": ["operations"],
   "thuer": ["generators"],
   "vanbesien" : ["dqm"],
+  "kmaeshima" : ["dqm"],
+  "vazzolini" : ["dqm"],
   "fabozzi" : ["pdmv"],
   "iahmad-khan" : ["externals"],
   "GurpreetSinghChahal" : ["pdmv"],


### PR DESCRIPTION
Adding current DQM conveners Kaori Maeshima and Virginia Azzolini as L2 for DQM
dmitrijus remains as main responsible for reviewing and signing PRs
vanbesien will/should be removed end of September