### PR TITLE
Cleanup of BTV POG package watchers

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -1,12 +1,9 @@
 tracking-pog:
   - VinInn
 btv-pog:
-  - acaudron
   - ferencek
   - JyothsnaKomaragiri
   - mverzett
-  - pvmulder
   - smoortga
-  - HeinerTholen
   - emilbols
   - andrzejnovak


### PR DESCRIPTION
Removing people no longer associated with CMS from the list of BTV POG package watchers. The request came from @HeinerTholen but I took the occasion for some additional cleanup (@acaudron, @pvmulder).

@JyothsnaKomaragiri and @smoortga, let me know in case you would like to be removed.

Also keeping in the loop @mverzett, @emilbols, @andrzejnovak