### PR TITLE
Update watchers.yml for pieterdavid

### DIFF
--- a/watchers.yaml
+++ b/watchers.yaml
@@ -1339,3 +1339,18 @@ jan-kaspar:
 - RecoCTPPS/ProtonReconstruction
 - RecoCTPPS/TotemRPLocal
 - RecoCTPPS/PixelLocal
+pieterdavid:
+- CalibTracker/Configuration
+- CalibTracker/Records
+- CalibTracker/SiStrip
+- DataFormats/SiStrip
+- DPGAnalysis/SiStripTools
+- RecoLocalTracker/ClusterParameterEstimator
+- RecoLocalTracker/Configuration
+- RecoLocalTracker/Records
+- RecoLocalTracker/SiStrip
+- RecoLocalTracker/SubCollectionProducers
+- SimTracker/Common
+- SimTracker/Configuration
+- SimTracker/Records
+- SimTracker/SiStripDigitizer


### PR DESCRIPTION
as SiStrip local reco, calibration and alignment L3 convener, to follow strip tracker-related PRs