### PR TITLE
Remove tocheng from alca L2 list

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -70,7 +70,6 @@ CMSSW_L2 = {
   "smuzaffar":        ["core", "externals"],
   "ssekmen":          ["fastsim"],
   "tlampen":          ["alca"],
-  "tocheng":          ["alca"],
   "wajidalikhan":     ["pdmv"],
   "christopheralanwest": ["alca"],
   "yuanchao":         ["alca"],


### PR DESCRIPTION
Tongguang Cheng (@tocheng) has completed his term as AlCaDB convener so I am removing him from the alca L2 list.