### PR TITLE
Revert "skip SiStrip/MechanicalView plots in alternative-comparisons"

### DIFF
--- a/run-pr-comparisons
+++ b/run-pr-comparisons
@@ -243,7 +243,7 @@ if [ "X$RUN_ALT_COMP" = Xtrue ]; then
     # create a mini script for running this comparisons in parallel
     echo '#!/bin/sh -ex' >> $ALT_COMP_DIR/command-$WF_NUMBER
     echo "cd $ALT_COMP_DIR/$WF_NUMBER" >> $ALT_COMP_DIR/command-$WF_NUMBER
-    echo "$ALT_COMP_DIR/$WF_NUMBER/makeDiff.sh $BASE_FILE $COMP_FILE $WF_NUMBER-result.ps 0 8$MOD "" "[0-9][0-9]/AlCaReco/Run summary/SiStrip/MechanicalView" || true" >> $ALT_COMP_DIR/command-$WF_NUMBER
+    echo "$ALT_COMP_DIR/$WF_NUMBER/makeDiff.sh $BASE_FILE $COMP_FILE $WF_NUMBER-result.ps 0 $MOD || true" >> $ALT_COMP_DIR/command-$WF_NUMBER
     echo "mv diff.ps $ALT_COMP_DIR/$WF_NUMBER-result.ps || true" >> $ALT_COMP_DIR/command-$WF_NUMBER
     echo "mv diff.pdf $ALT_COMP_DIR/$WF_NUMBER-result.pdf || true" >> $ALT_COMP_DIR/command-$WF_NUMBER
     echo "gzip -f $ALT_COMP_DIR/$WF_NUMBER-result.ps || true" >> $ALT_COMP_DIR/command-$WF_NUMBER


### PR DESCRIPTION
Reverts cms-sw/cms-bot#881

after https://github.com/cms-sw/cmssw/pull/20050 is merged in CMSSW_9_3_X_2017-08-04-1100
it looks like SiStrip/MechanicalView monitoring in CMSSW is now apparently stable and does not go on/off randomly producing empty plots.

this damage control fix from #881 is not  needed anymore

the processing times are also consistently low https://cmssdt.cern.ch/jenkins/job/compare-root-files-short-matrix/buildTimeTrend
I checked several cases that took more than 1h, and in all of them apparently there are 30 mins spent in moving the outputs out (most likely all in send_jenkins_artifacts calls)
