### PR TITLE
Don't process .gz file in project area.

### DIFF
--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -9,7 +9,7 @@ for prof in ${PROFILES} ; do
   mkdir -p $WORKSPACE/igprof/${prof}
   cd $WORKSPACE/igprof/${prof}
   runTheMatrix.py $WORKFLOWS --ibeos --command "-n $EVENTS --profile $prof" 2>&1 | tee runTheMatrix.log
-  for f in $(find . -name '*.gz' -type f) ; do
+  for f in $(find . -name '*.gz' -type f| grep -v CMSSW) ; do
     echo "processing file $f"
     OUTFILE=${f//.gz/.sql3}
     echo $OUTFILE


### PR DESCRIPTION
Prevents this error
```
++ find . -name '*.gz' -type f
+ for f in '$(find . -name '\''*.gz'\'' -type f)'
+ echo 'processing file ./CMSSW_11_2_X_2020-08-03-1100/.SCRAM/slc7_amd64_gcc820/DirCache.db.gz'
processing file ./CMSSW_11_2_X_2020-08-03-1100/.SCRAM/slc7_amd64_gcc820/DirCache.db.gz
+ OUTFILE=./CMSSW_11_2_X_2020-08-03-1100/.SCRAM/slc7_amd64_gcc820/DirCache.db.sql3
+ echo ./CMSSW_11_2_X_2020-08-03-1100/.SCRAM/slc7_amd64_gcc820/DirCache.db.sql3
./CMSSW_11_2_X_2020-08-03-1100/.SCRAM/slc7_amd64_gcc820/DirCache.db.sql3
+ igprof-analyse -d -c ./CMSSW_11_2_X_2020-08-03-1100/.SCRAM/slc7_amd64_gcc820/DirCache.db.gz --sqlite
./CMSSW_11_2_X_2020-08-03-1100/.SCRAM/slc7_amd64_gcc820/DirCache.db.gz:0: syntax error, last token read was ''

```