### PR TITLE
reco comparisons: plots for JPT jets;  packed candidates from heavy ion miniAOD

### DIFF
--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -2841,11 +2841,20 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       }
     }
 
-    if (stepContainsNU(step, "all")) {
+    if (stepContainsNU(step, "all") || stepContainsNU(step, "pat")) {
       packedCand("packedPFCandidates_");
       packedCand("lostTracks_");
       packedCand("lostTracks_eleTracks");
       packedCand("packedPFCandidatesDiscarded_");
+      packedCand("hiPixelTracks_");
+
+      for (const TString& inst : {"pfCandidatesTMOneStationTight", "pfCandidatesAllTrackerMuons", 
+                                 "lostTracksTMOneStationTight", "lostTracksAllTrackerMuons"} ) {
+        tbr="patPackedCandidatesRefs_packedCandidateMuonID_"+inst+"_"+recoS+".obj";
+        if (checkBranchOR(tbr, true)){
+          plotvar(tbr+"@.size()");
+        }
+      }
 
       tbr="patHcalDepthEnergyFractionsedmValueMap_packedPFCandidates_hcalDepthEnergyFractions_"+recoS+".obj";
       if (checkBranchOR(tbr, true)){
@@ -3628,6 +3637,7 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       jets("recoTrackJets","ak5TrackJets");
       jets("recoTrackJets","ak4TrackJets");
       jets("recoJPTJets","JetPlusTrackZSPCorJetAntiKt5");
+      jets("recoJPTJets","JetPlusTrackZSPCorJetAntiKt4");
       jets("recoJPTJets", "TCTauJetPlusTrackZSPCorJetAntiKt5");
       jets("recoPFJets","ak5PFJets");
       jets("recoPFJets","ak5PFJetsCHS");


### PR DESCRIPTION
- add plots for JPT jets AK4 (forgotten post-migration from AK5 since a while). Needed for cms-sw/cmssw#30430
- add plots of counts of packedCand refs from packedCandidateMuonID (heavy ions re-miniAOD). Needed for/after cms-sw/cmssw#30253 
- hiPixelTracks as packed candidates (heavy ions re-miniAOD). Needed for/after cms-sw/cmssw#30313


