### PR TITLE
Externals stats on Elastic

### DIFF
--- a/es_externals_stats.py
+++ b/es_externals_stats.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from cmsutils import percentile
+from es_utils import send_payload
+from sys import argv
+import json
+from hashlib import sha1
+
+def get_average_stats_for_external(stats_dict, opts_dict, params=None, cpu_normalize=1):
+
+    sdata = None
+    try:
+        stats = stats_dict
+        xdata = {}
+        for stat in stats:
+            for item in stat:
+                try:
+                    xdata[item].append(stat[item])
+                except:
+                    xdata[item] = []
+                    xdata[item].append(stat[item])
+        sdata = {}
+        if params:
+            for p in params: sdata[p] = params[p]
+        for x in xdata:
+            data = sorted(xdata[x])
+            if x in ["time", "num_threads", "processes", "num_fds"]:
+                sdata[x] = data[-1]
+                continue
+            if not x in ["rss", "vms", "pss", "uss", "shared", "data", "cpu"]: continue
+            dlen = len(data)
+            if (x == "cpu") and (cpu_normalize > 1) and (data[-1] > 100):
+                data = [d / cpu_normalize for d in data]
+            for t in ["min", "max", "avg", "median", "25", "75", "90"]: sdata[x + "_" + t] = 0
+            if dlen > 0:
+                sdata[x + "_min"] = data[0]
+                sdata[x + "_max"] = data[-1]
+                if dlen > 1:
+                    dlen2 = int(dlen / 2)
+                    if (dlen % 2) == 0:
+                        sdata[x + "_median"] = int((data[dlen2 - 1] + data[dlen2]) / 2)
+                    else:
+                        sdata[x + "_median"] = data[dlen2]
+                    sdata[x + "_avg"] = int(sum(data) / dlen)
+                    for t in [25, 75, 90]:
+                        sdata[x + "_" + str(t)] = int(percentile(t, data, dlen))
+                else:
+                    for t in ["25", "75", "90", "avg", "median"]:
+                        sdata[x + "_" + t] = data[0]
+
+    except Exception as e: print(e.message)
+    return sdata
+
+# give a list of relevant keys to get from the options dictionary, could be all or limited
+def create_index_name_from_args(opts_dict=None, list_of_keys=None):
+    if opts_dict and list_of_keys:
+        result_string = ''
+        for k in list_of_keys: result_string = result_string+str(opts_dict[k])
+        return sha1(result_string).hexdigest()
+    else:
+        return None
+
+if __name__ == "__main__":
+
+    stats_json_arg = argv[1]
+    opts_json_arg = argv[2]
+    week = argv[3]
+
+    with open(stats_json_arg, "r") as stats_json_file: stats_json = json.load(stats_json_file)
+    with open(opts_json_arg, "r") as opts_json_file: opts_json = json.load(opts_json_file)
+
+    index_name = "externals_build_runtime_stats_summary_testindex"
+    doc = "external-runtime-stats-summary_testindex"
+    index_sha1 = create_index_name_from_args(opts_json, opts_json.keys())
+    payload = get_average_stats_for_external(stats_json, opts_json, None, 1)
+    payload.update(opts_json)
+    print('externals stats: ', stats_json_arg, 'options json: ', opts_json, 'week is: ', week)
+    try:
+        print(json.dumps(payload, indent=1, sort_keys=True))
+    #   #send_payload(index+'-'+week,doc, index_sha1,json.dumps(payload))
+    except Exception as e: print(e.message)
+    #print('index sha is: ', index_sha1)
+

--- a/es_externals_stats.py
+++ b/es_externals_stats.py
@@ -9,8 +9,6 @@ if __name__ == "__main__":
 
     stats_json_f = argv[1]
     opts_json_f = argv[2]
