### PR TITLE
Mark CMSSW_8_0_34_UL/slc7_amd64_gcc530 as production release

### DIFF
--- a/releases.map
+++ b/releases.map
@@ -2488,5 +2488,5 @@ architecture=slc7_amd64_gcc630;label=CMSSW_9_3_17;type=Production;state=Announce
 architecture=slc6_amd64_gcc630;label=CMSSW_9_3_17;type=Production;state=Announced;prodarch=1;
 architecture=slc7_amd64_gcc820;label=CMSSW_10_6_8;type=Production;state=Announced;prodarch=0;
 architecture=slc7_amd64_gcc700;label=CMSSW_10_6_8;type=Production;state=Announced;prodarch=1;
-architecture=slc7_amd64_gcc530;label=CMSSW_8_0_34_UL;type=Production;state=Announced;prodarch=0;
+architecture=slc7_amd64_gcc530;label=CMSSW_8_0_34_UL;type=Production;state=Announced;prodarch=1;
 architecture=slc6_amd64_gcc530;label=CMSSW_8_0_34;type=Production;state=Announced;prodarch=1;


### PR DESCRIPTION
FYI @fabiocos 