### PR TITLE
comparisons:  map updates; reco comparisons/validate.C add recent muon variables, PF debug plots, more strict configuration

### DIFF
--- a/comparisons/matrix_RE.txt
+++ b/comparisons/matrix_RE.txt
@@ -51,45 +51,45 @@ RunHI2011wf140p53 140.53_RunHI2011+RunHI2011+*/step2.root reRECO
 HydjetQwf40p0 40.0_HydjetQ_MinBias_2760GeV+HydjetQ_MinBias_2760GeV*/step3.root RECO
 HydjetQMinBiaswf140p0 140.0_HydjetQ_MinBias_2760GeV+HydjetQ_MinBias_2760GeV*/step3.root RECO
 ZEEMMHIwf140p4 140.4_ZEEMM_13_HI+ZEEMM_13_HI*/step3.root RECO
-ZEEMMHIwf302p0 302.0_Pyquen_ZeemumuJets_pt10_2760GeV+Pyquen_ZeemumuJets_pt10_2760GeV+*/step3.root RECO
-EPOSPPb8160GeVwf281p0 281.0_EPOS_PPb_8160GeV_MinimumBias+*/step3.root RECO
+ZEEMMHIwf302p0 302.0_Pyquen_ZeemumuJets_pt10_2760GeV+Pyquen_ZeemumuJets_pt10_2760GeV*/step3.root RECO
+EPOSPPb8160GeVwf281p0 281.0_EPOS_PPb_8160GeV_MinimumBias*/step3.root RECO
 HydjetQB12in2018wf150p0 150.0_HydjetQ_B12_5020GeV_*/step3.root RECO
 #
 #  Run2 MC
 #
-QCD13TeVPt3Ts3T5wf1313p0 1313.0_QCD_Pt_3000_3500_13+*/step3.root RECO
+QCD13TeVPt3Ts3T5wf1313p0 1313.0_QCD_Pt_3000_3500_13*/step3.root RECO
 ZpEE2250wf1344p0 1344.0_ZpEE_2250_13TeV+ZpEE_2250_13TeV*/step3.root RECO
 ZpTT1500wf1345p0 1345.0_ZpTT_1500_13TeV*/step3.root RECO
 CosmicsUP15wf1307p0 1307.0_Cosmics*/step3.root RECO
 BeamHalo13wf1308p0 1308.0_BeamHalo_13+BeamHalo_13*/step3.root RECO
 BuJpsiK13TeVwf1340p0 1340.0_BuJpsiK_13+BuJpsiK_13*/step3.root RECO
-QCD13TeVFlatPt15s3000wf1338p0 1338.0_QCD_FlatPt_15_3000HS_13+*/step3.root RECO
-SingleElectron13Pt1000wf1316p0 1316.0_SingleElectronPt1000_UP15+*/step3.root RECO
-SingleElectron13Pt35wf1317p0 1317.0_SingleElectronPt35_UP15+*/step3.root RECO
-SingleGamma13Pt10wf1318p0 1318.0_SingleGammaPt10_UP15+*/step3.root RECO
-SingleGamma13Pt35wf1319p0 1319.0_SingleGammaPt35_UP15+*/step3.root RECO
-SingleMu13Pt10wf1320p0 1320.0_SingleMuPt10_UP15+*/step3.root RECO
+QCD13TeVFlatPt15s3000wf1338p0 1338.0_QCD_FlatPt_15_3000HS_13*/step3.root RECO
+SingleElectron13Pt1000wf1316p0 1316.0_SingleElectronPt1000_UP15*/step3.root RECO
+SingleElectron13Pt35wf1317p0 1317.0_SingleElectronPt35_UP15*/step3.root RECO
+SingleGamma13Pt10wf1318p0 1318.0_SingleGammaPt10_UP15*/step3.root RECO
+SingleGamma13Pt35wf1319p0 1319.0_SingleGammaPt35_UP15*/step3.root RECO
+SingleMu13Pt10wf1320p0 1320.0_SingleMuPt10_UP15*/step3.root RECO
 SingleMu13Pt100wf1321p0 1321.0_SingleMuPt100_UP15+SingleMuPt100_UP15*/step3.root RECO