-    # stats_json_f = "/home/mrodozov/Downloads/all/build_zstd/BUILD/slc7_amd64_gcc820/external/cmake/3.14.5-cms/cmake.json"
-    # opts_json_f = "/home/mrodozov/Downloads/all/build_zstd/BUILD/slc7_amd64_gcc820/external/cmake/3.14.5-cms/opts.json"
     with open(stats_json_f, "r") as stats_json_file: stats_json = json.load(stats_json_file)
     with open(opts_json_f, "r") as opts_json_file: opts_json = json.load(opts_json_file)
     file_stamp = int(tstat(stats_json_f).st_mtime)  # get the file stamp from the file

--- a/es_externals_stats.py
+++ b/es_externals_stats.py
@@ -1,83 +1,23 @@
 #!/usr/bin/env python
 from __future__ import print_function
-from cmsutils import percentile
-from es_utils import send_payload
 from sys import argv
 import json
-from hashlib import sha1
-
-def get_average_stats_for_external(stats_dict, opts_dict, params=None, cpu_normalize=1):
-
-    sdata = None
-    try:
-        stats = stats_dict
-        xdata = {}
-        for stat in stats:
-            for item in stat:
-                try:
-                    xdata[item].append(stat[item])
-                except:
-                    xdata[item] = []
-                    xdata[item].append(stat[item])
-        sdata = {}
-        if params:
-            for p in params: sdata[p] = params[p]
-        for x in xdata:
-            data = sorted(xdata[x])
-            if x in ["time", "num_threads", "processes", "num_fds"]:
-                sdata[x] = data[-1]
-                continue
-            if not x in ["rss", "vms", "pss", "uss", "shared", "data", "cpu"]: continue
-            dlen = len(data)
-            if (x == "cpu") and (cpu_normalize > 1) and (data[-1] > 100):
-                data = [d / cpu_normalize for d in data]
-            for t in ["min", "max", "avg", "median", "25", "75", "90"]: sdata[x + "_" + t] = 0
-            if dlen > 0:
-                sdata[x + "_min"] = data[0]
-                sdata[x + "_max"] = data[-1]
-                if dlen > 1:
-                    dlen2 = int(dlen / 2)
-                    if (dlen % 2) == 0:
-                        sdata[x + "_median"] = int((data[dlen2 - 1] + data[dlen2]) / 2)
-                    else:
-                        sdata[x + "_median"] = data[dlen2]
-                    sdata[x + "_avg"] = int(sum(data) / dlen)
-                    for t in [25, 75, 90]:
-                        sdata[x + "_" + str(t)] = int(percentile(t, data, dlen))
-                else:
-                    for t in ["25", "75", "90", "avg", "median"]:
-                        sdata[x + "_" + t] = data[0]
-
-    except Exception as e: print(e.message)
-    return sdata
-
-# give a list of relevant keys to get from the options dictionary, could be all or limited
-def create_index_name_from_args(opts_dict=None, list_of_keys=None):
-    if opts_dict and list_of_keys:
-        result_string = ''
-        for k in list_of_keys: result_string = result_string+str(opts_dict[k])
-        return sha1(result_string).hexdigest()
-    else:
-        return None
+from os import stat as tstat
+from es_utils import es_send_external_stats
 
 if __name__ == "__main__":
 
-    stats_json_arg = argv[1]
-    opts_json_arg = argv[2]
-    week = argv[3]
-
-    with open(stats_json_arg, "r") as stats_json_file: stats_json = json.load(stats_json_file)
-    with open(opts_json_arg, "r") as opts_json_file: opts_json = json.load(opts_json_file)
-
+    #stats_json_arg = argv[1]
+    #opts_json_arg = argv[2]
+    #with open(stats_json_arg, "r") as stats_json_file: stats_json = json.load(stats_json_file)
+    #with open(opts_json_arg, "r") as opts_json_file: opts_json = json.load(opts_json_file)
+    stats_json_f = "/home/mrodozov/Downloads/all/build_zstd/BUILD/slc7_amd64_gcc820/external/cmake/3.14.5-cms/cmake.json"
+    opts_json_f = "/home/mrodozov/Downloads/all/build_zstd/BUILD/slc7_amd64_gcc820/external/cmake/3.14.5-cms/opts.json"
+    with open(stats_json_f, "r") as stats_json_file: stats_json = json.load(stats_json_file)
+    with open(opts_json_f, "r") as opts_json_file: opts_json = json.load(opts_json_file)
+    file_stamp = int(tstat(stats_json_f).st_mtime)  # get the file stamp from the file
+    week = str((file_stamp / 86400 + 4) / 7)
     index_name = "externals_build_runtime_stats_summary_testindex"
