### PR TITLE
add BigProducts/Simulation to simulation category

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1354,6 +1354,7 @@ CMSSW_CATEGORIES = {
     "Utilities/RelMon",
   ],
   "simulation": [
+    "BigProducts/Simulation",
     "DataFormats/CSCDigi",
     "DataFormats/CTPPSDetId",
     "DataFormats/CTPPSDigi",


### PR DESCRIPTION
I noticed in https://github.com/cms-sw/cmssw/pull/27613 that this package was missing from the simulation category. It seems to me that it belongs there (in addition to core, where it is currently assigned).

@civanch FYI