### PR TITLE
reco comparisons: workflow map updates

### DIFF
--- a/comparisons/matrix_RE.txt
+++ b/comparisons/matrix_RE.txt
@@ -92,7 +92,8 @@ VBFH125BB13TeVwf1363p0 1363.0_VBFHToBB_M125_Pow_py8_Evt_13*/step3.root RECO
 BsToJpsiPhi13TeVwf1366p0 1366.0_BsToJpsiPhi_13+BsToJpsiPhi_13*/step3.root RECO
 SingleMu13Pt1wf1306p0 1306.0_SingleMuPt1_UP15*/step3.root RECO
 ZEEFS13pHLTwf135p4 135.4_ZEE_13+ZEEFS_13*/step1.root HLT
-ZEEFS13pPATwf135p4 135.4_ZEE_13+ZEEFS_13*/step1.root PAT
+ZEEFS13pRECOwf135p4 135.4_ZEE_13+ZEEFS_13*/step1.root RECO
+ZEEFS13pMINIAODwf135p4 135.4_ZEE_13+ZEEFS_13*/step3.root PAT
 ZEEPUwf25200p0 25200.0_ZEE_13+ZEE_13*/step3.root RECO
 TTbarPUwf25202p0 25202.0_TTbar_13+TTbar_13*/step3.root RECO
 TTbarPUwf50202p0 50202.0_TTbar_13+TTbar_13*/step3.root RECO
@@ -764,6 +765,10 @@ CloseByPhoton2026D41wf20493p52 20493.52_CloseByParticleGun+CloseByParticle_Photo
 #
 TTbar14TeV2026D41PUwf20634p0 20634.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2026D41PU_*/step3.root RECO
 #
+#  D43 (minimal set)
+#
+TTbar14TeV2026D43wf20834p0 20834.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2026D43_GenSim*+*/step3.root RECO
+#
 #   D44
 #
 SingleElectronPt35in2026D44wf21202p0 21202.0_SingleElectronPt35+SingleElectronPt35_pythia8_2026D44_GenSim*+*/step3.root RECO
@@ -779,6 +784,22 @@ QCD600to800in14TeV2026D44wf21253p0 21253.0_QCD_Pt_600_800_14+QCD_Pt_600_800_14Te
 #
 TTbar14TeV2026D44PUwf21434p0 21434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2026D44PU_*/step3.root RECO
 #
+#  D45 (minimal set)
+#
+TTbar14TeV2026D45wf21634p0 21634.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2026D45_GenSim*+*/step3.root RECO
+#
 #  D46 (minimal set)
 #
 TTbar14TeV2026D46wf22034p0 22034.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2026D46_GenSim*+*/step3.root RECO
+#
+#  D47 (minimal set)
+#
+TTbar14TeV2026D47wf22434p0 22434.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2026D47_GenSim*+*/step3.root RECO
+#
+#  D48 (minimal set)
+#
+TTbar14TeV2026D48wf22834p0 22834.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2026D48_GenSim*+*/step3.root RECO
+#
+#  D49 (minimal set)
+#
+TTbar14TeV2026D49wf23234p0 23234.0_TTbar_14TeV+TTbar_14TeV_TuneCUETP8M1_2026D49_GenSim*+*/step3.root RECO


### PR DESCRIPTION
- fix mappring for workflow 135.4 [bugfix]
- minimal map for recent/new 2026 workflows: D43, D45, D4[7-9]: [supersedes #1229 ]

 