-SingleMu13Pt1000wf1322p0 1322.0_SingleMuPt1000_UP15+*/step3.root RECO
+SingleMu13Pt1000wf1322p0 1322.0_SingleMuPt1000_UP15*/step3.root RECO
 TTbar13wf1325p0 1325.0_TTbar_13+TTbar_13*/step3.root RECO
 TTbar13wf11325p0 11325.0_TTbar_13_unsch+TTbar_13*/step3.root RECO
 TTbar13reMINIAODwf1325p5 1325.5_TTbar_13_reminiaod*/step2.root PAT
 ZEE13reMINIAODwf1325p5 1325.5_ProdZEE_13_reminiaod*/step2.root PAT
 TTbar13reMINIAODwf1325p51 1325.51_TTbar_13_94Xreminiaod*/step2.root PAT
-TTbar13nanoAODwf1325p7 1325.7_TTbar_13_94XNanoAOD*/step2.root DQM
-ZMM13TeVwf1330p0 1330.0_ZMM_13+*/step3.root RECO
-H125GG13TeVwf1332p0 1332.0_H125GGgluonfusion_13+*/step3.root RECO
+TTbar13nanoAODwf1325p7 1325.7_TTbar_13_94X*NanoAOD*/step2.root DQM
+ZMM13TeVwf1330p0 1330.0_ZMM_13*/step3.root RECO
+H125GG13TeVwf1332p0 1332.0_H125GGgluonfusion_13*/step3.root RECO
 VBFH125BB13TeVwf1363p0 1363.0_VBFHToBB_M125_Pow_py8_Evt_13*/step3.root RECO
 BsToJpsiPhi13TeVwf1366p0 1366.0_BsToJpsiPhi_13+BsToJpsiPhi_13*/step3.root RECO
-SingleMu13Pt1wf1306p0 1306.0_SingleMuPt1_UP15+*/step3.root RECO
-ZEEFS13wf135p4 135.4_ZEE_13+ZEEFS_13+*/step1.root HLT
+SingleMu13Pt1wf1306p0 1306.0_SingleMuPt1_UP15*/step3.root RECO
+ZEEFS13wf135p4 135.4_ZEE_13+ZEEFS_13*/step1.root HLT
 ZEEPUwf25200p0 25200.0_ZEE_13+ZEE_13*/step3.root RECO
 TTbarPUwf25202p0 25202.0_TTbar_13+TTbar_13*/step3.root RECO
 TTbarPUwf50202p0 50202.0_TTbar_13+TTbar_13*/step3.root RECO
 H125GG13TeVPUwf25203p0 25203.0_H125GGgluonfusion_13+H125GGgluonfusion_13*/step3.root RECO
 ZMMPUwf25206p0 25206.0_ZMM_13+ZMM_13*/step3.root RECO
 QCD13TeVFlatPt15s3000PUwf25209p0 25209.0_QCD_FlatPt_15_3000HS_13+QCD_FlatPt_15_3000HS_13*/step3.root RECO
-VBFH125BB13TeVPUwf25213p0 25213.0_VBFHToBB_M125_Pow_py8_Evt_13+*/step3.root RECO
+VBFH125BB13TeVPUwf25213p0 25213.0_VBFHToBB_M125_Pow_py8_Evt_13*/step3.root RECO
 ProdZEE13TeVPUpmxwf250200p1 250200.1_ProdZEE_13*/step3.root RECO
 TTbar13TeVPUpmxwf250202p0 250202.0_TTbar_13*/step3.root RECO
 ProdTTbar13TeVPUpmxwf250202p1 250202.1_ProdTTbar_13*/step3.root RECO
