### PR TITLE
In support of cmssw#26187, add CommonTools/BaseParticlePropagator to fastsim and reconstruction

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -680,11 +680,11 @@ CMSSW_CATEGORIES = {
     "",
   ],
   "fastsim": [
+    "CommonTools/BaseParticlePropagator",
     "FastSimDataFormats/External",
     "FastSimDataFormats/L1GlobalMuonTrigger",
     "FastSimDataFormats/NuclearInteractions",
     "FastSimDataFormats/PileUpEvents",
-    "FastSimulation/BaseParticlePropagator",
     "FastSimulation/CTPPSFastGeometry",
     "FastSimulation/CTPPSFastSim",
     "FastSimulation/CTPPSFastTrackingProducer",
@@ -981,6 +981,7 @@ CMSSW_CATEGORIES = {
     "DPGAnalysis/Skims",
   ],
   "reconstruction": [
+    "CommonTools/BaseParticlePropagator",
     "CommonTools/CandAlgos",
     "CommonTools/CandUtils",
     "CommonTools/Clustering1D",


### PR DESCRIPTION
cms-sw/cmssw#26187 moves FastSimulation/BaseParticlePropagator to CommonTools/BaseParticlePropagator . This affects both reconstruction and fastsim, the new utility package may be jointly supervised by both categories