### PR TITLE
Bring the old file structure for DEPS folder

### DIFF
--- a/build-cmssw-ib-with-patch
+++ b/build-cmssw-ib-with-patch
@@ -194,8 +194,9 @@ if [ "${DRY_RUN}" = "" ] ; then
     echo DATE=`date`
     rm -rf ${WRKDIR}/tmp
     PYTHONPATH= $CMSBUILD_CMD ${EX_OPTS} deprecate-local $TOOL_CONF_PACKAGES
-    mv ${WRKDIR}/WEB ${WRKDIR}/DEPS
-    for i in `ls ${WRKDIR}/DEPS/${ARCHITECTURE}`; do mv ${WRKDIR}/DEPS/${ARCHITECTURE}/$i ${WRKDIR}/DEPS/${ARCHITECTURE}/$(echo $i | tr "+" " " | awk '{print $2}').json; done
+    mv ${WRKDIR}/WEB/${ARCHITECTURE} ${WRKDIR}/DEPS
+    rm -rf ${WRKDIR}/WEB
+    for i in `ls ${WRKDIR}/DEPS`; do mv ${WRKDIR}/DEPS/$i ${WRKDIR}/DEPS/$(echo $i | tr "+" " " | awk '{print $2}').json; done
     echo DATE=`date`
   fi
 fi


### PR DESCRIPTION
old releases are having DEPS/*.json structure:
CMSSW_11_2_CLANG_X_2020-11-08-2300/slc7_amd64_gcc820/100238/DEPS/
 but now they are having DEPS/arch/*.json:
CMSSW_11_2_CLANG_X_2020-11-20-2300/slc7_amd64_gcc820/100883/DEPS/
which failed the jenkins job when it couldn't copy the arch folder
when building with pkgtools having the WEB/arch structure is correct to not overwrite things,
but in this case we only build one arch within one job and renaming WEB/arch to DEPS is safe.
Everything else would require conditions in the jenkins job which is not necessary
the architecture is already in the path so having it release/arch/DEPS/arch in this case is redundant