@@ -139,8 +139,8 @@ RunMET2017F136p832 136.832_RunMET2017F+*/step3.root reRECO
 #
 # 2017 workflows follow
 #
-Cosmics2017wf7p2 7.2_Cosmics_UP17+*/step3.root RECO
-CosmicsSPLoose2017wf7p3 7.3_CosmicsSPLoose_UP17+*/step3.root RECO
+Cosmics2017wf7p2 7.2_Cosmics_UP17*/step3.root RECO
+CosmicsSPLoose2017wf7p3 7.3_CosmicsSPLoose_UP17*/step3.root RECO
 SingleElectronPt35in2017wf10002p0 10002.0_SingleElectronPt35+SingleElectronPt35_pythia8_2017*/step3.root RECO
 SingleElectronPt1000in2017wf10003p0 10003.0_SingleElectronPt1000+SingleElectronPt1000_pythia8_2017*/step3.root RECO
 SingleGammaPt10in2017wf10004p0 10004.0_SingleGammaPt10+SingleGammaPt10_pythia8_2017*/step3.root RECO
@@ -197,6 +197,7 @@ SingleGammaPt10in2018wf10804p0 10804.0_SingleGammaPt10+SingleGammaPt10_pythia8_2
 SingleGammaPt35in2018wf10805p0 10805.0_SingleGammaPt35+SingleGammaPt35_pythia8_2018*_GenSimFull*+*/step3.root RECO
 SingleMuPt10in2018wf10807p0 10807.0_SingleMuPt10+SingleMuPt10_pythia8_2018*_GenSimFull*+*/step3.root RECO
 SingleMuPt1000in2018wf10809p0 10809.0_SingleMuPt1000+SingleMuPt1000_pythia8_2018*_GenSimFull*+*/step3.root RECO
+TenMuExtendedE2018wf10811p0 10811.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2018*_GenSimFull*+*/step3.root RECO
 TenMuE2018wf10821p0 10821.0_TenMuE_0_200+TenMuE_0_200_pythia8_2018*_GenSimFull*+*/step3.root RECO
 MinBias13TeV2018wf10823p0 10823.0_MinBias_13+MinBias_13TeV_pythia8_TuneCUETP8M1_2018*_GenSimFull*+*/step3.root RECO
 TTbar13TeV2018wf10824p0 10824.0_TTbar_13+TTbar_13TeV_TuneCUETP8M1_2018*_GenSimFull*+*/step3.root RECO
@@ -527,14 +528,14 @@ TTbar14TeV2023D18PUwf23434p0 23434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D1
 #
 #   D17
 #
-SingleElectronPt35in2023D17wf20002p0 20002.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D17_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleElectronPt1000in2023D17wf20003p0 20003.0_SingleElectronPt1000+SingleElectronPt1000_pythia8_2023D17_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleMuPt10in2023D17wf20007p0 20007.0_SingleMuPt10+SingleMuPt10_pythia8_2023D17_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleMuPt1000in2023D17wf20009p0 20009.0_SingleMuPt1000+SingleMuPt1000_pythia8_2023D17_GenSimHLBeamSpotFull+*/step3.root RECO
-TenMuExtendedE2023D17wf20011p0 20011.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D17_GenSimHLBeamSpotFull+*/step3.root RECO
-TTbar14TeV2023D17wf20034p0 20034.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14+*/step3.root RECO
-ZEE14TeV2023D17wf20046p0 20046.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14+*/step3.root RECO
-QCD600to800in14TeV2023D17wf20053p0 20053.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14+*/step3.root RECO
+SingleElectronPt35in2023D17wf20002p0 20002.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D17_GenSimHLBeamSpotFull*/step3.root RECO
+SingleElectronPt1000in2023D17wf20003p0 20003.0_SingleElectronPt1000+SingleElectronPt1000_pythia8_2023D17_GenSimHLBeamSpotFull*/step3.root RECO
+SingleMuPt10in2023D17wf20007p0 20007.0_SingleMuPt10+SingleMuPt10_pythia8_2023D17_GenSimHLBeamSpotFull*/step3.root RECO
+SingleMuPt1000in2023D17wf20009p0 20009.0_SingleMuPt1000+SingleMuPt1000_pythia8_2023D17_GenSimHLBeamSpotFull*/step3.root RECO
+TenMuExtendedE2023D17wf20011p0 20011.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D17_GenSimHLBeamSpotFull*/step3.root RECO
+TTbar14TeV2023D17wf20034p0 20034.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14*/step3.root RECO
+ZEE14TeV2023D17wf20046p0 20046.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14*/step3.root RECO
+QCD600to800in14TeV2023D17wf20053p0 20053.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D17_GenSimHLBeamSpotFull14*/step3.root RECO
 #
 #   D17Timing
 #
