### PR TITLE
Add category xpog with no package associated for AN release branch management

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -65,6 +65,8 @@ CMSSW_L2 = {
   "gudrutis" : ["externals"],
   "lpernie" : ["alca"],
   "jfernan2": ["dqm"],
+  "arizzi": ["xpog"],
+  "gpetruc": ["xpog"],
   CMSBUILD_USER: ["tests", "code-checks" ],
 }
 

--- a/categories_map.py
+++ b/categories_map.py
@@ -603,7 +603,7 @@ CMSSW_CATEGORIES={
    "RecoMuon/L3TrackFinder",
    "RecoTauTag/HLTProducers",
   ],
-  "xpog": [""],
+  "xpog": [],
   "analysis": [
    "EgammaAnalysis/ElectronTools",
    "CondFormats/JetMETObjects",

--- a/categories_map.py
+++ b/categories_map.py
@@ -602,9 +602,9 @@ CMSSW_CATEGORIES={
    "RecoMuon/L3MuonProducer",
    "RecoMuon/L3TrackFinder",
    "RecoTauTag/HLTProducers",
- ],
- "xpog": [""],
- "analysis": [
+  ],
+  "xpog": [""],
+  "analysis": [
    "EgammaAnalysis/ElectronTools",
    "CondFormats/JetMETObjects",
    "HiggsAnalysis/CombinedLimit",

--- a/categories_map.py
+++ b/categories_map.py
@@ -603,6 +603,7 @@ CMSSW_CATEGORIES={
    "RecoMuon/L3TrackFinder",
    "RecoTauTag/HLTProducers",
  ],
+ "xpog": [""],
  "analysis": [
    "EgammaAnalysis/ElectronTools",
    "CondFormats/JetMETObjects",


### PR DESCRIPTION
As agreed, a new empty category "xpog" with no CMSSW package associated is added, and the present XPOG coordinators are associated as responsible. This addition is intended to support the forthcoming AN release branch management, where the integration will be mostly done based on agreement from the XPOG coordinators (+ basic technical tests).  