### PR TITLE
reco comparisons: TICL monitoring: tracksters with multiclusters, TICL and PF Candidates

### DIFF
--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -1132,7 +1132,44 @@ void hgcalMultiClusters(TString cName ){
   plotvar(bObj+".eta()");
   plotvar(bObj+".phi()");
   plotvar("log10("+bObj+".energy())");
-  plotvar(bObj+".time()");
+  plotvar("min(100,max(-20,"+bObj+".time()))");
+}
+
+void tracksters(TString cName ){
+  TString bObj = "ticlTracksters_"+cName+"_"+recoS+".obj";
+  if (! checkBranchOR(bObj, true)) return;
+  plotvar(bObj+"@.size()");
+  plotvar(bObj+".vertices_@.size()");
+  plotvar(bObj+".vertex_multiplicity_@.size()");
+
+  plotvar(bObj+".barycenter().phi()");
+  plotvar(bObj+".barycenter().eta()");
+  plotvar(bObj+".barycenter().z()");
+  plotvar(bObj+".id_probabilities(0)");
+  plotvar(bObj+".id_probabilities(2)");
+  plotvar(bObj+".id_probabilities(4)");
+  plotvar("log10("+bObj+".raw_energy())");
+  plotvar("log10("+bObj+".regressed_energy())");
+  plotvar("min(100,max(-20,"+bObj+".time()))");
+}
+
+void ticlCands(TString cName ){
+  TString bObj = "TICLCandidates_"+cName+"_"+recoS+".obj";
+  if (! checkBranchOR(bObj, true)) return;
+  plotvar(bObj+"@.size()");
+
+  plotvar(bObj+".phi()");
+  plotvar(bObj+".eta()");
+  plotvar("log10("+bObj+".pt())");
+  plotvar(bObj+".id_probability(TICLCandidate::ParticleType::photon)");
+  plotvar(bObj+".id_probability(TICLCandidate::ParticleType::electron)");
+  plotvar(bObj+".id_probability(TICLCandidate::ParticleType::muon)");
+  plotvar(bObj+".id_probability(TICLCandidate::ParticleType::neutral_pion)");
+  plotvar(bObj+".id_probability(TICLCandidate::ParticleType::charged_hadron)");
+  plotvar(bObj+".id_probability(TICLCandidate::ParticleType::neutral_hadron)");
+  plotvar("log10("+bObj+".rawEnergy())");
+  plotvar("min(100,max(-20,"+bObj+".time()))");
+  plotvar("log10("+bObj+".timeError())");
 }
 
 void plotTrack(TString alias, TString var){
@@ -2438,7 +2475,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
         plotvar(tbr+".m_data.localPosition().y()");
       }
 
-      allTracks("trackExtenderWithMTD__RECO");
+      allTracks("trackExtenderWithMTD__"+recoS);
       tbr="floatedmValueMap_trackExtenderWithMTD_";
       plotvar(tbr+"generalTrackBeta_"+recoS+".obj.values_");
       plotvar(tbr+"generalTrackt0_"+recoS+".obj.values_");
@@ -3261,7 +3298,19 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       hgcalMultiClusters("multiClustersFromTrackstersEM_MultiClustersFromTracksterByCA");
       hgcalMultiClusters("multiClustersFromTrackstersTrk_TrkMultiClustersFromTracksterByCA");
       hgcalMultiClusters("multiClustersFromTrackstersMIP_MIPMultiClustersFromTracksterByCA");
+      hgcalMultiClusters("ticlMultiClustersFromTrackstersEM_");
+      hgcalMultiClusters("ticlMultiClustersFromTrackstersHAD_");
+      hgcalMultiClusters("ticlMultiClustersFromTrackstersMIP_");
+      hgcalMultiClusters("ticlMultiClustersFromTrackstersMerge_");
+      hgcalMultiClusters("ticlMultiClustersFromTrackstersTrk_");
 
+      tracksters("ticlTrackstersEM_");
+      tracksters("ticlTrackstersHAD_");
+      tracksters("ticlTrackstersMIP_");
+      tracksters("ticlTrackstersMerge_");
+      tracksters("ticlTrackstersTrk_");
+
+      ticlCands("ticlCandidateFromTracksters_");
       // miniaod
       superClusters("reducedEgamma_reducedSuperClusters");
       superClusters("reducedEgamma_reducedOOTSuperClusters");
@@ -3361,6 +3410,8 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       allpf(-1, "particleFlowTmp_CleanedPunchThroughNeutralHadrons");
       allpf(-1, "particleFlowTmp_CleanedTrackerAndGlobalMuons");
       allpf(-1, "particleFlowTmp_electrons");
+
+      allpf(-1, "pfTICL_");
 
       tbr="recoPFMETs_pfMet__"+recoS+".obj";
       if (checkBranchOR(tbr, true)){


### PR DESCRIPTION
updates in validate.C used for reco comparisons. The main part is the addition of monitoring for TICL reconstruction, which is available in the default workflows since 11_1_0_pre6.
