### PR TITLE
Added  RecoTauTag/TrainingFiles under reconstruction

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1274,6 +1274,7 @@ CMSSW_CATEGORIES = {
     "RecoTauTag/ImpactParameter",
     "RecoTauTag/RecoTau",
     "RecoTauTag/TauTagTools",
+    "RecoTauTag/TrainingFiles",
     "RecoTracker/CkfPattern",
     "RecoTracker/Configuration",
     "RecoTracker/ConversionSeedGenerators",


### PR DESCRIPTION
We only have cms-data/RecoTauTag-TrainingFiles repository which should be under reconstruction.