-    doc = "external-runtime-stats-summary_testindex"
-    index_sha1 = create_index_name_from_args(opts_json, opts_json.keys())
-    payload = get_average_stats_for_external(stats_json, opts_json, None, 1)
-    payload.update(opts_json)
-    print('externals stats: ', stats_json_arg, 'options json: ', opts_json, 'week is: ', week)
-    try:
-        print(json.dumps(payload, indent=1, sort_keys=True))
-    #   #send_payload(index+'-'+week,doc, index_sha1,json.dumps(payload))
-    except Exception as e: print(e.message)
-    #print('index sha is: ', index_sha1)
-
+    doc_name= "external-runtime-stats-summary-document_testdoc"
+    sdata = es_send_external_stats(stats_json, opts_json, 1, week, es_index_name=index_name, es_doc_name=doc_name)
+    print(json.dumps(sdata, indent=1, sort_keys=True))

--- a/es_externals_stats.py
+++ b/es_externals_stats.py
@@ -17,5 +17,4 @@ if __name__ == "__main__":
     week = str((file_stamp / 86400 + 4) / 7)
     index_name = "externals_build_runtime_stats_summary_testindex"
     doc_name= "external-runtime-stats-summary-document_testdoc"
-    sdata = es_send_external_stats(stats_json, opts_json, 1, week, es_index_name=index_name, es_doc_name=doc_name)
-    print(json.dumps(sdata, indent=1, sort_keys=True))
+    es_send_external_stats(stats_json, opts_json, 1, week, es_index_name=index_name, es_doc_name=doc_name)

--- a/es_externals_stats.py
+++ b/es_externals_stats.py
@@ -13,6 +13,4 @@ if __name__ == "__main__":
     with open(opts_json_f, "r") as opts_json_file: opts_json = json.load(opts_json_file)
     file_stamp = int(tstat(stats_json_f).st_mtime)  # get the file stamp from the file
     week = str((file_stamp / 86400 + 4) / 7)
-    index_name = "externals_stats_summary_testindex"
-    doc_name = "externals-runtime-stats-summary-testdoc"
-    es_send_external_stats(stats_json, opts_json, 1, week, es_index_name=index_name, es_doc_name=doc_name)
+    es_send_external_stats(stats_json, opts_json, 1, week)

--- a/es_externals_stats.py
+++ b/es_externals_stats.py
@@ -13,6 +13,6 @@ if __name__ == "__main__":
     with open(opts_json_f, "r") as opts_json_file: opts_json = json.load(opts_json_file)
     file_stamp = int(tstat(stats_json_f).st_mtime)  # get the file stamp from the file
     week = str((file_stamp / 86400 + 4) / 7)
-    index_name = "externals_build_runtime_stats_summary_testindex"
-    doc_name= "external-runtime-stats-summary-document_testdoc"
+    index_name = "externals_stats_summary_testindex"
+    doc_name = "externals-runtime-stats-summary-testdoc"
     es_send_external_stats(stats_json, opts_json, 1, week, es_index_name=index_name, es_doc_name=doc_name)

--- a/es_externals_stats.py
+++ b/es_externals_stats.py
@@ -13,4 +13,4 @@ if __name__ == "__main__":
     with open(opts_json_f, "r") as opts_json_file: opts_json = json.load(opts_json_file)
     file_stamp = int(tstat(stats_json_f).st_mtime)  # get the file stamp from the file
     week = str((file_stamp / 86400 + 4) / 7)
