### PR TITLE
DQMHistoSizes: make output more detailed

### DIFF
--- a/logRootQA.py
+++ b/logRootQA.py
@@ -162,7 +162,7 @@ def checkDQMSize(r1,r2,diff, wfs):
         print 'Missing dqmMemoryStats in this release'
         return -1
 
-    output,error=runCommand(['dqmMemoryStats.py','-x','-u','KiB','-p3','-c0','-d3','--summary','-r',r1,'-i',r2])
+    output,error=runCommand(['dqmMemoryStats.py','-x','-u','KiB','-p3','-c0','-d2','--summary','-r',r1,'-i',r2])
     lines = output.splitlines()
     total = re.search("\d+\.\d+", lines[-1])
     if not total:
@@ -174,13 +174,14 @@ def checkDQMSize(r1,r2,diff, wfs):
     print lines, diff
     maxdiff = 10
     for line in lines:
-        if len(diff) >= maxdiff: break # limit amount of output
         if re.match("\s*-?\d+.*", line): # normal output line
             if line not in diff:
+                if len(diff) == maxdiff:
+                    diff.append(" ... <truncated>");
+                    wfs.append(getWorkflow(r1))
+                if len(diff) >= maxdiff: continue # limit amount of output
                 diff.append(line)
                 wfs.append(getWorkflow(r1))
-                if len(diff) == maxdiff:
-                    diff[-1] += " <truncated>"
             else:
                 idx = diff.index(line)
                 if not wfs[idx].endswith(",..."):

--- a/logRootQA.py
+++ b/logRootQA.py
@@ -235,8 +235,8 @@ qaIssues=False
 #scp -r 23485 dlange@cmsdev01:/build/dlange/171103/t1/.
 
 #https://cmssdt.cern.ch/SDT/jenkins-artifacts/baseLineComparisons/CMSSW_9_0_X_2017-03-22-1100+18042/18957/validateJR/
-baseDir='../t1/runTheMatrix-results'
-testDir='../t1/matrix-results'
+baseDir='base/'
+testDir='test/'
 jrDir='../t1/23485/validateJR'
 compDir='../t1/23485'
 
@@ -300,18 +300,18 @@ if not sameEvts:
 
 print '\n'
 # now check the JR comparisons for differences
-nDiff=summaryJR(jrDir)
-print 'SUMMARY Reco comparison results:',nDiff,'differences found in the comparisons' 
-print '\n'
+#nDiff=summaryJR(jrDir)
+#print 'SUMMARY Reco comparison results:',nDiff,'differences found in the comparisons' 
+#print '\n'
 
-compSummary=summaryComp(compDir)
-print 'SUMMARY DQMHistoTests: Total files compared:',compSummary[6]
-print 'SUMMARY DQMHistoTests: Total histograms compared:',compSummary[0]
-print 'SUMMARY DQMHistoTests: Total failures:',compSummary[1]
-print 'SUMMARY DQMHistoTests: Total nulls:',compSummary[2]
-print 'SUMMARY DQMHistoTests: Total successes:',compSummary[3]
-print 'SUMMARY DQMHistoTests: Total skipped:',compSummary[4]
-print 'SUMMARY DQMHistoTests: Total Missing objects:',compSummary[5]
+#compSummary=summaryComp(compDir)
+#print 'SUMMARY DQMHistoTests: Total files compared:',compSummary[6]
+#print 'SUMMARY DQMHistoTests: Total histograms compared:',compSummary[0]
+#print 'SUMMARY DQMHistoTests: Total failures:',compSummary[1]
+#print 'SUMMARY DQMHistoTests: Total nulls:',compSummary[2]
+#print 'SUMMARY DQMHistoTests: Total successes:',compSummary[3]
+#print 'SUMMARY DQMHistoTests: Total skipped:',compSummary[4]
+#print 'SUMMARY DQMHistoTests: Total Missing objects:',compSummary[5]
 
 newDQM=0
 nDQM=0
@@ -327,6 +327,6 @@ print 'SUMMARY DQMHistoSizes: Histogram memory added:',newDQM,'KiB(',nDQM,'files
 
 
 #### conclude
-print "SUMMARY Checked",nLog,"log files,",nRoot,"edm output root files,",compSummary[6],"DQM output files"
+print "SUMMARY Checked",nLog,"log files,",nRoot,"edm output root files,","DQM output files"
 if not qaIssues:
     print "No potential problems in log/root QA checks!"

--- a/logRootQA.py
+++ b/logRootQA.py
@@ -253,8 +253,8 @@ qaIssues=False
 #scp -r 23485 dlange@cmsdev01:/build/dlange/171103/t1/.
 
 #https://cmssdt.cern.ch/SDT/jenkins-artifacts/baseLineComparisons/CMSSW_9_0_X_2017-03-22-1100+18042/18957/validateJR/
-baseDir='base/'
-testDir='test/'
+baseDir='../t1/runTheMatrix-results'
+testDir='../t1/matrix-results'
 jrDir='../t1/23485/validateJR'
 compDir='../t1/23485'
 
@@ -318,18 +318,18 @@ if not sameEvts:
 
 print '\n'
 # now check the JR comparisons for differences
-#nDiff=summaryJR(jrDir)
-#print 'SUMMARY Reco comparison results:',nDiff,'differences found in the comparisons' 
-#print '\n'
+nDiff=summaryJR(jrDir)
+print 'SUMMARY Reco comparison results:',nDiff,'differences found in the comparisons' 
+print '\n'
 
