### PR TITLE
remove cmssw/externals/arch/lib for PR testing

### DIFF
--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -376,10 +376,8 @@ if ${BUILD_EXTERNAL} ; then
       # Setup all the toolfiles previously built
       DEP_NAMES=
       if [ -e "${BTOOLS}/cmssw.xml" ] ; then cp ${BTOOLS}/cmssw.xml ${CTOOLS}/cmssw.xml ; fi
-      if [ -d "$WORKSPACE/$CMSSW_IB/config/SCRAM/hooks/runtime" ] ; then
-        RMV_CMSSW_EXTERNAL="$WORKSPACE/$CMSSW_IB/config/SCRAM/hooks/runtime/99-cmssw-external-lib"
-        echo '#!/bin/bash' > ${RMV_CMSSW_EXTERNAL}
-        echo 'echo "RUNTIME:path:remove:LD_LIBRARY_PATH=${RELEASETOP}/external/${SCRAM_ARCH}/lib"' >> ${RMV_CMSSW_EXTERNAL}
+      RMV_CMSSW_EXTERNAL="$WORKSPACE/$CMSSW_IB/config/SCRAM/hooks/runtime/99-remove-release-external-lib"
+      if [ -f "${RMV_CMSSW_EXTERNAL}" ] ; then
         chmod +x ${RMV_CMSSW_EXTERNAL}
       fi
       for xml in $(ls ${CTOOLS}/*.xml) ; do

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -375,6 +375,13 @@ if ${BUILD_EXTERNAL} ; then
     if [ "X$BUILD_FULL_CMSSW" != "Xtrue" ] ; then
       # Setup all the toolfiles previously built
       DEP_NAMES=
+      if [ -e "${BTOOLS}/cmssw.xml" ] ; then cp ${BTOOLS}/cmssw.xml ${CTOOLS}/cmssw.xml ; fi
+      if [ -d "$WORKSPACE/$CMSSW_IB/config/SCRAM/hooks/runtime" ] ; then
+        RMV_CMSSW_EXTERNAL="$WORKSPACE/$CMSSW_IB/config/SCRAM/hooks/runtime/99-cmssw-external-lib"
+        echo '#!/bin/bash' > ${RMV_CMSSW_EXTERNAL}
+        echo 'echo "RUNTIME:path:remove:LD_LIBRARY_PATH=${RELEASETOP}/external/${SCRAM_ARCH}/lib"' >> ${RMV_CMSSW_EXTERNAL}
+        chmod +x ${RMV_CMSSW_EXTERNAL}
+      fi
       for xml in $(ls ${CTOOLS}/*.xml) ; do
         name=$(basename $xml)
         tool=$(echo $name | sed 's|.xml$||')

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -465,6 +465,7 @@ sed -i -e 's|^define  *processTmpMMDData.*|processTmpMMDData=true\ndefine proces
 set +x
 eval $(scram run -sh)
 set -x
+echo $LD_LIBRARY_PATH | tr ':' '\n'
 BUILD_LOG_DIR="${CMSSW_BASE}/tmp/${SCRAM_ARCH}/cache/log"
 ANALOG_CMD="scram build outputlog && ($CMS_BOT_DIR/buildLogAnalyzer.py --logDir ${BUILD_LOG_DIR}/src || true)"
 report_pull_request_results_all_prs_with_commit "TESTS_RUNNING" --report-pr ${REPORT_H_CODE} --pr-job-id ${BUILD_NUMBER} --add-message "Test started: $CMSSW_IB for $SCRAM_ARCH" ${NO_POST}


### PR DESCRIPTION
We create cmssw dev area while PR testing. This means during PR tests we have following paths in LD_LIBRARY_PATH

- `CMSSW_BASE/biglib/SCRAM_ARCH`
- `CMSSW_BASE/lib/SCRAM_ARCH`
- `CMSSW_BASE/external/SCRAM_ARCH/lib`
- `RELEASETOP/biglib/SCRAM_ARCH`
- `RELEASETOP/lib/SCRAM_ARCH`
- **`RELEASETOP/external/SCRAM_ARCH/lib`**

Now if newer version of an external has removed a library and we did not update the tool's toolfile then during PR tests the missing library is still found via `RELEASETOP/external/SCRAM_ARCH/lib` and PR tests run successfully. 

This PR makes sure that during PR tests we remove `RELEASETOP/external/SCRAM_ARCH/lib` and all external libs should be available via `CMSSW_BASE/external/SCRAM_ARCH/lib` 