@@ -542,10 +543,10 @@ TTbar14TeV2023D17Timingwf20034p2 20034.2_TTbar_14TeV_Timing+TTbar_14TeV_TuneCUET
 #
 #   D17PU
 #
-TenMuExtendedE2023D17PUwf20211p0 20211.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D17PU_GenSimHLBeamSpotFull+*/step3.root RECO
-TTbar14TeV2023D17PUwf20234p0 20234.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14+*/step3.root RECO
-ZEE14TeV2023D17PUwf20246p0 20246.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14+*/step3.root RECO
-QCD600to800in14TeV2023D17PUwf20253p0 20253.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14+*/step3.root RECO
+TenMuExtendedE2023D17PUwf20211p0 20211.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D17PU_GenSimHLBeamSpotFull*/step3.root RECO
+TTbar14TeV2023D17PUwf20234p0 20234.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14*/step3.root RECO
+ZEE14TeV2023D17PUwf20246p0 20246.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14*/step3.root RECO
+QCD600to800in14TeV2023D17PUwf20253p0 20253.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D17PU_GenSimHLBeamSpotFull14*/step3.root RECO
 #
 #   D17PUTiming
 #
@@ -553,14 +554,14 @@ TTbar14TeV2023D17PUTimingwf20234p2 20234.2_TTbar_14TeV_Timing+TTbar_14TeV_TuneCU
 #
 #   D19
 #
-SingleElectronPt35in2023D19wf20402p0 20402.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D19_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleElectronPt1000in2023D19wf20403p0 20403.0_SingleElectronPt1000+SingleElectronPt1000_pythia8_2023D19_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleMuPt10in2023D19wf20407p0 20407.0_SingleMuPt10+SingleMuPt10_pythia8_2023D19_GenSimHLBeamSpotFull+*/step3.root RECO
-SingleMuPt1000in2023D19wf20409p0 20409.0_SingleMuPt1000+SingleMuPt1000_pythia8_2023D19_GenSimHLBeamSpotFull+*/step3.root RECO
-TenMuExtendedE2023D19wf20411p0 20411.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D19_GenSimHLBeamSpotFull+*/step3.root RECO
-TTbar14TeV2023D19wf20434p0 20434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14+*/step3.root RECO
-ZEE14TeV2023D19wf20446p0 20446.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14+*/step3.root RECO
-QCD600to800in14TeV2023D19wf20453p0 20453.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14+*/step3.root RECO
+SingleElectronPt35in2023D19wf20402p0 20402.0_SingleElectronPt35+SingleElectronPt35_pythia8_2023D19_GenSimHLBeamSpotFull*/step3.root RECO
+SingleElectronPt1000in2023D19wf20403p0 20403.0_SingleElectronPt1000+SingleElectronPt1000_pythia8_2023D19_GenSimHLBeamSpotFull*/step3.root RECO
+SingleMuPt10in2023D19wf20407p0 20407.0_SingleMuPt10+SingleMuPt10_pythia8_2023D19_GenSimHLBeamSpotFull*/step3.root RECO
+SingleMuPt1000in2023D19wf20409p0 20409.0_SingleMuPt1000+SingleMuPt1000_pythia8_2023D19_GenSimHLBeamSpotFull*/step3.root RECO
+TenMuExtendedE2023D19wf20411p0 20411.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D19_GenSimHLBeamSpotFull*/step3.root RECO
+TTbar14TeV2023D19wf20434p0 20434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14*/step3.root RECO
+ZEE14TeV2023D19wf20446p0 20446.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14*/step3.root RECO
+QCD600to800in14TeV2023D19wf20453p0 20453.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D19_GenSimHLBeamSpotFull14*/step3.root RECO
 #
 #   D19Timing
 #
