### PR TITLE
Add FWCore/Reflection in support of cms-sw/cmssw#27287

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -309,6 +309,7 @@ CMSSW_CATEGORIES = {
     "FWCore/PythonParameterSet",
     "FWCore/PythonUtilities",
     "FWCore/ROOTTests",
+    "FWCore/Reflection",
     "FWCore/RootAutoLibraryLoader",
     "FWCore/SOA",
     "FWCore/ServiceRegistry",


### PR DESCRIPTION
Update of https://github.com/cms-sw/cms-bot/blob/master/categories_map.py to add the new package FWCore/Refelction proposed in cms-sw/cmssw#27287 . The package is assigned to the "core" group.