### PR TITLE
Filter 'edm::ConcurrentHadronizerFilter<Pythia8Hadronizer' in modules2statics report

### DIFF
--- a/run_clang_static_analysis
+++ b/run_clang_static_analysis
@@ -27,7 +27,7 @@ fi
 ./create_statics_esd_reports.sh
 ls -ltrh
 tar cvfz dumper-checker.tgz *.txt*
-egrep '::(stream|global)::[^ ]+::(produce|analyze|filter)\(\)' modules2statics.txt | egrep -v 'edm::RootInputFileSequence::initTheFile\(\)' | egrep -v 'PrintGeomInfoAction::update\(\)'  > modules2statics-filter1.txt
+egrep '::(stream|global)::[^ ]+::(produce|analyze|filter)\(\)' modules2statics.txt | egrep -v 'edm::RootInputFileSequence::initTheFile\(\)' | egrep -v 'PrintGeomInfoAction::update\(\)' | egrep -v 'edm::ConcurrentHadronizerFilter<Pythia8Hadronizer' > modules2statics-filter1.txt
 mkdir $WORKSPACE/reports
 for f in dumper-checker.tgz esd2tlf.txt tlf2esd.txt statics2modules.txt modules2statics.txt override-flagged-classes.txt modules2statics-filter1.txt ; do
   [ -f $f ] && cp $f $WORKSPACE/reports/$f

--- a/run_clang_static_analysis
+++ b/run_clang_static_analysis
@@ -27,7 +27,7 @@ fi
 ./create_statics_esd_reports.sh
 ls -ltrh
 tar cvfz dumper-checker.tgz *.txt*
-egrep '::(stream|global)::[^ ]+::(produce|analyze|filter)\(\)' modules2statics.txt | egrep -v 'edm::RootInputFileSequence::initTheFile\(\)' | egrep -v 'PrintGeomInfoAction::update\(\)' | egrep -v 'edm::ConcurrentHadronizerFilter<Pythia8Hadronizer' > modules2statics-filter1.txt
+egrep '::(stream|global)::[^ ]+::(produce|analyze|filter)\(\)' modules2statics.txt | egrep -v -f statics-filter1.txt > modules2statics-filter1.txt
 mkdir $WORKSPACE/reports
 for f in dumper-checker.tgz esd2tlf.txt tlf2esd.txt statics2modules.txt modules2statics.txt override-flagged-classes.txt modules2statics-filter1.txt ; do
   [ -f $f ] && cp $f $WORKSPACE/reports/$f

--- a/statics-filter1.txt
+++ b/statics-filter1.txt
@@ -1,0 +1,3 @@
+edm::RootInputFileSequence::initTheFile
+PrintGeomInfoAction::update
+edm::ConcurrentHadronizerFilter<Pythia8Hadronizer


### PR DESCRIPTION
The only way to avoid reporting the link to statics in ```edm::ConcurrentHadronizerFilter<Pythia8Hadronizer, gen::ConcurrentExternalDecayDriver>::filter()```  is to mark all statics linked through the base class as safe. To avoid doing this just filter edm::ConcurrentHadronizerFilter<Pythia8Hadronize  from the modules2statics report.