-    es_send_external_stats(stats_json, opts_json, 1, week)
+    es_send_external_stats(stats_json, opts_json, 1, week, file_stamp)

--- a/es_externals_stats.py
+++ b/es_externals_stats.py
@@ -7,12 +7,10 @@ from es_utils import es_send_external_stats
 
 if __name__ == "__main__":
 
-    #stats_json_arg = argv[1]
-    #opts_json_arg = argv[2]
-    #with open(stats_json_arg, "r") as stats_json_file: stats_json = json.load(stats_json_file)
-    #with open(opts_json_arg, "r") as opts_json_file: opts_json = json.load(opts_json_file)
-    stats_json_f = "/home/mrodozov/Downloads/all/build_zstd/BUILD/slc7_amd64_gcc820/external/cmake/3.14.5-cms/cmake.json"
-    opts_json_f = "/home/mrodozov/Downloads/all/build_zstd/BUILD/slc7_amd64_gcc820/external/cmake/3.14.5-cms/opts.json"
+    stats_json_f = argv[1]
+    opts_json_f = argv[2]
+    # stats_json_f = "/home/mrodozov/Downloads/all/build_zstd/BUILD/slc7_amd64_gcc820/external/cmake/3.14.5-cms/cmake.json"
+    # opts_json_f = "/home/mrodozov/Downloads/all/build_zstd/BUILD/slc7_amd64_gcc820/external/cmake/3.14.5-cms/opts.json"
     with open(stats_json_f, "r") as stats_json_file: stats_json = json.load(stats_json_file)
     with open(opts_json_f, "r") as opts_json_file: opts_json = json.load(opts_json_file)
     file_stamp = int(tstat(stats_json_f).st_mtime)  # get the file stamp from the file

