### PR TITLE
Init loop internal variable

### DIFF
--- a/report-pull-request-results.py
+++ b/report-pull-request-results.py
@@ -61,6 +61,7 @@ def parse_workflow_info( parts, relval_dir ):
   # it starts asumed as not found
   out_file = MATRIX_WORKFLOW_STEP_LOG_FILE_NOT_FOUND
   workflow_info[ 'step' ] = MATRIX_WORKFLOW_STEP_NA
+  out_directory = None
   for i in range( 0 , len( parts ) ):
     current_part = parts[ i ]
     if ( current_part == 'cd' ):


### PR DESCRIPTION
a test failed
https://cmssdt.cern.ch/jenkins/job/ib-run-pr-relvals/672/consoleFull
with:
`UnboundLocalError: local variable 'out_directory' referenced before assignment`
because the variable didn't exist outside the loop's scope. Maybe a condition exists in which the var is not set in that loop