### PR TITLE
Move CommonTools/TriggerUtils from reco to hlt and l1

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -876,6 +876,7 @@ CMSSW_CATEGORIES = {
     "HeterogeneousCore/SonicTriton",
   ],
   "hlt": [
+    "CommonTools/TriggerUtils",
     "CondCore/HLTPlugins",
     "CondFormats/HLTObjects",
     "CondTools/HLT",
@@ -911,6 +912,7 @@ CMSSW_CATEGORIES = {
     "CalibCalorimetry/HcalTPGAlgos",
     "CalibCalorimetry/HcalTPGEventSetup",
     "CalibCalorimetry/HcalTPGIO",
+    "CommonTools/TriggerUtils",
     "CondCore/L1TPlugins",
     "CondFormats/L1TObjects",
     "CondTools/L1Trigger",
@@ -1057,7 +1059,6 @@ CMSSW_CATEGORIES = {
     "CommonTools/RecoAlgos",
     "CommonTools/Statistics",
     "CommonTools/TrackerMap",
-    "CommonTools/TriggerUtils",
     "CommonTools/UtilAlgos",
     "CommonTools/Utils",
     "CondFormats/SiPixelTransient",


### PR DESCRIPTION
"CommonTools/TriggerUtils" contains tools used for validation of L1 and HLT objects, not really for reco.

I did not remove the ownership of analysis to the package, but perhaps this is also something that can be considered.

@cms-sw/l1-l2 @cms-sw/hlt-l2