### PR TITLE
Auto-discover CC7 and SLC6 images available for DMWM

### DIFF
--- a/openstack/hg/os.sh
+++ b/openstack/hg/os.sh
@@ -1,2 +1,4 @@
-IMAGE_CC7="CC7 - x86_64 [2018-05-16]"
-IMAGE_SLC6="SLC6 - x86_64 [2018-05-16]"
+#!/bin/sh -ex
+
+IMAGE_CC7=`openstack image list | grep 'CC7 - x86_64' | awk -F'|' '{print $3}' | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]]*$//'`
+IMAGE_SLC6=`openstack image list | grep 'SLC6 - x86_64' | awk -F'|' '{print $3}' | sed -e 's/^[[:space:]]*//' | sed -e 's/[[:space:]]*$//'`


### PR DESCRIPTION
@smuzaffar the openstack-create job is failing again, and it turns out the previous image is no longer available. 
This script should be able to discover what's the image name available (assuming only one CC7/SLC6 match)