### PR TITLE
Only sort tag names

### DIFF
--- a/create-new-data-pr.py
+++ b/create-new-data-pr.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
       exit(0)
 
   last_release_tag = None
-  releases = sorted([tag.name for tag in data_repo.get_tags()], reverse=True)
+  releases = [tag['name'] for tag in loads(urlopen("https://api.github.com/repos/%s/tags" % opts.data_repo).read())]
   for tag_name in releases:
       if not (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", tag_name)):
           continue #loop until it finds a tag matching the pattern
@@ -93,7 +93,7 @@ if __name__ == "__main__":
       new_rel = data_repo.create_git_release(new_tag, new_tag, 'Details in: '+data_repo_pr.html_url, False, False)
 
   last_release_tag = None
-  releases = sorted([tag.name for tag in data_repo.get_tags()], reverse=True)
+  releases = [tag['name'] for tag in loads(urlopen("https://api.github.com/repos/%s/tags" % opts.data_repo).read())]
   for tag_name in releases:
       if not (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", tag_name)):
           continue #loop until it finds a tag matching the pattern

--- a/create-new-data-pr.py
+++ b/create-new-data-pr.py
@@ -51,10 +51,10 @@ if __name__ == "__main__":
 
   last_release_tag = None
   releases = sorted([tag.name for tag in data_repo.get_tags()], reverse=True)
-  for i in releases:
-      if not (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", i.tag_name)):
+  for tag_name in releases:
+      if not (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", tag_name)):
           continue #loop until it finds a tag matching the pattern
-      last_release_tag = i.tag_name
+      last_release_tag = tag_name
       break
 
   if last_release_tag:
@@ -94,10 +94,10 @@ if __name__ == "__main__":
 
   last_release_tag = None
   releases = sorted([tag.name for tag in data_repo.get_tags()], reverse=True)
-  for i in releases:
-      if not (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", i.tag_name)):
+  for tag_name in releases:
+      if not (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", tag_name)):
           continue #loop until it finds a tag matching the pattern
-      last_release_tag = i.tag_name
+      last_release_tag = tag_name
       break
 
   default_cms_dist_branch = dist_repo.default_branch

--- a/create-new-data-pr.py
+++ b/create-new-data-pr.py
@@ -52,10 +52,9 @@ if __name__ == "__main__":
   last_release_tag = None
   releases = [tag['name'] for tag in loads(urlopen("https://api.github.com/repos/%s/tags" % opts.data_repo).read())]
   for tag_name in releases:
-      if not (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", tag_name)):
-          continue #loop until it finds a tag matching the pattern
-      last_release_tag = tag_name
-      break
+      if (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", tag_name)):
+        last_release_tag = tag_name
+        break
 
   if last_release_tag:
     comparison = data_repo.compare(data_repo_base_branch, last_release_tag)
@@ -92,17 +91,9 @@ if __name__ == "__main__":
       # message should be referencing the PR that triggers this job
       new_rel = data_repo.create_git_release(new_tag, new_tag, 'Details in: '+data_repo_pr.html_url, False, False)
 
-  last_release_tag = None
-  releases = [tag['name'] for tag in loads(urlopen("https://api.github.com/repos/%s/tags" % opts.data_repo).read())]
-  for tag_name in releases:
-      if not (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", tag_name)):
-          continue #loop until it finds a tag matching the pattern
-      last_release_tag = tag_name
-      break
-
   default_cms_dist_branch = dist_repo.default_branch
   repo_name_only = opts.data_repo.split('/')[1]
-  repo_tag_pr_branch = 'update-'+repo_name_only+'-to-'+last_release_tag
+  repo_tag_pr_branch = 'update-'+repo_name_only+'-to-'+new_tag
 
   sb = dist_repo.get_branch(default_cms_dist_branch)
   dest_branch = None #

--- a/create-new-data-pr.py
+++ b/create-new-data-pr.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
       exit(0)
 
   last_release_tag = None
-  releases = data_repo.get_releases()
+  releases = sorted([tag.name for tag in data_repo.get_tags()], reverse=True)
   for i in releases:
       if not (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", i.tag_name)):
           continue #loop until it finds a tag matching the pattern
@@ -93,7 +93,7 @@ if __name__ == "__main__":
       new_rel = data_repo.create_git_release(new_tag, new_tag, 'Details in: '+data_repo_pr.html_url, False, False)
 
   last_release_tag = None
-  releases = data_repo.get_releases()
+  releases = sorted([tag.name for tag in data_repo.get_tags()], reverse=True)
   for i in releases:
       if not (re.match("^(V[0-9]{2}-[0-9]{2}-[0-9]{2})$", i.tag_name)):
           continue #loop until it finds a tag matching the pattern


### PR DESCRIPTION
following suggestion in https://github.com/cms-sw/cms-bot/pull/1466
This is tested and sorts the tags here:
https://github.com/npc-data/PhysicsTools-NanoAOD/releases
like this:
V01-07-00
V01-06-01
V01-06-00
V01-05-00
V01-04-00
V01-03-00
V01-02-06
V01-02-05
V01-02-04
V01-02-01
V01-02-00
V01-01-00
V01-00-12
V01-00-11
V01-00-10
V01-00-09
V01-00-08
V01-00-07
V01-00-06
V01-00-05
V01-00-04
V01-00-03
V01-00-02
V01-00-01
V01-00-00
although the last release/tag is 01-02-06