### PR TITLE
reduce pr test messages and make use of commit status

### DIFF
--- a/github_utils.py
+++ b/github_utils.py
@@ -418,6 +418,13 @@ def get_combined_statuses(commit, repository, token=None):
   if not token: token = get_gh_token(repository)
   return github_api("/repos/%s/commits/%s/status" % (repository, commit), token, method='GET')
 
+
+def set_comment_emoji(comment_id, repository, emoji="+1", token=None):
+  if not token: token = get_gh_token(repository)
+  params = {"content" : emoji }
+  headers = {"Accept": "application/vnd.github.squirrel-girl-preview+json"}
+  return github_api('/repos/%s/issues/comments/%s/reactions' % (repository, comment_id), token, params, headers=headers)
+
 def mark_commit_status(commit, repository, context="default", state="pending", url="", description="Test started", token=None, reset=False):
   if not token: token = get_gh_token(repository)
   params = {'state': state, 'target_url': url, 'description': description, 'context': context}

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -177,7 +177,7 @@ for PR in ${PULL_REQUESTS}; do
     echo ${COMMIT} | sed 's|.* ||' > "$(get_path_to_pr_metadata ${PR})/COMMIT"
     echo "${PR}=${COMMIT}" >> ${WORKSPACE}/prs_commits.txt
 done
-if $FIRST_PR_ONLY ; then MAIN_PR_COMMIT="-c $(cat $(get_path_to_pr_metadata ${MAIN_PULL_REQUEST})/COMMIT)" ; fi
+#if $FIRST_PR_ONLY ; then MAIN_PR_COMMIT="-c $(cat $(get_path_to_pr_metadata ${MAIN_PULL_REQUEST})/COMMIT)" ; fi
 
 mark_commit_status_all_prs '' 'pending' -u "${BUILD_URL}" -d 'Setting up build environment' --reset || true
 if $REQUIRED_TEST ; then mark_commit_status_all_prs 'required' 'success' -d 'OK' || true ; fi

--- a/report-pull-request-results.py
+++ b/report-pull-request-results.py
@@ -597,7 +597,7 @@ def mark_commit( action , commit_hash , tests_url ):
 #---- Global variables
 #---------------------------------------------------------------------------------------
 
-COMPARISON_READY_MSG = 'Comparison is ready'
+COMPARISON_READY_MSG = 'Comparison results are now available'
 COMPARISON_INCOMPLETE_MSG = 'There are some workflows for which there are errors in the baseline:\n {workflows} ' \
                             'The results for the comparisons for these workflows could be incomplete \n' \
                             'This means most likely that the IB is having errors in the relvals.'\


### PR DESCRIPTION
An attempt to reduce pr tests messages. We make use of commit statuses to keep track of pr test states , so there is no need to post test started.