### PR TITLE
reco comparisons: nanoAOD and MTD plot updates

### DIFF
--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -1355,33 +1355,35 @@ void tauIDContainer(const TString& bName){
 }
 
 void flatTable(const TString& shortName){
-  const TString tName = "nanoaodFlatTable_"+shortName;
-  plotvar(tName+"_"+recoS+".obj.size_");
-  PlotStats res = plotvar(tName+"_"+recoS+".obj.columns_@.size()");
+  const TString bObj = "nanoaodFlatTable_"+shortName+"_"+recoS+".obj";
+  if (! checkBranchOR(bObj, true)) return;
+
+  plotvar(bObj+".size_");
+  PlotStats res = plotvar(bObj+".columns_@.size()");
   if (res.new_mean == 0 && res.new_entries != 0){ //over/underflow case
-    std::cout<<"WARNING: Branch "<<tName<<" columns_@.size() is off scale vs ref"<<std::endl;
+    std::cout<<"WARNING: Branch "<<bObj<<" columns_@.size() is off scale vs ref"<<std::endl;
   }
   int nCols = res.ref_mean;
   if (res.ref_rms != 0){//size varies event to event => use xmax instead
     nCols = res.ref_xmax;
   }
 
-  refEvents->SetAlias("xN", tName+"_"+recoS+".obj.size_");
-  Events->SetAlias("xN", tName+"_"+recoS+".obj.size_");
+  refEvents->SetAlias("xN", bObj+".size_");
+  Events->SetAlias("xN", bObj+".size_");
   for (int i = 0; i< nCols; ++i){
-    res = plotvar(tName+"_"+recoS+Form(".obj.columns_[%i].type", i));
+    res = plotvar(bObj+Form(".columns_[%i].type", i));
     if (res.new_mean == res.ref_mean && res.new_entries != 0 && res.ref_entries != 0){//plot only matching content
-      const char* cName = Events->Query(tName+"_"+recoS+Form(".obj.columnName(%i)", i), "", "", 1)->Next()->GetField(0);
+      const char* cName = Events->Query(bObj+Form(".columnName(%i)", i), "", "", 1)->Next()->GetField(0);
 
-      refEvents->SetAlias(Form("xC%i", i), tName+"_"+recoS+Form(".obj.columns_[%i].firstIndex", i));
-      Events->SetAlias(Form("xC%i", i), tName+"_"+recoS+Form(".obj.columns_[%i].firstIndex", i));
+      refEvents->SetAlias(Form("xC%i", i), bObj+Form(".columns_[%i].firstIndex", i));
+      Events->SetAlias(Form("xC%i", i), bObj+Form(".columns_[%i].firstIndex", i));
 
       if (res.new_mean == 0){
-        plotvar(tName+"_"+recoS+Form(".obj.floats_*(\"%s\"!=\"\")",cName), Form("Iteration$>=xC%i&&Iteration$<xC%i+xN", i, i));
+        plotvar(bObj+Form(".floats_*(\"%s\"!=\"\")",cName), Form("Iteration$>=xC%i&&Iteration$<xC%i+xN", i, i));
       } else if (res.new_mean == 1){
-        plotvar(tName+"_"+recoS+Form(".obj.ints_*(\"%s\"!=\"\")",cName), Form("Iteration$>=xC%i&&Iteration$<xC%i+xN", i, i));
+        plotvar(bObj+Form(".ints_*(\"%s\"!=\"\")",cName), Form("Iteration$>=xC%i&&Iteration$<xC%i+xN", i, i));
       } else {
-        plotvar(tName+"_"+recoS+Form(".obj.uint8s_*(\"%s\"!=\"\")",cName), Form("Iteration$>=xC%i&&Iteration$<xC%i+xN", i, i));
+        plotvar(bObj+Form(".uint8s_*(\"%s\"!=\"\")",cName), Form("Iteration$>=xC%i&&Iteration$<xC%i+xN", i, i));
       }
     }
   }
@@ -1522,7 +1524,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
 
     //Check if it's a NANOEDM
     if (checkBranchAND("nanoaodFlatTable_muonTable__"+recoS+".")){
-      const int nTabs = 52;
+      const int nTabs = 66;
       TString tNames[nTabs] = {
         "btagWeightTable_",                      //0
         "caloMetTable_",                         //1
@@ -1576,6 +1578,23 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
         "vertexTable_otherPVs",                  //49
         "vertexTable_pv",                        //50
         "vertexTable_svs",                       //51
+        //additions from comparisons-24Jun2020
+        "chsMetTable_",                          //52
+        "corrT1METJetTable_",                    //53
+        "deepMetResolutionTuneTable_",           //54
+        "deepMetResponseTuneTable_",             //55
+        "metFixEE2017Table_",                    //56
+        "rawPuppiMetTable_",                     //57
+        //
+        "subjetMCTable_",                        //58
+        "fatJetMCTable_",                        //59
+        "l1PreFiringEventWeightTable_",          //60
+        //
+        "HTXSCategoryTable_",                    //61
+        "extraFlagsTable_",                      //62
+        "fsrTable_",                             //63
+        "genWeightsTable_LHEReweighting",        //64
+        "rivetPhotonTable_",                     //65
       };
       for (int iT = 0; iT < nTabs; ++iT){
         flatTable(tNames[iT]);
@@ -2482,7 +2501,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
         plotvar(tbr+".m_data.y()");
         plotvar(tbr+".m_data.energy()");
         plotvar(tbr+".m_data.time()");
-        plotvar(tbr+".m_data.time_error()");
+        plotvar(tbr+".m_data.timeError()");
       }
 
       tbr="FTLClusteredmNewDetSetVector_mtdClusters_FTLEndcap_"+recoS+".obj";
@@ -2492,7 +2511,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
         plotvar(tbr+".m_data.y()");
         plotvar(tbr+".m_data.energy()");
         plotvar(tbr+".m_data.time()");
-        plotvar(tbr+".m_data.time_error()");
+        plotvar(tbr+".m_data.timeError()");
       }
 
       //tracking rechits
@@ -2503,8 +2522,6 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
             plotvar(tbr+".m_data.energy()");
             plotvar(tbr+".m_data.time()");
         */
-        plotvar(tbr+".m_data.localPosition().x()");
-        plotvar(tbr+".m_data.localPosition().y()");
       }
 
       allTracks("trackExtenderWithMTD__"+recoS);
