### PR TITLE
Fix sign in DQMHistoSizes

### DIFF
--- a/logRootQA.py
+++ b/logRootQA.py
@@ -164,7 +164,7 @@ def checkDQMSize(r1,r2,diff, wfs):
 
     output,error=runCommand(['dqmMemoryStats.py','-x','-u','KiB','-p3','-c0','-d2','--summary','-r',r1,'-i',r2])
     lines = output.splitlines()
-    total = re.search("\d+\.\d+", lines[-1])
+    total = re.search("-?\d+\.\d+", lines[-1])
     if not total:
         print 'Weird output',r1
         print output


### PR DESCRIPTION
The regular expression for the total change does not capture the sign, so it will always detect a size increase... the detailed statistics however are fine.

This fixes the regular expression.

(spotted in #979, though but not related to it)