### PR TITLE
reco comparisons: map updated for miniAOD workflows; plots for pat::MET

### DIFF
--- a/comparisons/matrix_RE.txt
+++ b/comparisons/matrix_RE.txt
@@ -74,7 +74,9 @@ SingleMu13Pt1000wf1322p0 1322.0_SingleMuPt1000_UP15+*/step3.root RECO
 TTbar13wf1325p0 1325.0_TTbar_13+TTbar_13*/step3.root RECO
 TTbar13wf11325p0 11325.0_TTbar_13_unsch+TTbar_13*/step3.root RECO
 TTbar13reMINIAODwf1325p5 1325.5_TTbar_13_reminiaod*/step2.root PAT
-TTbar13nanoAODwf1325p7 1325.7_TTbar_13_94XNanoAODINPUT+*/step2.root DQM
+ZEE13reMINIAODwf1325p5 1325.5_ProdZEE_13_reminiaod*/step2.root PAT
+TTbar13reMINIAODwf1325p51 1325.51_TTbar_13_94Xreminiaod*/step2.root PAT
+TTbar13nanoAODwf1325p7 1325.7_TTbar_13_94XNanoAOD*/step2.root DQM
 ZMM13TeVwf1330p0 1330.0_ZMM_13+*/step3.root RECO
 H125GG13TeVwf1332p0 1332.0_H125GGgluonfusion_13+*/step3.root RECO
 VBFH125BB13TeVwf1363p0 1363.0_VBFHToBB_M125_Pow_py8_Evt_13*/step3.root RECO
@@ -132,6 +134,7 @@ RunSinglePh2017B136p788 136.788_RunSinglePh2017B+*/step3.root reRECO
 RunDoubleEG2017Fwf136p829 136.829_RunDoubleEG2017F+*/step3.root reRECO
 RunDoubleMuon2017Fwf136p83 136.83_RunDoubleMuon2017F+*/step3.root reRECO
 RunJetHT2017F136p831 136.831_RunJetHT2017F+*/step3.root reRECO
+RunJetHT2017FreMINIAOD136p8311 136.8311_RunJetHT2017F_reminiaod+*/step2.root PAT
 RunMET2017F136p832 136.832_RunMET2017F+*/step3.root reRECO
 #
 # 2017 workflows follow

--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -230,7 +230,6 @@ double plotvar(TString v,TString cut="", bool tryCatch = false){
   return countDiff;
 }
 
