### PR TITLE
Add new L1 sign-off responsible - Ben Krikler.

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -29,6 +29,7 @@ CMSSW_L2 = {
   "agrohsje":         ["generators"],
   "alja":             ["visualization"],
   "andrius-k":        ["dqm"],
+  "benkrikler":       ["l1"],
   "civanch":          ["simulation", "geometry", "fastsim"],
   "cmsdoxy":          ["docs"],
   "cvuosalo":         ["geometry"],


### PR DESCRIPTION
Ben Krikler is our new L1T DQM convener.  He is replacing Thomas Reis. 
He will mostly be taking care of L1 PRs that have to do with DQM oriented software, but hopefully will also assist with the main L1 PRs.

Please approve.  Thanks.