### PR TITLE
Split profiling workflows the same way for igprof and profiling jobs. 

### DIFF
--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -13,7 +13,7 @@ for prof in ${PROFILES} ; do
     if [[ $WORKFLOWS = *all* ]];  then
         WF="-i all -l $WORKFLOW"
     else
-        WF="-l $WORKFLOW"
+        WF="-w upgrade -l $WORKFLOW"
     fi
     if [ "$prof" = "mp" ];then
       runTheMatrix.py $WF --command "-n $EVENTS --profile $prof --no_exec" 2>&1 | tee runTheMatrix.log

--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -9,7 +9,7 @@ if [ "X$EVENTS" = "X" ] ; then EVENTS=100; fi
 for prof in ${PROFILES} ; do
   mkdir -p $WORKSPACE/igprof/${prof}
   cd $WORKSPACE/igprof/${prof}
-  for WORKFLOW in `echo $WORKFLOWS | sed 's|-l||;s|,| |g;s|-i all||'`;do
+  for WORKFLOW in `echo $WORKFLOWS | sed 's|-l ||;s|,| |g;s|-i all||'`;do
     if [[ $WORKFLOWS = *all* ]];  then
         WF="-i all -l $WORKFLOW"
     else
@@ -17,7 +17,7 @@ for prof in ${PROFILES} ; do
     fi
     if [ "$prof" = "mp" ];then
       runTheMatrix.py $WF --command "-n $EVENTS --profile $prof --no_exec" 2>&1 | tee runTheMatrix.log