--- a/es_utils.py
+++ b/es_utils.py
@@ -248,11 +248,12 @@ def es_send_resource_stats(release, arch, name, version, sfile,
   try:send_payload(index+"-"+week,doc,idx,json.dumps(sdata))
   except Exception as e: print(e.message)
 
-def es_send_external_stats(stats_dict, opts_dict, cpu_normalize=1, week='',
+def es_send_external_stats(stats_dict, opts_dict, cpu_normalize=1, week='', file_timestamp=0,
                            es_index_name='externals_stats_summary_testindex',
                            es_doc_name='externals-runtime-stats-summary-testdoc'):
   index_sha = sha1( ''.join([str(x) for x in opts_dict.values()])).hexdigest()
   sdata = get_summary_stats_from_dictionary(stats_dict, cpu_normalize)
   sdata.update(opts_dict)
+  sdata["@timestamp"]=file_timestamp
   try:send_payload(es_index_name+"-"+week, es_doc_name, index_sha, json.dumps(sdata))
   except Exception as e: print(e.message)

--- a/es_utils.py
+++ b/es_utils.py
@@ -237,15 +237,13 @@ def es_send_resource_stats(release, arch, name, version, sfile,
     release_queue = release.split("_X_",1)[0]+"_X"
   else:
     release_queue = "_".join(release.split("_")[:3])+"_X"
-
   sdata = {"release": release, "release_queue": release_queue, "architecture": arch,
            "step": version, "@timestamp": rel_msec, "workflow": name,
            "hostname": hostname, "exit_code": exit_code}
-  if params:
-    for p in params: sdata[p] = params[p]
   stats = json.load(open(sfile))
   average_stats = get_summary_stats_from_dictionary(stats, cpu_normalize)
   sdata.update(average_stats)
+  if params: sdata.update(params)
   idx = sha1(release + arch + name + version + str(rel_sec)).hexdigest()
   try: print(json.dumps(sdata, indent=1, sort_keys=True))
   #try:send_payload(index+"-"+week,doc,idx,json.dumps(sdata))

--- a/es_utils.py
+++ b/es_utils.py
@@ -260,16 +260,3 @@ def es_send_external_stats(stats_dict, opts_dict, cpu_normalize=1, week='',
   try: print(json.dumps(sdata, indent=1, sort_keys=True))
   #try:send_payload(es_index_name+"-"+week, es_doc_name, index_sha, json.dumps(sdata))
   except Exception as e: print(e.message)
-
-if __name__ == "__main__":
-
-  stats_json_file = "/home/mrodozov/Downloads/all/build_zstd/BUILD/slc7_amd64_gcc820/external/cmake/3.14.5-cms/cmake.json"
-  opts_json_file = "/home/mrodozov/Downloads/all/build_zstd/BUILD/slc7_amd64_gcc820/external/cmake/3.14.5-cms/opts.json"
-  #with open(stats_json_file, "r") as stats_json_file: stats_json = json.load(stats_json_file)
-  with open(stats_json_file, "r") as stats_json_f: stats_json = json.load(stats_json_f)
-  with open(opts_json_file, "r") as opts_json_f: opts_json = json.load(opts_json_f)
-  file_stamp = int(tstat(stats_json_file).st_mtime)  # get the file stamp from the file
-  week = str((file_stamp / 86400 + 4) / 7)
-  #read the data
-  es_send_resource_stats("CMSSW_10_2_X_2020-01-24-1100", "slc7_amd64_gcc820", "step1", "1", stats_json_file, "hostname", 0, params=None, cpu_normalize=1, index="index_name", doc="doc_name")
-  es_send_external_stats(stats_json, opts_json, 1, week)

--- a/es_utils.py
+++ b/es_utils.py
@@ -254,6 +254,6 @@ def es_send_external_stats(stats_dict, opts_dict, cpu_normalize=1, week='', file
   index_sha = sha1( ''.join([str(x) for x in opts_dict.values()])).hexdigest()
   sdata = get_summary_stats_from_dictionary(stats_dict, cpu_normalize)
   sdata.update(opts_dict)
-  sdata["@timestamp"]=file_timestamp
+  sdata["@timestamp"]=file_timestamp*1000
   try:send_payload(es_index_name+"-"+week, es_doc_name, index_sha, json.dumps(sdata))
   except Exception as e: print(e.message)

--- a/es_utils.py
+++ b/es_utils.py
@@ -245,8 +245,7 @@ def es_send_resource_stats(release, arch, name, version, sfile,
   sdata.update(average_stats)
   if params: sdata.update(params)
   idx = sha1(release + arch + name + version + str(rel_sec)).hexdigest()
-  try: print(json.dumps(sdata, indent=1, sort_keys=True))
-  #try:send_payload(index+"-"+week,doc,idx,json.dumps(sdata))
+  try:send_payload(index+"-"+week,doc,idx,json.dumps(sdata))
   except Exception as e: print(e.message)
 
 def es_send_external_stats(stats_dict, opts_dict, cpu_normalize=1, week='',
@@ -255,6 +254,5 @@ def es_send_external_stats(stats_dict, opts_dict, cpu_normalize=1, week='',
   index_sha = sha1( ''.join([str(x) for x in opts_dict.values()])).hexdigest()
   sdata = get_summary_stats_from_dictionary(stats_dict, cpu_normalize)
   sdata.update(opts_dict)
-  try: print(json.dumps(sdata, indent=1, sort_keys=True))
-  #try:send_payload(es_index_name+"-"+week, es_doc_name, index_sha, json.dumps(sdata))
+  try:send_payload(es_index_name+"-"+week, es_doc_name, index_sha, json.dumps(sdata))
   except Exception as e: print(e.message)


### PR DESCRIPTION
This adds changes for
1. Add summary function get_summary_stats_from_dictionary
Records are as expected
https://es-cmssdt.cern.ch/kibana/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:AW_svgachldp7JMpTV51,interval:auto,query:(match_all:()),sort:!('@timestamp',desc))
2. Add script to be used by Jenkins
The result of es_send_resource_stats was validated against result produced with the old version,
jsons (values of sdata, see line 248) are the same