-#compSummary=summaryComp(compDir)
-#print 'SUMMARY DQMHistoTests: Total files compared:',compSummary[6]
-#print 'SUMMARY DQMHistoTests: Total histograms compared:',compSummary[0]
-#print 'SUMMARY DQMHistoTests: Total failures:',compSummary[1]
-#print 'SUMMARY DQMHistoTests: Total nulls:',compSummary[2]
-#print 'SUMMARY DQMHistoTests: Total successes:',compSummary[3]
-#print 'SUMMARY DQMHistoTests: Total skipped:',compSummary[4]
-#print 'SUMMARY DQMHistoTests: Total Missing objects:',compSummary[5]
+compSummary=summaryComp(compDir)
+print 'SUMMARY DQMHistoTests: Total files compared:',compSummary[6]
+print 'SUMMARY DQMHistoTests: Total histograms compared:',compSummary[0]
+print 'SUMMARY DQMHistoTests: Total failures:',compSummary[1]
+print 'SUMMARY DQMHistoTests: Total nulls:',compSummary[2]
+print 'SUMMARY DQMHistoTests: Total successes:',compSummary[3]
+print 'SUMMARY DQMHistoTests: Total skipped:',compSummary[4]
+print 'SUMMARY DQMHistoTests: Total Missing objects:',compSummary[5]
 
 commonDQMs=getCommonFiles(baseDir,testDir,'DQM*.root')
 newDQM=0
@@ -347,6 +347,6 @@ for line, wf in zip(diff,wfs):
 
 
 #### conclude
-print "SUMMARY Checked",nLog,"log files,",nRoot,"edm output root files,","DQM output files"
+print "SUMMARY Checked",nLog,"log files,",nRoot,"edm output root files,",compSummary[6],"DQM output files"
 if not qaIssues:
     print "No potential problems in log/root QA checks!"

--- a/logRootQA.py
+++ b/logRootQA.py
@@ -2,23 +2,24 @@
 
 from os import listdir
 from os.path import isfile, join
+from fnmatch import fnmatch
 import os
 import subprocess
 import sys
 
-def getFiles(d,ending):
-    return [os.path.join(dp, f) for dp, dn, filenames in os.walk(d) for f in filenames if os.path.splitext(f)[1] == '.'+ending]
+def getFiles(d,pattern):
+    return [os.path.join(dp, f) for dp, dn, filenames in os.walk(d) for f in filenames if fnmatch(f, pattern)]
 #    return  [ f for f in listdir(d) if isfile(join(d,f)) ]
 
-def getCommonFiles(d1,d2,ending):
-    l1=getFiles(d1,ending)
+def getCommonFiles(d1,d2,pattern):
+    l1=getFiles(d1,pattern)
     print "l1",l1
-    l2=getFiles(d2,ending)
+    l2=getFiles(d2,pattern)
     print "l2",l2
     common=[]
     for l in l1:
         lT=l[len(d1):]
-        if 'step' not in lT or 'runall' in lT or 'dasquery' in lT: continue
+        if 'runall' in lT or 'dasquery' in lT: continue
         if d2+lT in l2:
             common.append(lT)
     return common
@@ -180,7 +181,7 @@ def summaryJR(jrDir):
         break
 
     for d in dirs:
-        diffs=getFiles(root+'/'+d,'png')
+        diffs=getFiles(root+'/'+d,'*.png')
         if len(diffs)>0:
             print 'JR results differ',len(diffs),d
             nDiff=nDiff+len(diffs)
@@ -255,7 +256,7 @@ if jrDir[-1]=='/':
 if compDir[-1]=='/':
     compDir=jrDir[:-1]
 
-commonLogs=getCommonFiles(baseDir,testDir,'log')
+commonLogs=getCommonFiles(baseDir,testDir,'step*.log')
 print commonLogs
 
 #### check the printouts
@@ -286,7 +287,7 @@ if lChanges:
     qaIssues=True
 print '\n'
 #### compare edmEventSize on each to look for new missing candidates
-commonRoots=getCommonFiles(baseDir,testDir,'root')
+commonRoots=getCommonFiles(baseDir,testDir,'step*.root')
 sameEvts=True
 nRoot=0
 for r in commonRoots:
@@ -313,10 +314,10 @@ print '\n'
 #print 'SUMMARY DQMHistoTests: Total skipped:',compSummary[4]
 #print 'SUMMARY DQMHistoTests: Total Missing objects:',compSummary[5]
 
+commonDQMs=getCommonFiles(baseDir,testDir,'DQM*.root')
 newDQM=0
 nDQM=0
-for r in commonRoots:
-    if 'inDQM' in r:
+for r in commonDQMs:
         t=checkDQMSize(baseDir+r,testDir+r)
         print r,t
         if t>=0: 


### PR DESCRIPTION
This PR revises the logic behind the `DQMHistoSizes` comparison output. It slightly changes its paradigm: from a tool to estimate run-time memory use (which was always flawed, but useful in the past), to one that automates a big part of DQM PR validation: check that the code changes only affect the DQM output that they claim to affect.

In more detail
- it now looks at harvesting output, and covers the full DQM process.
- it uses the "baseline camparison" feature of `dqmMemoryStats.py` to get a detailed difference in content.
- it condenses down this comparison to no more than 11 lines, deduplicating changes in multiple files and truncating the rest. These lines are added to the `SUMMARY`.
- it reports workflow numbers for the changes found, to give a hint where to start debugging when unexpected changes appear.

To be effective, this needs https://github.com/cms-sw/cmssw/pull/22925 , but it will also work without it (just outputting noise if nothing significant changed). The new comparison is about 2x slower than before (up to ~1min per file), since reading the harvesting output format is slower.

This change was only tested on a few samples locally, I hope it does not break any of the other comparisons touched.  