### PR TITLE
Lizard, sort by CNN in descending order.

### DIFF
--- a/lizard-processing/src/lizard_to_html.py
+++ b/lizard-processing/src/lizard_to_html.py
@@ -34,6 +34,7 @@ html_end = '''
 $(document).ready(function() {{
     var data = {data};
     $('#table-id').DataTable({{
+            order: [1, 'desc'], // order on CCN
             data: data,
             deferRender:    true,
             {comment_out_scrollX}scrollX: true,


### PR DESCRIPTION
Updated lizard_to_html.py script so that it would sort on CNN column by default. 