### PR TITLE
remove DataFormats/NanoAOD from the reco category

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1094,7 +1094,6 @@ CMSSW_CATEGORIES = {
     "DataFormats/MuonData",
     "DataFormats/MuonReco",
     "DataFormats/MuonSeed",
-    "DataFormats/NanoAOD",
     "DataFormats/OnlineMetaData",
     "DataFormats/ParticleFlowCandidate",
     "DataFormats/ParticleFlowReco",


### PR DESCRIPTION
I can't recall this was practical or needed since the original addition in 2017 in https://github.com/cms-sw/cms-bot/commit/48f365673a6fb521c9e50439acf8c855354f6790
