### PR TITLE
drop only those files which are all clean

### DIFF
--- a/comparisons/filter-failed-comparison.py
+++ b/comparisons/filter-failed-comparison.py
@@ -11,29 +11,19 @@ WF_DIR=basename(WF_PATH)
 DES_DIR=join(sys.argv[2],WF_DIR)
 
 htmls=[basename(h)[:-5] for h in glob.glob(WF_PATH+"/*.html")]
-all_ok=[]
 DES_DIR_CREATED=False
 for h in sorted(htmls):
-  for s in all_ok[::-1]:
-    if h.startswith(s):
-      print("All OK:%s (%s)" % (h, s))
-      h = None
-      break
-  if not h: continue
   e, o = run_cmd("grep 'Skipped:\|Null:\|Fail:' '%s/%s.html' | wc -l" % (WF_PATH,h))
-  print("Working on %s:%s: %s" % (h,e,o))
   if not e:
     if int(o)>0:
       if not DES_DIR_CREATED:
         run_cmd("mkdir -p %s" % DES_DIR)
         DES_DIR_CREATED=True
       run_cmd("mv '%s/%s.html' '%s/%s.html'" % (WF_PATH,h,DES_DIR,h))
-    else:
-      all_ok.append("%s_" % h)
   else:
-    print("ERROR: %s/%s\n%s" %(WF_DIR,h,o))
+    print("Error Filtering: %s/%s\n%s" %(WF_DIR,h,o))
 
 if DES_DIR_CREATED:
   run_cmd("mv %s/*.png %s/" % (WF_PATH, DES_DIR))
   run_cmd("echo ErrorDocument 404 /SDT/html/pr_comparison_ok.html > %s/.htaccess" % DES_DIR)
-print("DONE:", WF_DIR)
+print("Done filtering:", WF_DIR)


### PR DESCRIPTION
During the PR tests of https://github.com/cms-sw/cmssw/pull/30071 we noticed that we are filtering  too many file files due to directory separator `_` and character `_` in the name. This PR make sure that we process all files and only filter out those which are clean