### PR TITLE
Install gfal2-python as part of rucio installation

### DIFF
--- a/rucio/install.sh
+++ b/rucio/install.sh
@@ -42,7 +42,7 @@ fi
 export PYTHONUSERBASE="${INSTALL_DIR}/${RUCIO_VERSION}"
 mkdir -p "${PYTHONUSERBASE}" "${INSTALL_DIR}/tmp"
 export TMPDIR="${INSTALL_DIR}/tmp"
-pip install --disable-pip-version-check --user ${PIP_PKG}==${RUCIO_VERSION}
+pip install --disable-pip-version-check --user ${PIP_PKG}==${RUCIO_VERSION} gfal2-python
 rm -f ${INSTALL_DIR}/rucio.cfg
 case ${RUCIO_CONFIG_URL} in
   file://*) cp -f $(echo ${RUCIO_CONFIG_URL} | sed 's|^file://||') ${INSTALL_DIR}/rucio.cfg ;;


### PR DESCRIPTION
The scripts developed by @dciangot require the [gfal2-python](https://pypi.org/project/gfal2-python/) package to work so they should be installed when installing rucio.

This is related to https://github.com/cms-sw/cmsdist/issues/5199 (and could resolve it).

FYI @belforte @ericvaandering