### PR TITLE
A fix to pick the correct version of DQM bin by bin comparison tool.

### DIFF
--- a/run-pr-comparisons
+++ b/run-pr-comparisons
@@ -119,8 +119,7 @@ echo "COMPARISON;RUNNING" >> $WORKSPACE/results/testsResults.txt
 send_jenkins_artifacts $WORKSPACE/results/testsResults.txt ${PR_BASELINE_JOBDIR}/testsResults.txt
 
 if $DQM_COMPARISON_TEST ; then
-  if command -v compareDQMOutput.py ; then
-    voms-proxy-init
+  if [ -e $CMSSW_RELEASE_BASE/bin/$SCRAM_ARCH/compareDQMOutput.py ] ; then
     compareDQMOutput.py -b ${JR_COMP_DIR}/$RELEASE_FORMAT/ -p ${JR_COMP_DIR}/PR-${PULL_REQUEST_NUMBER} -o $CMS_BOT_DIR/dqm-comparison/dqmComparisonOutput/ -n $PULL_REQUEST_NUMBER -t $PULL_REQUEST_JOB_ID -r $RELEASE_FORMAT -s $WORKSPACE/upload/ -j $NUM_PROC &> $WORKSPACE/upload/dqmBinByBinLog.log || true
     echo "DQM_BIN_BY_BIN_COMPARISON;OK,DQM bin by bin comparison,See results,/SDT/jenkins-artifacts/${COMP_UPLOAD_DIR}/dqm-histo-comparison-summary.html" >> $WORKSPACE/results/testsResults.txt
   fi

--- a/run-pr-comparisons
+++ b/run-pr-comparisons
@@ -118,10 +118,12 @@ sed -i '/COMPARISON;/d' $WORKSPACE/results/testsResults.txt
 echo "COMPARISON;RUNNING" >> $WORKSPACE/results/testsResults.txt
 send_jenkins_artifacts $WORKSPACE/results/testsResults.txt ${PR_BASELINE_JOBDIR}/testsResults.txt
 
-if $DQM_COMPARISON_TEST ; then 
-  voms-proxy-init
-  python $CMS_BOT_DIR/dqm-comparison/compareDQMOutput.py -b ${JR_COMP_DIR}/$RELEASE_FORMAT/ -p ${JR_COMP_DIR}/PR-${PULL_REQUEST_NUMBER} -o $CMS_BOT_DIR/dqm-comparison/dqmComparisonOutput/ -n $PULL_REQUEST_NUMBER -r $RELEASE_FORMAT -s $WORKSPACE/upload/ -j $NUM_PROC 2> $WORKSPACE/upload/dqmBinByBinLog.log || true
-  echo "DQM_BIN_BY_BIN_COMPARISON;OK,DQM bin by bin comparison,See results,/SDT/jenkins-artifacts/${COMP_UPLOAD_DIR}/dqm-histo-comparison-summary.html" >> $WORKSPACE/results/testsResults.txt
+if $DQM_COMPARISON_TEST ; then
+  if command -v compareDQMOutput.py ; then
+    voms-proxy-init
+    compareDQMOutput.py -b ${JR_COMP_DIR}/$RELEASE_FORMAT/ -p ${JR_COMP_DIR}/PR-${PULL_REQUEST_NUMBER} -o $CMS_BOT_DIR/dqm-comparison/dqmComparisonOutput/ -n $PULL_REQUEST_NUMBER -t $PULL_REQUEST_JOB_ID -r $RELEASE_FORMAT -s $WORKSPACE/upload/ -j $NUM_PROC &> $WORKSPACE/upload/dqmBinByBinLog.log || true
+    echo "DQM_BIN_BY_BIN_COMPARISON;OK,DQM bin by bin comparison,See results,/SDT/jenkins-artifacts/${COMP_UPLOAD_DIR}/dqm-histo-comparison-summary.html" >> $WORKSPACE/results/testsResults.txt
+  fi
 fi
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Since the tool was moved from bot to CMSSW, we have to invoke differently. Added additional conditional to check if tool exists so this PR could be merged immediately. 