### PR TITLE
reco comparisons driver: check that both input root files are available before running validate.C

### DIFF
--- a/comparisons/validateJR.sh
+++ b/comparisons/validateJR.sh
@@ -24,9 +24,9 @@ done
 grep root ${inList} | grep -v "#" | while read -r dsN fNP procN comm; do
     #fNP can be a pattern: path-expand it first
     fN=`echo ${baseA}/${fNP} | cut -d" " -f1 | sed -e "s?^${baseA}/??g"`
-    [ ! -f "${baseA}/${fN}" ] && echo Missing ${baseA}/${fN}
-    #process regular files first
-    if [ -f "${baseA}/${fN}" ]; then
+    #[ ! -f "${baseA}/${fN}" ] && echo Missing ${baseA}/${fN}
+    #process regular files first; need files both in baseA and baseB
+    if [ -f "${baseA}/${fN}" -a -f "${baseB}/${fN}" ]; then
 	extN=all_${diffN}_${dsN}
 	mkdir -p ${extN}
 	pushd ${extN}
@@ -44,7 +44,8 @@ grep root ${inList} | grep -v "#" | while read -r dsN fNP procN comm; do
     if [ ! -f "${baseA}/${mFN}" ]; then
         mFN="${fNBase}_inMINIAODSIM.root"
     fi
-    if [ -f "${baseA}/${mFN}" ]; then
+    #need files both in baseA and baseB
+    if [ -f "${baseA}/${mFN}" -a -f "${baseB}/${mFN}" ]; then
 	echo $mFN
 	extmN=all_mini_${diffN}_${dsN}
 	mkdir -p ${extmN}


### PR DESCRIPTION
while testing https://github.com/cms-sw/cmssw/pull/32325#issuecomment-735484569
`Reco comparison had 1 failed jobs` showed up somewhat unexpectedly.
It was triggered by a request to include a workflow in the test which does not have a reference. These unpaired inputs should not be used to run validate.C (fwlite-based reco comparisons).

this PR should resolve the issue