-
 void jet(TString type, TString algo, TString var, bool log10Var = false, bool trycatch = false, bool notafunction = false){
   TString v = type+"_"+algo+(algo.Contains("_")? "_" : "__")+recoS+".obj."+var+(notafunction? "" : "()");
   if (log10Var) v = "log10(" + v + ")";
@@ -331,10 +330,10 @@ void calomet(TString algo, TString var, bool doLog10 = false){
   plotvar(v);
 }
 
-void met(TString var, TString cName = "tcMet_", TString tName = "recoMETs_",  bool notafunction=false){
-  TString v=notafunction ? tName+cName+"_"+recoS+".obj."+var:
-    tName+cName+"_"+recoS+".obj."+var+"()";
-  plotvar(v);
+void met(TString var, TString cName = "tcMet_", TString tName = "recoMETs_",  bool log10Var = false, bool trycatch = false, bool notafunction=false){
+  TString v = tName+cName+"_"+recoS+".obj."+var+(notafunction? "" : "()");
+  if (log10Var) v = "log10(" + v + ")";
+  plotvar(v, "", trycatch);
 }
 
 void metVars(TString cName = "tcMet_", TString tName = "recoMETs_") {
@@ -345,6 +344,37 @@ void metVars(TString cName = "tcMet_", TString tName = "recoMETs_") {
   met("phi",cName,tName);
   met("sumEt",cName,tName);
   met("significance",cName,tName);
+}
+
+void patMetVars(TString cName){
+  const TString tName = "patMETs_";
+  metVars(cName, tName);
+  
+  met("userFloats_@.size", cName, tName);
+  for (int i = 0; i< 32; ++i){
+    plotvar(tName+cName+"_"+recoS+Form(".obj[0].userFloats_[%d]",i), "", true);
+  }
+  met("userInts_@.size", cName, tName);
+  for (int i = 0; i< 32; ++i){
+    plotvar(tName+cName+"_"+recoS+Form(".obj[0].userInts_[%d]",i), "", true);
+  }
+  met("userCands_@.size", cName, tName);
+
+  met("pfMET_[0].NeutralEMFraction", cName, tName, false, true, true);
+  met("pfMET_[0].NeutralHadFraction", cName, tName, false, true, true);
+  met("pfMET_[0].ChargedEMFraction", cName, tName, false, true, true);
+  met("pfMET_[0].ChargedHadFraction", cName, tName, false, true, true);
+  met("pfMET_[0].MuonFraction", cName, tName, false, true, true);
+  met("pfMET_[0].Type6Fraction", cName, tName, false, true, true);
+  met("pfMET_[0].Type7Fraction", cName, tName, false, true, true);
+
+  for (int i = 0; i< 24; ++i){
+    plotvar(tName+cName+"_"+recoS+Form(".obj[0].uncertainties_[%d].dpx()",i), "", true);
+    plotvar(tName+cName+"_"+recoS+Form(".obj[0].uncertainties_[%d].dsumEt()",i), "", true);
+
+    plotvar(tName+cName+"_"+recoS+Form(".obj[0].corrections_[%d].dpx()",i), "", true);
+    plotvar(tName+cName+"_"+recoS+Form(".obj[0].corrections_[%d].dsumEt()",i), "", true);
+  }
 }
 
 void tau(TString var, TString cName = "hpsPFTauProducer_", TString tName = "recoPFTaus_", 
@@ -2291,6 +2321,12 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar("log10(recoPFRecHits_particleFlowRecHitHO_Cleaned_"+recoS+".obj.energy())");
       plotvar("recoPFRecHits_particleFlowRecHitHO_Cleaned_"+recoS+".obj.time()");
 
+      plotvar("recoPFRecHits_particleFlowRecHitECAL__"+recoS+".obj@.size()");
+      plotvar("recoPFRecHits_particleFlowRecHitECAL__"+recoS+".obj.position_.eta()");
+      plotvar("recoPFRecHits_particleFlowRecHitECAL__"+recoS+".obj.position_.phi()");
+      plotvar("log10(recoPFRecHits_particleFlowRecHitECAL__"+recoS+".obj.energy())");
+      plotvar("recoPFRecHits_particleFlowRecHitECAL__"+recoS+".obj.time()");
+
       plotvar("recoPFRecHits_particleFlowRecHitECAL_Cleaned_"+recoS+".obj@.size()");
       plotvar("recoPFRecHits_particleFlowRecHitECAL_Cleaned_"+recoS+".obj.position_.eta()");
       plotvar("recoPFRecHits_particleFlowRecHitECAL_Cleaned_"+recoS+".obj.position_.phi()");
@@ -2488,10 +2524,10 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       metVars("htMetAK7_");
 
       // miniaod
-      metVars("slimmedMETs_","patMETs_");
-      metVars("slimmedMETsPuppi_","patMETs_");
+      patMetVars("slimmedMETs_");
+      patMetVars("slimmedMETsPuppi_");
       // miniaod debug
-      metVars("patMETsPuppi_","patMETs_");
+      patMetVars("patMETsPuppi_");
       metVars("pfMetT1Puppi_","recoPFMETs_");
       metVars("pfMetPuppi_","recoPFMETs_");
 

--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -369,11 +369,11 @@ void patMetVars(TString cName){
   met("pfMET_[0].Type7Fraction", cName, tName, false, true, true);
 
   for (int i = 0; i< 24; ++i){
-    plotvar(tName+cName+"_"+recoS+Form(".obj[0].uncertainties_[%d].dpx()",i), "", true);
-    plotvar(tName+cName+"_"+recoS+Form(".obj[0].uncertainties_[%d].dsumEt()",i), "", true);
+    plotvar(tName+cName+"_"+recoS+Form(".obj[0].uncertainties_[%d].dpx()",i), tName+cName+"_"+recoS+Form(".obj[0].uncertainties_@.size()>%d",i), true);
+    plotvar(tName+cName+"_"+recoS+Form(".obj[0].uncertainties_[%d].dsumEt()",i), tName+cName+"_"+recoS+Form(".obj[0].uncertainties_@.size()>%d",i), true);
 
-    plotvar(tName+cName+"_"+recoS+Form(".obj[0].corrections_[%d].dpx()",i), "", true);
-    plotvar(tName+cName+"_"+recoS+Form(".obj[0].corrections_[%d].dsumEt()",i), "", true);
+    plotvar(tName+cName+"_"+recoS+Form(".obj[0].corrections_[%d].dpx()",i), tName+cName+"_"+recoS+Form(".obj[0].corrections_@.size()>%d",i), true);
+    plotvar(tName+cName+"_"+recoS+Form(".obj[0].corrections_[%d].dsumEt()",i), tName+cName+"_"+recoS+Form(".obj[0].corrections_@.size()>%d",i), true);
   }
 }
 


### PR DESCRIPTION
- map file is updated to cover recent additions/changes in (re)miniAOD workflows
- fwlite-based scripts updates:
    - pat::MET plots now include PAT-specific variables including uncertainties
    - plots for ```particleFlowRecHitECAL__ ``` were added for debug purposes (this collection is not saved by default in RECO or higher data tiers checked in jenkins)

