### PR TITLE
skip SiStrip/MechanicalView plots in alternative-comparisons

### DIFF
--- a/run-pr-comparisons
+++ b/run-pr-comparisons
@@ -234,7 +234,7 @@ if [ "X$RUN_ALT_COMP" = Xtrue ]; then
     # create a mini script for running this comparisons in parallel
     echo '#!/bin/sh -ex' >> $ALT_COMP_DIR/command-$WF_NUMBER
     echo "cd $ALT_COMP_DIR/$WF_NUMBER" >> $ALT_COMP_DIR/command-$WF_NUMBER
-    echo "$ALT_COMP_DIR/$WF_NUMBER/makeDiff.sh $BASE_FILE $COMP_FILE $WF_NUMBER-result.ps 0 $MOD || true" >> $ALT_COMP_DIR/command-$WF_NUMBER
+    echo "$ALT_COMP_DIR/$WF_NUMBER/makeDiff.sh $BASE_FILE $COMP_FILE $WF_NUMBER-result.ps 0 8$MOD "" "[0-9][0-9]/AlCaReco/Run summary/SiStrip/MechanicalView" || true" >> $ALT_COMP_DIR/command-$WF_NUMBER
     echo "mv diff.ps $ALT_COMP_DIR/$WF_NUMBER-result.ps || true" >> $ALT_COMP_DIR/command-$WF_NUMBER
     echo "mv diff.pdf $ALT_COMP_DIR/$WF_NUMBER-result.pdf || true" >> $ALT_COMP_DIR/command-$WF_NUMBER
     echo "gzip -f $ALT_COMP_DIR/$WF_NUMBER-result.ps || true" >> $ALT_COMP_DIR/command-$WF_NUMBER


### PR DESCRIPTION
plots in SiStrip/MechanicalView have been failing for over a year now in data workflows in a mode that generates O(10K) plots with differences which take forever to print to file (even worse considering that jenkins does it for pdf and ps).

something similar could probably be done in relmon plots as well, but I'm not aware of an anti-pattern option there.
This PR should reduce the CPU wasted by at least a factor of 2 (I'm guessing that relmon takes about the same time to make these plots).
