### PR TITLE
Correct case of username yuanchao

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -74,7 +74,7 @@ CMSSW_L2 = {
   "tocheng":          ["alca"],
   "wajidalikhan":     ["pdmv"],
   "christopheralanwest": ["alca"],
-  "YuanChao":         ["alca"],
+  "yuanchao":         ["alca"],
   CMSBUILD_USER:      ["tests" ],
 }
 


### PR DESCRIPTION
In commit f5ee9fa7b9788cef892019d7c0d2ee68eccd5cab, I copied the username from the URL https://github.com/YuanChao, not realizing that the username in the URL is not case sensitive, though the username itself apparently is (at least for the cms-bot). As a consequence, @yuanchao could not sign off on PRs, such as https://github.com/cms-sw/cmssw/pull/31586#issuecomment-702821191. 

This PR corrects the case of the username.