### PR TITLE
Add CalibTracker/StandaloneTrackerTopology to categories.py

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -1278,6 +1278,7 @@ CMSSW_CATEGORIES={
    "CalibTracker/SiStripHitEfficiency",
    "CalibTracker/SiStripLorentzAngle",
    "CalibTracker/SiStripQuality",
+   "CalibTracker/StandaloneTrackerTopology",
    "Calibration/EcalAlCaRecoProducers",
    "Calibration/EcalCalibAlgos",
    "Calibration/EcalTBTools",


### PR DESCRIPTION
New package proposed in https://github.com/cms-sw/cmssw/pull/21298 .
The reasoning behind putting it under alca (in `CalibTracker/`) was that most of the packages that use it are there (but now there are also some in db (CondCore/SiStripPlugins), and in visualization, so maybe geometry would be more appropriate?)