### PR TITLE
Add package HeterogeneousCore/CUDAServices to the Core category

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -36,6 +36,7 @@ CMSSW_CATEGORIES={
    "FWCore/Sources", "FWCore/TFWLiteSelector",
    "FWCore/TFWLiteSelectorTest",
    "FWCore/Utilities", "FWCore/Version",
+   "HeterogeneousCore/CUDAServices",
    "PerfTools/Callgrind",
    "PerfTools/EdmEvent", "IOMC/Input",
    "IOMC/RandomEngine",


### PR DESCRIPTION
Package HeterogeneousCore/CUDAServices has been proposed as the first one of a list for a new Subsystem. Assigned to the Core category.

@Dr15Jones @smuzaffar please suggest an alternative if you consider it more appropriate