### PR TITLE
Exernals stats on Elastic (rebased)

### DIFF
--- a/es_externals_stats.py
+++ b/es_externals_stats.py
@@ -1,16 +1,9 @@
 #!/usr/bin/env python
-from __future__ import print_function
 from sys import argv
-import json
-from os import stat as tstat
 from es_utils import es_send_external_stats
 
 if __name__ == "__main__":
 
     stats_json_f = argv[1]
     opts_json_f = argv[2]
-    with open(stats_json_f, "r") as stats_json_file: stats_json = json.load(stats_json_file)
-    with open(opts_json_f, "r") as opts_json_file: opts_json = json.load(opts_json_file)
-    file_stamp = int(tstat(stats_json_f).st_mtime)  # get the file stamp from the file
-    week = str((file_stamp / 86400 + 4) / 7)
-    es_send_external_stats(stats_json, opts_json, 1, week, file_stamp)
+    es_send_external_stats(stats_json_f, opts_json_f, 1)

--- a/es_externals_stats.py
+++ b/es_externals_stats.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from sys import argv
+import json
+from os import stat as tstat
+from es_utils import es_send_external_stats
+
+if __name__ == "__main__":
+
+    stats_json_f = argv[1]
+    opts_json_f = argv[2]
+    with open(stats_json_f, "r") as stats_json_file: stats_json = json.load(stats_json_file)
+    with open(opts_json_f, "r") as opts_json_file: opts_json = json.load(opts_json_file)
+    file_stamp = int(tstat(stats_json_f).st_mtime)  # get the file stamp from the file
+    week = str((file_stamp / 86400 + 4) / 7)
+    es_send_external_stats(stats_json, opts_json, 1, week, file_stamp)


### PR DESCRIPTION
This adds changes for
1.    Add summary function get_summary_stats_from_dictionary
    Records are as expected
    https://es-cmssdt.cern.ch/kibana/app/kibana#/discover?_g=()&_a=(columns:!(_source),index:AW_svgachldp7JMpTV51,interval:auto,query:(match_all:()),sort:!('@timestamp',desc))
2.    Add script to be used by Jenkins
    The result of es_send_resource_stats was validated against result produced with the old version,
    jsons (values of sdata, see line 248) are the same
