### PR TITLE
reco comparisons updates: reduced GSF; use try/catch in all packedCandidates plots to let plots complete

### DIFF
--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -701,7 +701,7 @@ void muonVars(TString cName = "muons_", TString tName = "recoMuons_"){
 void packedCandVar(TString var, TString cName = "packedPFCandidates_", TString tName = "patPackedCandidates_", bool notafunction = false){
   TString v= notafunction ? tName+cName+"_"+recoS+".obj."+var :
     tName+cName+"_"+recoS+".obj."+var+"()" ;
-  plotvar(v, "", notafunction ? false : true);//ask for try/catch if it's a function
+  plotvar(v, "", true);//ask for try/catch regardless of the type of the plotted variables
 }
 
 void packedCand(TString cName = "packedPFCandidates_", TString tName = "patPackedCandidates_"){
@@ -2203,7 +2203,8 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
 
       ///gsf tracks plots
       gsfTrackVars("electronGsfTracks_");
-      gsfTrackVars("electronGsfTracksFromMultiCl_");      
+      gsfTrackVars("electronGsfTracksFromMultiCl_");
+      gsfTrackVars("reducedEgamma_reducedGsfTracks");
     }
 
     if (step.Contains("all") || step.Contains("pflow")){


### PR DESCRIPTION
- bug fix: use try/catch in all packedCandidates plots
    - previously plots of data members directly could complete; now it looks like ROOT is calling constructors still and the plots fail. This update fixes the problem by catching the exception
    - Here is an example log from jenkins: https://cmssdt.cern.ch/SDT/jenkins-artifacts/baseLineComparisons/CMSSW_9_3_X_2017-08-20-1100+19964/22029/validateJR/all_mini_OldVSNew_RunSinglePh2017B136p788/all_mini_OldVSNew_RunSinglePh2017B136p788.log


- new plots: add plots of reducedGsfTracks for the new product added in https://github.com/cms-sw/cmssw/pull/19964
