### PR TITLE
run-ib-igprof:  Remove escapes from $ in awk command

### DIFF
--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -27,7 +27,7 @@ for prof in ${PROFILES} ; do
             mv RES_CPU_$OUTFILE RES_CPU_step3.txt
             export IGREP=RES_CPU_step3.txt
             export IGSORT=sorted_RES_CPU_step3.txt
-            awk -v module=doEvent 'BEGIN { total = 0; } { if(substr(\$0,0,1)=="-"){good = 0;}; if(good&&length(\$0)>0){print \$0; total += \$3;}; if(substr(\$0,0,1)=="["&&index(\$0,module)!=0) {good = 1;} } END { print "Total: "total } ' \${IGREP} | sort -n -r -k1 | awk '{ if(index(\$0,"Total: ")!=0){total=\$0;} else{print \$0;} } END { print total; }' > ${IGSORT} 2>&1 || ERR=1
+            awk -v module=doEvent 'BEGIN { total = 0; } { if(substr($0,0,1)=="-"){good = 0;}; if(good&&length($0)>0){print $0; total += $3;}; if(substr($0,0,1)=="["&&index($0,module)!=0) {good = 1;} } END { print "Total: "total } ' ${IGREP} | sort -n -r -k1 | awk '{ if(index($0,"Total: ")!=0){total=$0;} else{print$0;} } END { print total; }' > ${IGSORT} 2>&1 || ERR=1
         fi
     fi
     if [ "$prof" = "mp" ]; then


### PR DESCRIPTION
Fix another bonehead mistake in copying over awk command from profiling script were it is echo-ed into a file to be run later.