### PR TITLE
Run igprof under Singularity with limited stack size set by ulimit -s. Updates to igprof job scripts.

### DIFF
--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 if [ "X$ADDITIONAL_TEST_NAME" = "Xigprof" ] ; then
   if ulimit -a ; then
+    ulimit -n 4096 -s 81920
     ulimit -a
   fi
 else

--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -13,12 +13,11 @@ for prof in ${PROFILES} ; do
     echo "processing file $f"
     OUTFILE=${f//.gz/.sql3}
     echo $OUTFILE
-    igprof-analyse -d -c $f --sqlite > $f.sql
     ERR=0
+    ( igprof-analyse -d -c $f --sqlite > $f.sql ) || ERR=1
     ${CMS_BOT_DIR}/fix-igprof-sql.py $f.sql | sqlite3 "$OUTFILE" > $f.log || ERR=1
     if [ $ERR -gt 0 ] ; then
       cat $f.log
-      exit 1
     fi
   done
 done


### PR DESCRIPTION
The segfault while running igprof under Singularity in docker_launcher.sh was caused by setting `ulimit -s unlimited`. Changing this to `ulimit -s 81920` results in no segfault.