### PR TITLE
adding Tongguang Cheng as L2 AlCa

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -63,6 +63,7 @@ CMSSW_L2 = {
   "monttj" : ["analysis"],
   "arunhep" : ["alca"],
   "pohsun" : ["alca"],
+  "tocheng" : ["alca"],
   "kpedro88" : ["upgrade"],
   "mrodozov" : ["externals"],
   "gudrutis" : ["externals"],


### PR DESCRIPTION
Hello @smuzaffar @fabiocos  , Tongguang is starting as AlCa/DB convener and thats why we would like to add him as L2 in github holding AlCa signature.
Could you please consider this request. 
Thanks.

FYI @tocheng @lpernie