### PR TITLE
check for static check logs for build errors

### DIFF
--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -700,6 +700,11 @@ if [ "X$DO_STATIC_CHECKS" = "Xtrue" -a "$ONLY_FIREWORKS" = false -a "X$CMSSW_PR"
   USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_LLVM_CHECKERS="-enable-checker threadsafety -enable-checker cms -disable-checker cms.FunctionDumper" \
     scram b -k -j ${NCPU2} checker SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runStaticChecks.log
   cp -R $WORKSPACE/$CMSSW_IB/llvm-analysis/*/* $WORKSPACE/llvm-analysis || true
+  if $IS_DEV_BRANCH && [ $(grep ': error: ' $WORKSPACE/llvm-analysis/runStaticChecks.log | wc -l) -gt 0 ] ; then
+    echo "EDM_ML_DEBUG_CHECKS;ERROR,Static Check build log,See Log,llvm-analysis/runStaticChecks.log" >> $RESULTS_FILE
+  else
+    echo "EDM_ML_DEBUG_CHECKS;OK,Static Check build log,See Log,llvm-analysis/runStaticChecks.log" >> $RESULTS_FILE
+  fi
   echo 'END OF STATIC CHECKS'
   echo '--------------------------------------'
   popd


### PR DESCRIPTION
Check for build errors during static checks. This might identify build errors due to the use of EDM_ML_DEBUG.

For Development release cycle: In case of build errors, this should add a new link on PR summary page which should point to static analysis build long. 