### PR TITLE
 Update tag versions on non-default branches

### DIFF
--- a/create-new-data-pr.py
+++ b/create-new-data-pr.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
   data_pr_base_branch = data_repo_pr.base.ref
   data_repo_default_branch = data_repo.default_branch
   # create master just to exist on the cms-data repo if it doesn't
-  if data_repo_default_branch == "main":
+  if data_repo_default_branch != "master":
       if "master" not in [branch.name for branch in data_repo.get_branches()]:
           data_repo.create_git_ref(ref='refs/heads/master', sha=data_repo.get_branch(data_repo_default_branch).commit.sha)
 

--- a/create-new-data-pr.py
+++ b/create-new-data-pr.py
@@ -107,12 +107,7 @@ if __name__ == "__main__":
           thrd = '00'
           print('files were modified, update mid version and reset minor', sec, thrd)
       new_tag = 'V'+first+'-'+sec+'-'+thrd
-      # message should be referencing the PR that triggers this job
-      pr_branch_sha = data_repo.get_branch(data_pr_base_branch).commit.sha
-      #there is a bug in old versions, we need this three calls instead of one: https://github.com/PyGithub/PyGithub/issues/1336
-      gh_tag = data_repo.create_git_tag(tag=new_tag,message='Details in: '+data_repo_pr.html_url,object=pr_branch_sha,type='tag type')
-      tag_ref = data_repo.create_git_ref(ref='refs/tags/'+new_tag, sha=gh_tag.sha)
-      new_rel = data_repo.create_git_release(new_tag, new_tag, 'Details in: '+data_repo_pr.html_url, False, False)
+      tag_ref = data_repo.create_git_ref(ref='refs/tags/'+new_tag, sha=data_repo.get_branch(data_pr_base_branch).commit.sha)
 
   default_cms_dist_branch = dist_repo.default_branch
   repo_name_only = opts.data_repo.split('/')[1]

--- a/create-new-data-pr.py
+++ b/create-new-data-pr.py
@@ -55,12 +55,11 @@ if __name__ == "__main__":
   last_release_tag = None
   repo_name_only = opts.data_repo.split("/")[1]
   #find the last tag on the default branch, which is needed in all cases
-  err, out = run_cmd("rm -rf %s; git clone git@github.com:%s && cd %s && git checkout %s && git log --pretty=\'%%s, %%d\' %s | grep tag:" % (repo_name_only, opts.data_repo, repo_name_only, data_repo_default_branch, data_repo_default_branch))
-
+  err, out = run_cmd("rm -rf repo && git clone --bare https://github.com/%s -b %s repo && GIT_DIR=repo git log --pretty='%%d'" % (opts.data_repo, data_repo_default_branch))
   last_release_tag = get_tag_from_string(out)
 
   if (data_pr_base_branch != data_repo_default_branch):
-      err, o = run_cmd("cd %s && git checkout %s && git log --pretty=\'%%s, %%d\' %s | grep tag:" % (repo_name_only, data_pr_base_branch, data_pr_base_branch))
+      err, o = run_cmd("rm -rf repo && git clone --bare https://github.com/%s -b %s repo && GIT_DIR=repo git log --pretty='%%d'" % (opts.data_repo, data_pr_base_branch))
       non_default_branch_last_tag = get_tag_from_string(o)
       if not non_default_branch_last_tag:
           print('Tags doesn\'t exist yet on %s branch, please create one manually first' % data_pr_base_branch)


### PR DESCRIPTION
This updates non default branches given they has at least one manually created tag
The suggested usage in here https://github.com/cms-data/RecoBTag-Combined/issues/41 
doesn't work because when the PR is merged the last sha of the branch changes and doesn't match the
last tag on it, and the job is always first merging the PR and then attempt to tag the branch.
Tested for
default branch
non-default with tags - in most cases the non default is branched from the default and has some tags
non-default without any tags - orphan branch with 0 tags
