### PR TITLE
Add pieterdavid and robervalwalsh to the watchers of EventFilter/SiSt…

### DIFF
--- a/watchers.yaml
+++ b/watchers.yaml
@@ -849,6 +849,7 @@ prolay:
 - SimTracker/Configuration
 - SimTracker/Records
 robervalwalsh:
+- EventFilter/SiStripRawToDigi
 - CalibTracker/Configuration
 - CalibTracker/Records
 - CalibTracker/SiStrip
@@ -1496,6 +1497,7 @@ jan-kaspar:
 - RecoCTPPS/TotemRPLocal
 - RecoCTPPS/PixelLocal
 pieterdavid:
+- EventFilter/SiStripRawToDigi
 - CalibTracker/Configuration
 - CalibTracker/Records
 - CalibTracker/SiStrip


### PR DESCRIPTION
…ripRawToDigi

as L3 conveners of the strips subgroup of the tracker DPG, which maintains the strip unpacker - it seems we forgot to include this in our list before.

CC @robervalwalsh