### PR TITLE
Run performance monitoring for comparison baseline 

### DIFF
--- a/run-ib-comparison-baseline
+++ b/run-ib-comparison-baseline
@@ -17,7 +17,7 @@ pushd "$WORKSPACE/matrix-results"
   if [ -f ${CMSSW_RELEASE_BASE}/src/Validation/Performance/python/TimeMemoryJobReport.py ]; then 
       [ $(runTheMatrix.py --help | grep 'command' | wc -l) -gt 0 ] && MATRIX_EXTRAS="--command '--customise Validation/Performance/TimeMemoryJobReport.customiseWithTimeMemoryJobReport' $MATRIX_EXTRAS"
   fi 
-  CMS_PATH=/cvmfs/cms-ib.cern.ch/week0 runTheMatrix.py -s -j $(Jenkins_GetCPU) ${MATRIX_EXTRAS} 2>&1 | tee -a $WORKSPACE/matrixTests.log
+  eval CMS_PATH=/cvmfs/cms-ib.cern.ch/week0 runTheMatrix.py -s -j $(Jenkins_GetCPU) ${MATRIX_EXTRAS} 2>&1 | tee -a $WORKSPACE/matrixTests.log
   MAPPING_FILE=wf_mapping.txt
   ROOT_FILES=`find . -name DQM*.root | sort`
   for f in $ROOT_FILES

--- a/run-ib-comparison-baseline
+++ b/run-ib-comparison-baseline
@@ -14,6 +14,9 @@ pushd "$WORKSPACE/matrix-results"
   MATRIX_EXTRAS=$(grep 'PR_TEST_MATRIX_EXTRAS=' $CMS_BOT_DIR/cmssw-pr-test-config | sed 's|.*=||')
   if [ ! "X$MATRIX_EXTRAS" = "X" ] ; then MATRIX_EXTRAS="-l $MATRIX_EXTRAS" ; fi
   [ $(runTheMatrix.py --help | grep 'job-reports' | wc -l) -gt 0 ] && MATRIX_EXTRAS="--job-reports $MATRIX_EXTRAS"
+  if [ -f ${CMSSW_RELEASE_BASE}/src/Validation/Performance/python/TimeMemoryJobReport.py ]; then 
+      [ $(runTheMatrix.py --help | grep 'command' | wc -l) -gt 0 ] && MATRIX_EXTRAS="--command '--customise Validation/Performance/TimeMemoryJobReport.customiseWithTimeMemoryJobReport' $MATRIX_EXTRAS"
+  fi 
   CMS_PATH=/cvmfs/cms-ib.cern.ch/week0 runTheMatrix.py -s -j $(Jenkins_GetCPU) ${MATRIX_EXTRAS} 2>&1 | tee -a $WORKSPACE/matrixTests.log
   MAPPING_FILE=wf_mapping.txt
   ROOT_FILES=`find . -name DQM*.root | sort`


### PR DESCRIPTION
The simple performance monitoring already added to PR tests in #1142 is now added also to the IB comparisons baseline, writing its output only into JobReport .