### PR TITLE
Add XPOG coordinators to the analysis category, remove the xpog category with no package assigned

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -65,8 +65,8 @@ CMSSW_L2 = {
   "gudrutis" : ["externals"],
   "lpernie" : ["alca"],
   "jfernan2": ["dqm"],
-  "arizzi": ["xpog"],
-  "gpetruc": ["xpog"],
+  "arizzi": ["analysis"],
+  "gpetruc": ["analysis"],
   CMSBUILD_USER: ["tests", "code-checks" ],
 }
 

--- a/categories_map.py
+++ b/categories_map.py
@@ -603,7 +603,6 @@ CMSSW_CATEGORIES={
    "RecoMuon/L3TrackFinder",
    "RecoTauTag/HLTProducers",
   ],
-  "xpog": [],
   "analysis": [
    "EgammaAnalysis/ElectronTools",
    "CondFormats/JetMETObjects",


### PR DESCRIPTION
For the management of the AN release: use the standard analysis category, remove the xpog category with no package assigned.