### PR TITLE
Code check fix

### DIFF
--- a/run-pr-code-checks
+++ b/run-pr-code-checks
@@ -55,12 +55,27 @@ pushd $CMSSW_BASE/src
 popd
 
 sed -i -e 's/ code-checks-internal *$/ code-checks-internal || $(CMD_true)/' ${CMSSW_BASE}/config/SCRAM/GMake/Makefile.coderules
+source $CMS_BOT_DIR/jenkins-artifacts
 
 #If we have any non-tests changed files
 touch ${CMSSW_BASE}/upload/code-checks.patch
 if $CODE_CHECKS ; then
   if [ -s $CMSSW_BASE/upload/code-checks-files.txt ] ; then
-    scram build -k -j $NUM_PROC code-checks USER_CODE_CHECKS_FILE="$CMSSW_BASE/upload/code-checks-files.txt"  2>&1 | tee ${CMSSW_BASE}/upload/code-checks.log
+    ERR=false
+    scram build -k -j $NUM_PROC code-checks USER_CODE_CHECKS_FILE="$CMSSW_BASE/upload/code-checks-files.txt" > ${CMSSW_BASE}/upload/code-checks.log 2>&1 || ERR=true
+    if $ERR then
+      echo '-code-checks' > ${CMSSW_BASE}/upload/code-checks-err.log
+      echo '' >> ${CMSSW_BASE}/upload/code-checks-err.log
+      echo 'ERROR: Build errors found during clang-tidy run.' >> ${CMSSW_BASE}/upload/code-checks-err.log
+      echo '```' >> ${CMSSW_BASE}/upload/code-checks-err.log
+      grep -A 3 ': error: \|gmake: \*\*\*' ${CMSSW_BASE}/upload/code-checks.log | sed "s|$CMSSW_BASE/src/||" >> ${CMSSW_BASE}/upload/code-checks-err.log
+      echo '```' >> ${CMSSW_BASE}/upload/code-checks-err.log
+      if [ "$DRY_RUN" != "true" ] ; then
+        send_jenkins_artifacts ${CMSSW_BASE}/upload/ pr-code-checks/${REPO_USER}-PR-${PULL_REQUEST}/${BUILD_NUMBER}
+        ${CMS_BOT_DIR}/comment-gh-pr -r ${REPOSITORY} -p $PULL_REQUEST -R ${CMSSW_BASE}/upload/code-checks-err.log
+      fi
+      exit 0
+    fi
     if [ -e ${CMSSW_BASE}/tmp/${SCRAM_ARCH}/code-checks-logs ] ; then
       mv ${CMSSW_BASE}/tmp/${SCRAM_ARCH}/code-checks-logs ${CMSSW_BASE}/upload
     fi
@@ -78,7 +93,7 @@ if $CODE_FORMAT ; then
   if [ -f ${CMSSW_BASE}/src/.clang-format ] ; then
     cp $CMSSW_BASE/upload/all-changed-files.txt $CMSSW_BASE/upload/code-format-files.txt
     if [ -s $CMSSW_BASE/upload/code-format-files.txt ] ; then
-      scram build -k -j $NUM_PROC code-format USER_CODE_FORMAT_FILE="$CMSSW_BASE/upload/code-format-files.txt"  2>&1 | tee $CMSSW_BASE/upload/code-format.log
+      scram build -k -j $NUM_PROC code-format USER_CODE_FORMAT_FILE="$CMSSW_BASE/upload/code-format-files.txt" > $CMSSW_BASE/upload/code-format.log 2>&1
       pushd $CMSSW_BASE/src
         git diff > ${CMSSW_BASE}/upload/code-format.patch
         if [ -s ${CMSSW_BASE}/upload/code-format.patch ] ; then

--- a/run-pr-code-checks
+++ b/run-pr-code-checks
@@ -54,7 +54,6 @@ pushd $CMSSW_BASE/src
   $CMS_BOT_DIR/pr-checks/check-pr-files -d -r ${REPO_USER}/cmssw ${PULL_REQUEST} > $CMSSW_BASE/upload/invalid_files.txt || true
 popd
 
-sed -i -e 's/ code-checks-internal *$/ code-checks-internal || $(CMD_true)/' ${CMSSW_BASE}/config/SCRAM/GMake/Makefile.coderules
 source $CMS_BOT_DIR/jenkins-artifacts
 
 #If we have any non-tests changed files

--- a/run-pr-code-checks
+++ b/run-pr-code-checks
@@ -113,7 +113,6 @@ if ${MULTIPLE_FILES_CHANGES} ; then
 fi
 
 if [ "$DRY_RUN" != "true" ] ; then
-  source $CMS_BOT_DIR/jenkins-artifacts
   send_jenkins_artifacts ${CMSSW_BASE}/upload/ pr-code-checks/${REPO_USER}-PR-${PULL_REQUEST}/${BUILD_NUMBER}
 fi
 RES="+code-checks"

--- a/run-pr-code-checks
+++ b/run-pr-code-checks
@@ -63,7 +63,7 @@ if $CODE_CHECKS ; then
   if [ -s $CMSSW_BASE/upload/code-checks-files.txt ] ; then
     ERR=false
     scram build -k -j $NUM_PROC code-checks USER_CODE_CHECKS_FILE="$CMSSW_BASE/upload/code-checks-files.txt" > ${CMSSW_BASE}/upload/code-checks.log 2>&1 || ERR=true
-    if $ERR then
+    if $ERR ; then
       echo '-code-checks' > ${CMSSW_BASE}/upload/code-checks-err.log
       echo '' >> ${CMSSW_BASE}/upload/code-checks-err.log
       echo 'ERROR: Build errors found during clang-tidy run.' >> ${CMSSW_BASE}/upload/code-checks-err.log


### PR DESCRIPTION
If clang-tidy itself fails then code-checks ignore all fixes and continue. This was observed for https://github.com/cms-sw/cmssw/pull/29527 where PR itself does not compile as it depent on another PR. This change will allow to mark code check fail if clang-tidy fails