-      cd [0-9]*
+      cd $WORKFLOW*
       for f in $(ls *GEN_SIM.py); do
          igprof -mp -t cmsRunGlibC -- cmsRunGlibC $f 2>&1 | tee ${f//.py/.log}
       done

--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -16,7 +16,7 @@ for prof in ${PROFILES} ; do
         WF="-w upgrade -l $WORKFLOW"
     fi
     if [ "$prof" = "mp" ];then
-      runTheMatrix.py $WF --command "-n $EVENTS --profile $prof --no_exec" 2>&1 | tee runTheMatrix.log
+      runTheMatrix.py $WF --command "-n $EVENTS --profile $prof --no_exec" 2>&1 | tee  ./runTheMatrix.log
       cd $WORKFLOW*
       for f in $(ls *GEN_SIM.py); do
          igprof -mp -t cmsRunGlibC -- cmsRunGlibC $f 2>&1 | tee ${f//.py/.log}
@@ -26,7 +26,8 @@ for prof in ${PROFILES} ; do
       done
       cd -
     else
-      runTheMatrix.py $WF --command "-n $EVENTS --profile $prof" 2>&1 | tee runTheMatrix.log
+      runTheMatrix.py $WF --command "-n $EVENTS --profile $prof" 2>&1 | tee ./runTheMatrix.log
+      mv runTheMatrix.log $(ls -d $WORKFLOW*)
     fi
   done
   for hpwf in $PROFILING_WORKFLOWS; do
@@ -47,16 +48,16 @@ for prof in ${PROFILES} ; do
     DIRNAME=$(dirname $f)
     OUTFILE=${BASENAME//.gz/.txt}
     if [ "$prof" = "pp" ]; then
-        ( igprof-analyse -v -d -g $f > "RES_CPU_${OUTFILE}" ) || ERR=1
+        ( igprof-analyse -v -d -g $f > "$DIRNAME/RES_CPU_${OUTFILE}" ) || ERR=1
         if [[ $OUTFILE == "step3"*"_EndOfJob.txt"  && $WORKFLOWS != "-i all -l 13"* ]];then
-            mv RES_CPU_$OUTFILE RES_CPU_step3.txt
-            export IGREP=RES_CPU_step3.txt
-            export IGSORT=sorted_RES_CPU_step3.txt
+            mv $DIRNAME/RES_CPU_$OUTFILE $DIRNAME/RES_CPU_step3.txt
+            export IGREP=$DIRNAME/RES_CPU_step3.txt
+            export IGSORT=$DIRNAME/sorted_RES_CPU_step3.txt
             awk -v module=doEvent 'BEGIN { total = 0; } { if(substr($0,0,1)=="-"){good = 0;}; if(good&&length($0)>0){print $0; total += $3;}; if(substr($0,0,1)=="["&&index($0,module)!=0) {good = 1;} } END { print "Total: "total } ' ${IGREP} | sort -n -r -k1 | awk '{ if(index($0,"Total: ")!=0){total=$0;} else{print$0;} } END { print total; }' > ${IGSORT} 2>&1 || ERR=1
         fi
     fi
     if [ "$prof" = "mp" ]; then
-        ( igprof-analyse -v -d -g -r MEM_LIVE $f > "RES_MEM_${OUTFILE}" ) || ERR=1
+        ( igprof-analyse -v -d -g -r MEM_LIVE $f > "$DIRNAME/RES_MEM_${OUTFILE}" ) || ERR=1
         OUTFILE=${BASENAME//.gz/.sql3}
         ( igprof-analyse --sqlite -v -d -g -r MEM_LIVE $f > $f.MEM_LIVE.sql ) || ERR=1
         ${CMS_BOT_DIR}/fix-igprof-sql.py $f.MEM_LIVE.sql | sqlite3 "$DIRNAME/MEM_LIVE_${OUTFILE}" > $DIRNAME/${OUTFILE}.MEM_LIVE.log || ERR=1

--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -9,19 +9,21 @@ if [ "X$EVENTS" = "X" ] ; then EVENTS=100; fi
 for prof in ${PROFILES} ; do
   mkdir -p $WORKSPACE/igprof/${prof}
   cd $WORKSPACE/igprof/${prof}
-  if [ "$prof" = "mp" ];then
-    runTheMatrix.py $WORKFLOWS --ibeos --command "-n $EVENTS --profile $prof --no_exec" 2>&1 | tee runTheMatrix.log
-    cd [0-9]*
-    for f in $(ls *GEN_SIM.py); do
-       igprof -mp -t cmsRunGlibC -- cmsRunGlibC $f 2>&1 | tee ${f//.py/.log}
-    done
-    for f in $(ls -1 step*.py| sort); do
-       igprof -mp -t cmsRunGlibC -- cmsRunGlibC $f 2>&1 | tee ${f//.py/.log}
-    done
-    cd -
-  else
-    runTheMatrix.py $WORKFLOWS --ibeos --command "-n $EVENTS --profile $prof" 2>&1 | tee runTheMatrix.log
-  fi
+  for WORKFLOW in $(echo $WORKFLOWS | sed 's|-l||;s|,| |');do
+    if [ "$prof" = "mp" ];then
+      runTheMatrix.py -l $WORKFLOW --command "-n $EVENTS --profile $prof --no_exec" 2>&1 | tee runTheMatrix.log
+      cd [0-9]*
+      for f in $(ls *GEN_SIM.py); do
+         igprof -mp -t cmsRunGlibC -- cmsRunGlibC $f 2>&1 | tee ${f//.py/.log}
+      done
+      for f in $(ls -1 step*.py| sort); do
+         igprof -mp -t cmsRunGlibC -- cmsRunGlibC $f 2>&1 | tee ${f//.py/.log}
+      done
+      cd -
+    else
+      runTheMatrix.py -l $WORKFLOW --command "-n $EVENTS --profile $prof" 2>&1 | tee runTheMatrix.log
+    fi
+  done
   for hpwf in $PROFILING_WORKFLOWS; do
     for s in step3 step4 ; do
       if [ $(ls -d ${hpwf}_*/${s}.root | wc -l) -eq 0 ] ; then continue ; fi

--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -4,14 +4,19 @@ case $CMS_BOT_DIR in /*) ;; *) CMS_BOT_DIR=$(pwd)/${CMS_BOT_DIR} ;; esac
 WORKFLOWS=$1
 PROFILES=$2
 EVENTS=$3
-PROFILING_WORKFLOWS=$(grep "PR_TEST_MATRIX_EXTRAS_PROFILING=" $CMS_BOT_DIR/cmssw-pr-test-config | sed 's|.*=||;s|,| |')
+PROFILING_WORKFLOWS=$(grep "PR_TEST_MATRIX_EXTRAS_PROFILING=" $CMS_BOT_DIR/cmssw-pr-test-config | sed 's|.*=||;s|,| |g')
 if [ "X$EVENTS" = "X" ] ; then EVENTS=100; fi
 for prof in ${PROFILES} ; do
   mkdir -p $WORKSPACE/igprof/${prof}
   cd $WORKSPACE/igprof/${prof}
-  for WORKFLOW in $(echo $WORKFLOWS | sed 's|-l||;s|,| |');do
+  for WORKFLOW in `echo $WORKFLOWS | sed 's|-l||;s|,| |g;s|-i all||'`;do
+    if [[ $WORKFLOWS = *all* ]];  then
+        WF="-i all -l $WORKFLOW"
+    else
+        WF="-l $WORKFLOW"
+    fi
     if [ "$prof" = "mp" ];then
-      runTheMatrix.py -l $WORKFLOW --command "-n $EVENTS --profile $prof --no_exec" 2>&1 | tee runTheMatrix.log
+      runTheMatrix.py $WF --command "-n $EVENTS --profile $prof --no_exec" 2>&1 | tee runTheMatrix.log
       cd [0-9]*
       for f in $(ls *GEN_SIM.py); do
          igprof -mp -t cmsRunGlibC -- cmsRunGlibC $f 2>&1 | tee ${f//.py/.log}
@@ -21,7 +26,7 @@ for prof in ${PROFILES} ; do
       done
       cd -
     else
-      runTheMatrix.py -l $WORKFLOW --command "-n $EVENTS --profile $prof" 2>&1 | tee runTheMatrix.log
+      runTheMatrix.py $WF --command "-n $EVENTS --profile $prof" 2>&1 | tee runTheMatrix.log
     fi
   done
   for hpwf in $PROFILING_WORKFLOWS; do

--- a/schedule-additional-tests
+++ b/schedule-additional-tests
@@ -10,6 +10,7 @@ for x in `grep ADDITIONAL_TESTS=  $CONFIG_MAP | grep "SCRAM_ARCH=$ARCHITECTURE;"
   if [ "$x" == "baseline" ]; then
     echo "REAL_ARCH=-GenuineIntel" >> ${pfile}
   fi
+  PROFILING_WORKFLOWS=$(grep "PR_TEST_MATRIX_EXTRAS_PROFILING=" $CMS_BOT_DIR/cmssw-pr-test-config | sed 's|.*=||' | tr ',' ' ')  
   if [ "$x" = "igprof-pp" -o  "$x" = "igprof-mp"  ] ; then
     prof=$(echo $x | sed 's|igprof-||')
     sed -i -e "s|ADDITIONAL_TEST_NAME=$x|ADDITIONAL_TEST_NAME=igprof|" ${pfile}
@@ -19,7 +20,6 @@ for x in `grep ADDITIONAL_TESTS=  $CONFIG_MAP | grep "SCRAM_ARCH=$ARCHITECTURE;"
     cp ${pfile} ${nfile}
     echo "WORKFLOWS=-i all -l $wf" >> ${nfile}
     echo "EVENTS=100" >> ${nfile}
-    PROFILING_WORKFLOWS=$(echo $(grep "PR_TEST_MATRIX_EXTRAS_PROFILING=" $CMS_BOT_DIR/cmssw-pr-test-config | sed 's|.*=||'), | tr ' ' ','| tr ',' '\n' | grep '^[0-9]' | sort | uniq | tr '\n' ',' | sed 's|,*$||')
     for wf in $PROFILING_WORKFLOWS; do
       nfile=$WORKSPACE/auto-$x-${wf}-properties
       cp ${pfile} ${nfile}
@@ -29,7 +29,6 @@ for x in `grep ADDITIONAL_TESTS=  $CONFIG_MAP | grep "SCRAM_ARCH=$ARCHITECTURE;"
     rm -f ${pfile}
   fi
   if [ "$x" = "profiling" ] ; then
-    PROFILING_WORKFLOWS=$(grep "PR_TEST_MATRIX_EXTRAS_PROFILING=" $CMS_BOT_DIR/cmssw-pr-test-config | sed 's|.*=||' | tr ',' ' ')
     for wf in $PROFILING_WORKFLOWS; do
       nfile=$WORKSPACE/auto-$x-${wf}-properties
       cp ${pfile} ${nfile}


### PR DESCRIPTION
Each job gets its own properties file. The run-ib-igprof script was also updated to split the WORKFLOWS var for use in a loop.