### PR TITLE
If igprof is being run do no set ulimit.

### DIFF
--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -ex
-if [ "X$ADDITIONAL_TEST_NAME" != "Xigprof" ] ; then
+if [ "X$ADDITIONAL_TEST_NAME" = "Xigprof" ] ; then
   if ulimit -a ; then
     ulimit -a
-  fi 
+  fi
 else
   if ulimit -a ; then
     opts=""

--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -ex
 if [ "X$ADDITIONAL_TEST_NAME" != "Xigprof" ] ; then
   if ulimit -a ; then
+    ulimit -a
+  fi 
+else
+  if ulimit -a ; then
     opts=""
     for o in n s u ; do
       opts="-$o $(ulimit -H -$o) ${opts}"

--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -1,11 +1,13 @@
 #!/bin/bash -ex
-if ulimit -a ; then
-  opts=""
-  for o in n s u ; do
-    opts="-$o $(ulimit -H -$o) ${opts}"
-  done
-  ulimit ${opts}
-  ulimit -a
+if [ "X$ADDITIONAL_TEST_NAME" != "Xigprof" ] ; then
+  if ulimit -a ; then
+    opts=""
+    for o in n s u ; do
+      opts="-$o $(ulimit -H -$o) ${opts}"
+    done
+    ulimit ${opts}
+    ulimit -a
+  fi
 fi
 kinit -R || true
 for repo in cms cms-ib grid projects unpacked ; do


### PR DESCRIPTION
Testing showed that commenting out the ulimit commands allowed igprof to run under Singularity. 

Used the Jenkins job parameter/ environment variable ADDITIONAL_TEST_NAME to skip running ulimit when ADDITIONAL_TEST_NAME=igprof.