### PR TITLE
Update templat and remove write filter condition for ib-matrix index

### DIFF
--- a/es/templates/cmssdt-runthematrix-data.json
+++ b/es/templates/cmssdt-runthematrix-data.json
@@ -39,6 +39,171 @@
         "TotalLoopCPU": {
           "type": "float"
         },
+        "HEAP_ARENA_N_UNUSED_CHUNKS":{
+          "type": "integer"
+        },
+        "HEAP_ARENA_SIZE_BYTES":{
+          "type": "integer"
+        },
+        "HEAP_MAPPED_N_CHUNKS":{
+          "type": "integer"
+        },
+        "HEAP_MAPPED_SIZE_BYTES":{
+          "type": "integer"
+        },
+        "HEAP_TOP_FREE_BYTES":{
+          "type": "integer"
+        },
+        "HEAP_UNUSED_BYTES":{
+          "type": "integer"
+        },
+        "HEAP_USED_BYTES":{
+          "type": "integer"
+        },
+        "LargestIncreaseRssEvent-a-COUNT":{
+          "type": "integer"
+        },
+        "LargestIncreaseRssEvent-b-RUN":{
+          "type": "integer"
+        },
+        "LargestIncreaseRssEvent-c-EVENT":{
+          "type": "integer"
+        },
+        "LargestIncreaseRssEvent-d-VSIZE":{
+          "type": "float"
+        },
+        "LargestIncreaseRssEvent-e-DELTV":{
+          "type": "float"
+        },
+        "LargestIncreaseRssEvent-f-RSS":{
+          "type": "float"
+        },
+        "LargestRssEvent-a-COUNT":{
+          "type": "integer"
+        },
+        "LargestRssEvent-b-RUN":{
+          "type": "integer"
+        },
+        "LargestRssEvent-c-EVENT":{
+          "type": "integer"
+        },
+        "LargestRssEvent-d-VSIZE":{
+          "type": "float"
+        },
+        "LargestRssEvent-e-DELTV":{
+          "type": "float"
+        },
+        "LargestRssEvent-f-RSS":{
+          "type": "float"
+        },
+        "LargestVsizeEventT1-a-COUNT":{
+          "type": "integer"
+        },
+        "LargestVsizeEventT1-b-RUN":{
+          "type": "integer"
+        },
+        "LargestVsizeEventT1-c-EVENT":{
+          "type": "integer"
+        },
+        "LargestVsizeEventT1-d-VSIZE":{
+          "type": "float"
+        },
+        "LargestVsizeEventT1-e-DELTV":{
+          "type": "float"
+        },
+        "LargestVsizeEventT1-f-RSS":{
+          "type": "float"
+        },
+        "LargestVsizeIncreaseEvent-a-COUNT":{
+          "type": "integer"
+        },
+        "LargestVsizeIncreaseEvent-b-RUN":{
+          "type": "integer"
+        },
+        "LargestVsizeIncreaseEvent-c-EVENT":{
+          "type": "integer"
+        },
+        "LargestVsizeIncreaseEvent-d-VSIZE":{
+          "type": "float"
+        },
+        "LargestVsizeIncreaseEvent-e-DELTV":{
+          "type": "float"
+        },
+        "LargestVsizeIncreaseEvent-f-RSS":{
+          "type": "float"
+        },
+        "SecondLargestRssEvent-a-COUNT":{
+          "type": "integer"
+        },
+        "SecondLargestRssEvent-b-RUN":{
+          "type": "integer"
+        },
+        "SecondLargestRssEvent-c-EVENT":{
+          "type": "integer"
+        },
+        "SecondLargestRssEvent-d-VSIZE":{
+          "type": "float"
+        },
+        "SecondLargestRssEvent-e-DELTV":{
+          "type": "float"
+        },
+        "SecondLargestRssEvent-f-RSS":{
+          "type": "float"
+        },
+        "SecondLargestVsizeEventT2-a-COUNT":{
+          "type": "integer"
+        },
+        "SecondLargestVsizeEventT2-b-RUN":{
+          "type": "integer"
+        },
+        "SecondLargestVsizeEventT2-c-EVENT":{
+          "type": "integer"
+        },
+        "SecondLargestVsizeEventT2-d-VSIZE":{
+          "type": "float"
+        },
+        "SecondLargestVsizeEventT2-e-DELTV":{
+          "type": "float"
+        },
+        "SecondLargestVsizeEventT2-f-RSS":{
+          "type": "float"
+        },
+        "ThirdLargestRssEvent-a-COUNT":{
+          "type": "integer"
+        },
+        "ThirdLargestRssEvent-b-RUN":{
+          "type": "integer"
+        },
+        "ThirdLargestRssEvent-c-EVENT":{
+          "type": "integer"
+        },
+        "ThirdLargestRssEvent-d-VSIZE":{
+          "type": "float"
+        },
+        "ThirdLargestRssEvent-e-DELTV":{
+          "type": "float"
+        },
+        "ThirdLargestRssEvent-f-RSS":{
+          "type": "float"
+        },
+        "ThirdLargestVsizeEventT3-a-COUNT":{
+          "type": "integer"
+        },
+        "ThirdLargestVsizeEventT3-b-RUN":{
+          "type": "integer"
+        },
+        "ThirdLargestVsizeEventT3-c-EVENT":{
+          "type": "integer"
+        },
+        "ThirdLargestVsizeEventT3-d-VSIZE":{
+          "type": "float"
+        },
+        "ThirdLargestVsizeEventT3-e-DELTV":{
+          "type": "float"
+        },
+        "ThirdLargestVsizeEventT3-f-RSS":{
+          "type": "float"
+        },
         "architecture": {
           "index": "not_analyzed",
           "type": "string"

--- a/es_relval_log.py
+++ b/es_relval_log.py
@@ -62,10 +62,9 @@ def es_parse_jobreport(payload,logFile):
         metrics_list = j.getchildren()
         for i in metrics_list:
           name=i.get("Name")
-          if name in ["AverageGrowthRateRss", "AverageGrowthRateVsize", "PeakValueVsize", "PeakValueRss"]:
-            val = i.get("Value")
-            if 'nan' in val: val=''
-            payload[name] = val
+          val = i.get("Value")
+          if 'nan' in val: val=''
+          payload[name] = val
       elif j.get("Metric") == "Timing":
         metrics_list = j.getchildren()
         for i in metrics_list:


### PR DESCRIPTION
Update 
https://es-cmssdt.cern.ch/kibana/app/elasticsearch_status#/index/cmssdt-ib-matrix-2583?_g=()
index with more fields and put the fields on elasticsearch (for plotting them, assuming)
Example for the new fields types taken from here:
https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-baseline-tests/CMSSW_11_0_X_2019-07-01-2300/slc7_amd64_gcc700/-GenuineIntel/matrix-results/250202.181_TTbar_13UP18+TTbar_13UP18+PREMIXUP18_PU25+DIGIPRMXLOCALUP18_PU25+RECOPRMXUP18_PU25+HARVESTUP18_PU25/JobReport2.xml