### PR TITLE
reco comparisons updates: 2017 data workflow map and monitor beamHalo flags

### DIFF
--- a/comparisons/matrix_RE.txt
+++ b/comparisons/matrix_RE.txt
@@ -113,7 +113,15 @@ RunJetHT2016EreMINIAODwf136p7611 136.7611_RunJetHT2016E_reminiaod+*/step2.root P
 RunMET2016Ewf136p762 136.762_RunMET2016E+*/step3.root reRECO
 RunSinglePh2016Ewf136p766 136.766_RunSinglePh2016E+*/step3.root reRECO
 RunJetHT2016Hwf136p772 136.772_RunJetHT2016H+*/step3.root reRECO
+#
+# 2017 data
+#
 RunHLTPhy2017Bwf136p78 136.78_RunHLTPhy2017B+*/step3.root reRECO
+RunDoubleEG2017Bwf136p781 136.781_RunDoubleEG2017B+*/step3.root reRECO
+RunDoubleMuon2017Bwf136p782 136.782_RunDoubleMuon2017B+*/step3.root reRECO
+RunJetHT2017B136p783 136.783_RunJetHT2017B+*/step3.root reRECO
+RunMET2017B136p784 136.784_RunMET2017B+*/step3.root reRECO
+RunSinglePh2017B136p788 136.788_RunSinglePh2017B+*/step3.root reRECO
 #
 # 2017 workflows follow
 #

--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -1176,6 +1176,8 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+recoS+".obj.CSCTightHaloId2015()");
       plotvar(tbr+recoS+".obj.GlobalLooseHaloId()");
       plotvar(tbr+recoS+".obj.GlobalTightHaloId()");
+      plotvar(tbr+recoS+".obj.GlobalTightHaloId2016()");
+      plotvar(tbr+recoS+".obj.GlobalSuperTightHaloId2016()");
       plotvar(tbr+recoS+".obj.getProblematicStrips()@.size()");
       plotvar(tbr+recoS+".obj.getProblematicStrips().cellTowerIds@.size()");
       plotvar(tbr+recoS+".obj.getProblematicStrips().hadEt");


### PR DESCRIPTION
Since a few days we have more complete set of 2017B workflows. The map update is also to align with the proposed https://github.com/cms-sw/cmssw/pull/19944 which would add a single photon workflow 136.788 to the short matrix tested by jenkins

validateJR fwlite plots were updated to include currently standard ID flags in the BeamHaloSummary