### PR TITLE
Make rucio setup.sh zsh compatible

### DIFF
--- a/rucio/setup.sh
+++ b/rucio/setup.sh
@@ -1,4 +1,4 @@
-THISDIR=$(dirname $BASH_SOURCE)
+THISDIR=$(dirname ${BASH_SOURCE:-${(%):-%N}})
 SELECTED_VERSION=${1-current}
 if [ ! -e ${THISDIR}/${SELECTED_VERSION}/bin/rucio ] ; then
   echo "Error: Unable to find rucio version '${SELECTED_VERSION}'" >&2


### PR DESCRIPTION
Implemented minimal changes, tested locally with both bash and zsh from different directories, providing both absolute and relative paths. `$BASH_SOURCE` is obviously only defined for bash.