@@ -568,19 +569,19 @@ TTbar14TeV2023D19Timingwf20434p2 20434.2_TTbar_14TeV_Timing+TTbar_14TeV_TuneCUET
 #
 #   D19PU
 #
-TenMuExtendedE2023D19PUwf20611p0 20611.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D19PU_GenSimHLBeamSpotFull+*/step3.root RECO
-TTbar14TeV2023D19PUwf20634p0 20634.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14+*/step3.root RECO
-ZEE14TeV2023D19PUwf20646p0 20646.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14+*/step3.root RECO
-QCD600to800in14TeV2023D19PUwf20653p0 20653.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14+*/step3.root RECO
+TenMuExtendedE2023D19PUwf20611p0 20611.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D19PU_GenSimHLBeamSpotFull*/step3.root RECO
+TTbar14TeV2023D19PUwf20634p0 20634.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14*/step3.root RECO
+ZEE14TeV2023D19PUwf20646p0 20646.0_ZEE_14+ZEE_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14*/step3.root RECO
+QCD600to800in14TeV2023D19PUwf20653p0 20653.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14*/step3.root RECO
 #
 #   D19PUTiming
 #
-TTbar14TeV2023D19PUTimingwf20634p2 20634.2_TTbar_14TeV_Timing+TTbar_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14_Timing+*/step3.root RECO
+TTbar14TeV2023D19PUTimingwf20634p2 20634.2_TTbar_14TeV_Timing+TTbar_14TeV_TuneCUETP8M1_2023D19PU_GenSimHLBeamSpotFull14_Timing*/step3.root RECO
 #
 #   D20
 #
-TenMuExtendedE2023D20wf20811p0 20811.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D20_GenSimHLBeamSpotFull+*/step3.root RECO
-TTbar14TeV2023D20wf20834p0 20834.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D20_GenSimHLBeamSpotFull14+*/step3.root RECO
+TenMuExtendedE2023D20wf20811p0 20811.0_TenMuExtendedE_0_200+TenMuExtendedE_0_200_pythia8_2023D20_GenSimHLBeamSpotFull*/step3.root RECO
+TTbar14TeV2023D20wf20834p0 20834.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2023D20_GenSimHLBeamSpotFull14*/step3.root RECO
 #
 #   D21
 #


### PR DESCRIPTION
- map updates
    - 10811 added
        - this should have no effect on jenkins tests]
    - fix 1325.7 wildcard to match to the latest update
        - used in jenkins and triggers warnings now
    - make MC wildcards more inclusive to handle MC with external inputs ("INPUT" text may be added when that input is available)
        - this is relevant only for private tests now
- fwlite plots updates
    - add plots for pat::Muons for recently added variables
        - this will show up in jenkins tests
    - step specifications now have an underscore enforced as a separator so that the map short name or other parts do not accidentally match the step specifications (in most cases we run "all_", but other options are present and are used occasionally)
        - this should have no effect on jenkins tests
    - add plots for PF debugging (pfdebug_ step specification) for local tests, this currently covers specifics of PF hadron calibrations looking in eta ranges up to 1.5, 1.5 to 2.5 and 2.5 to 3
        - this should have no effect on jenkins tests