@@ -2515,6 +2532,12 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+"generalTracktmtd_"+recoS+".obj.values_");
       plotvar(tbr+"pathLength_"+recoS+".obj.values_");
       plotvar(tbr+"tmtd_"+recoS+".obj.values_");
+      plotvar(tbr+"btlMatchChi2_"+recoS+".obj.values_");
+      plotvar(tbr+"etlMatchChi2_"+recoS+".obj.values_");
+      plotvar("min(20,"+tbr+"btlMatchChi2_"+recoS+".obj.values_)", tbr+"btlMatchChi2_"+recoS+".obj.values_>=0");
+      plotvar("min(20,"+tbr+"etlMatchChi2_"+recoS+".obj.values_)", tbr+"etlMatchChi2_"+recoS+".obj.values_>=0");
+      plotvar(tbr+"btlMatchTimeChi2_"+recoS+".obj.values_");
+      plotvar(tbr+"etlMatchTimeChi2_"+recoS+".obj.values_");
 
       tbr="floatedmValueMap_tofPID_";
       plotvar(tbr+"t0_"+recoS+".obj.values_");


### PR DESCRIPTION
- MTD
    - fix time error variable accessor name (```timeError```) for FTLClusters
    - drop nonexistent value (transient) plotting of positions in mtdTrackingRecHits
    - add plots of BTL and ETL chi2 matches with tracks
- NANO
    - update the list of plotted tables to the full list available as of CMSSW_11_2_X_2020-06-18-1100

the comparisons on jenkins tests are expected to run and return no differences on "self"-comparisons