### PR TITLE
Run custom CMS clang-tidy checks in PR testing.

### DIFF
--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -702,8 +702,8 @@ if [ "X$DO_STATIC_CHECKS" = "Xtrue" -a "X$CMSSW_PR" != X -a "$RUN_TESTS" = "true
   echo 'CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See Log,llvm-analysis/runCMSClangTidyChecks.log' >> ${RESULTS_DIR}/static.txt
   echo '--------------------------------------'
   USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' scram b -k -j ${NCPU2} code-checks-run SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
-  if $IS_DEV_BRANCH && [ $(grep ': warning: call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | wc -l) -gt 0 ]; then
-    grep ': warning: call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | sort -u >> $WORKSPACE/llvm-analysis/cmsclangtidy.txt
+  if $IS_DEV_BRANCH && [ $(grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get' | wc -l) -gt 0 ]; then
+    grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get'| sort -u >> $WORKSPACE/llvm-analysis/cmsclangtidy.txt
     echo "CMS_CLANG_TIDY_CHECKS;ERROR,CMS clang-tidy checks EventSetupRecord::get warnings,See warnings log,llvm-analysis/cmsclangtidy.txt" >> ${RESULTS_DIR}/static.txt
   else
     echo "CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See Log,llvm-analysis/runCMSClangTidyChecks.log" >> ${RESULTS_DIR}/static.txt

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -701,18 +701,16 @@ if [ "X$DO_STATIC_CHECKS" = "Xtrue" -a "X$CMSSW_PR" != X -a "$RUN_TESTS" = "true
 
   echo 'CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See clang-tidy log,llvm-analysis/runCMSClangTidyChecks.log' >> ${RESULTS_DIR}/clangtidy.txt
   echo '--------------------------------------'
-  touch all-changed-files.txt
-  pushd src; git diff --name-only $CMSSW_IB  > ../all-changed-files.txt;popd
-  grep -v '^[^/]*/[^/]*/test/' all-changed-files.txt > code-checks-files.txt          || true
-  grep -v '^[^/]*/[^/]*/data/' code-checks-files.txt > filename-code-checks-files.txt || true
-  $CMS_BOT_DIR/cms-filename-checks.py filename-code-checks-files.txt $CMSSW_RELEASE_BASE/src > invalid-filenames.txt || true
   echo "Changed files:"
-  cat code-checks-files.txt
   echo ""
-  USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' scram b -k -j ${NCPU2} code-checks USER_CODE_CHECKS_FILE="code-checks-files.txt" SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
-  if $IS_DEV_BRANCH && [ $(grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get' | wc -l) -gt 0 ]; then
+  cat $WORKSPACE/changed-files
+  echo ""
+  USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' scram b -k -j ${NCPU2} code-checks USER_CODE_CHECKS_FILE="$WORKSPACE/changed-files" SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
+  warncount=$(grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get' | wc -l) 
+  if $IS_DEV_BRANCH && [ $warncount -gt 0 ]; then
     grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get'| sort -u > $WORKSPACE/llvm-analysis/cmsclangtidy.txt
     echo "CMS_CLANG_TIDY_CHECKS_ESRGET;ERROR,CMS clang-tidy checks EventSetupRecord::get warnings,See clang-tidy warnings log,llvm-analysis/cmsclangtidy.txt" >> ${RESULTS_DIR}/clangtidy.txt
+    echo "**CMS Clang-Tidy warnings**: There are $warncount Clang-Tidy warnings. See ${PR_RESULT_URL}/llvm-analysis/cmsclangtidy.txt for details." >> ${RESULTS_DIR}/09-report.res
   else
     echo "CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See clang-tidy log,llvm-analysis/runCMSClangTidyChecks.log" >> ${RESULTS_DIR}/clangtidy.txt
   fi

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -701,7 +701,15 @@ if [ "X$DO_STATIC_CHECKS" = "Xtrue" -a "X$CMSSW_PR" != X -a "$RUN_TESTS" = "true
 
   echo 'CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See clang-tidy log,llvm-analysis/runCMSClangTidyChecks.log' >> ${RESULTS_DIR}/clangtidy.txt
   echo '--------------------------------------'
-  USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' scram b -k -j ${NCPU2} code-checks-run SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
+  UP_DIR=.
+  curl -s -L https://patch-diff.githubusercontent.com/raw/${REPOSITORY}/pull/${PULL_REQUEST}.patch | grep '^diff --git ' | sed 's|.* a/||;s|  *b/.*||' | sort | uniq > ${UP_DIR}/all-changed-files.txt
+  grep -v '^[^/]*/[^/]*/test/' ${UP_DIR}/all-changed-files.txt > ${UP_DIR}/code-checks-files.txt          || true
+  grep -v '^[^/]*/[^/]*/data/' ${UP_DIR}/code-checks-files.txt > ${UP_DIR}/filename-code-checks-files.txt || true
+  $CMS_BOT_DIR/cms-filename-checks.py ${UP_DIR}/filename-code-checks-files.txt $CMSSW_RELEASE_BASE/src > ${UP_DIR}/invalid-filenames.txt || true
+  echo "Changed files:"
+  cat ${UP_DIR}/code-checks-files.txt
+  echo ""
+  USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' USER_CODE_CHECKS_FILE="${UP_DIR}/code-checks-files.txt" scram b -k -j ${NCPU2} code-checks-run SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
   if $IS_DEV_BRANCH && [ $(grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get' | wc -l) -gt 0 ]; then
     grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get'| sort -u > $WORKSPACE/llvm-analysis/cmsclangtidy.txt
     echo "CMS_CLANG_TIDY_CHECKS_ESRGET;ERROR,CMS clang-tidy checks EventSetupRecord::get warnings,See clang-tidy warnings log,llvm-analysis/cmsclangtidy.txt" >> ${RESULTS_DIR}/clangtidy.txt

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -699,14 +699,14 @@ if [ "X$DO_STATIC_CHECKS" = "Xtrue" -a "X$CMSSW_PR" != X -a "$RUN_TESTS" = "true
   echo 'END OF STATIC CHECKS'
   echo '--------------------------------------'
 
-  echo 'CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See Log,llvm-analysis/runCMSClangTidyChecks.log' >> ${RESULTS_DIR}/static.txt
+  echo 'CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See clang-tidy log,llvm-analysis/runCMSClangTidyChecks.log' >> ${RESULTS_DIR}/clangtidy.txt
   echo '--------------------------------------'
   USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' scram b -k -j ${NCPU2} code-checks-run SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
   if $IS_DEV_BRANCH && [ $(grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get' | wc -l) -gt 0 ]; then
-    grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get'| sort -u >> $WORKSPACE/llvm-analysis/cmsclangtidy.txt
-    echo "CMS_CLANG_TIDY_CHECKS;ERROR,CMS clang-tidy checks EventSetupRecord::get warnings,See warnings log,llvm-analysis/cmsclangtidy.txt" >> ${RESULTS_DIR}/static.txt
+    grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get'| sort -u > $WORKSPACE/llvm-analysis/cmsclangtidy.txt
+    echo "CMS_CLANG_TIDY_CHECKS_ESRGET;ERROR,CMS clang-tidy checks EventSetupRecord::get warnings,See clang-tidy warnings log,llvm-analysis/cmsclangtidy.txt" >> ${RESULTS_DIR}/clangtidy.txt
   else
-    echo "CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See Log,llvm-analysis/runCMSClangTidyChecks.log" >> ${RESULTS_DIR}/static.txt
+    echo "CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See clang-tidy log,llvm-analysis/runCMSClangTidyChecks.log" >> ${RESULTS_DIR}/clangtidy.txt
   fi
   echo 'END OF CLANG-TIDY CHECKS'
   echo '--------------------------------------'

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -690,12 +690,25 @@ if [ "X$DO_STATIC_CHECKS" = "Xtrue" -a "X$CMSSW_PR" != X -a "$RUN_TESTS" = "true
   cp -R $WORKSPACE/$CMSSW_IB/llvm-analysis/*/* $WORKSPACE/llvm-analysis || true
   if $IS_DEV_BRANCH && [ $(grep ': error: ' $WORKSPACE/llvm-analysis/runStaticChecks.log | wc -l) -gt 0 ] ; then
     echo "EDM_ML_DEBUG_CHECKS;ERROR,Static Check build log,See Log,llvm-analysis/runStaticChecks.log" >> ${RESULTS_DIR}/static.txt
-  elif $IS_DEV_BRANCH && [ $(grep ': warning: ' $WORKSPACE/llvm-analysis/runStaticChecks.log | grep edm::eventsetup::EventSetupRecord::get | wc -l) -gt 0 ] ; then
-    echo "EDM_ML_DEBUG_CHECKS;WARNING,Static Check build log,See Log,llvm-analysis/runStaticChecks.log" >> ${RESULTS_DIR}/static.txt
+  elif $IS_DEV_BRANCH && [ $(grep ': warning: ' $WORKSPACE/llvm-analysis/runStaticChecks.log | grep '[threadsafety.ESRecordGetChecker]' | wc -l) -gt 0 ] ; then
+    grep ': warning: ' $WORKSPACE/llvm-analysis/runStaticChecks.log | grep edm::eventsetup::EventSetupRecord::get | sort -u > $WORKSPACE/llvm-analysis/esrget-sa.txt
+    echo "STATIC_CHECK_ESRGET;ERROR,Static analyzer EventSetupRecord::get warnings,See warnings log,llvm-analysis/esrget-sa.txt" >> ${RESULTS_DIR}/static.txt
   else
     echo "EDM_ML_DEBUG_CHECKS;OK,Static Check build log,See Log,llvm-analysis/runStaticChecks.log" >> ${RESULTS_DIR}/static.txt
   fi
   echo 'END OF STATIC CHECKS'
+  echo '--------------------------------------'
+
+  echo 'CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See Log,llvm-analysis/runCMSClangTidyChecks.log' >> ${RESULTS_DIR}/static.txt
+  echo '--------------------------------------'
+  USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' scram b -k -j ${NCPU2} code-checks-run SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
+  if $IS_DEV_BRANCH && [ $(grep ': warning: call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | wc -l) -gt 0 ]; then
+    grep ': warning: call of function EventSetupRecord::get(ESHandle&) is deprecated and should be replaced with a call to EventSetup::getHandle(ESGetToken&' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | sort -u >> $WORKSPACE/llvm-analysis/cmsclangtidy.txt
+    echo "CMS_CLANG_TIDY_CHECKS;ERROR,CMS clang-tidy checks EventSetupRecord::get warnings,See warnings log,llvm-analysis/cmsclangtidy.txt" >> ${RESULTS_DIR}/static.txt
+  else
+    echo "CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See Log,llvm-analysis/runCMSClangTidyChecks.log" >> ${RESULTS_DIR}/static.txt
+  fi
+  echo 'END OF CLANG-TIDY CHECKS'
   echo '--------------------------------------'
   popd
 fi

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -701,7 +701,7 @@ if [ "X$DO_STATIC_CHECKS" = "Xtrue" -a "X$CMSSW_PR" != X -a "$RUN_TESTS" = "true
 
   echo 'CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See clang-tidy log,llvm-analysis/runCMSClangTidyChecks.log' >> ${RESULTS_DIR}/clangtidy.txt
   echo '--------------------------------------'
-  UP_DIR=.
+  UP_DIR=$PWD
   curl -s -L https://patch-diff.githubusercontent.com/raw/${REPOSITORY}/pull/${PULL_REQUEST}.patch | grep '^diff --git ' | sed 's|.* a/||;s|  *b/.*||' | sort | uniq > ${UP_DIR}/all-changed-files.txt
   grep -v '^[^/]*/[^/]*/test/' ${UP_DIR}/all-changed-files.txt > ${UP_DIR}/code-checks-files.txt          || true
   grep -v '^[^/]*/[^/]*/data/' ${UP_DIR}/code-checks-files.txt > ${UP_DIR}/filename-code-checks-files.txt || true
@@ -709,7 +709,7 @@ if [ "X$DO_STATIC_CHECKS" = "Xtrue" -a "X$CMSSW_PR" != X -a "$RUN_TESTS" = "true
   echo "Changed files:"
   cat ${UP_DIR}/code-checks-files.txt
   echo ""
-  USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' USER_CODE_CHECKS_FILE="${UP_DIR}/code-checks-files.txt" scram b -k -j ${NCPU2} code-checks-run SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
+  USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' scram b -k -j ${NCPU2} code-checks USER_CODE_CHECKS_FILE="${UP_DIR}/code-checks-files.txt" SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
   if $IS_DEV_BRANCH && [ $(grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get' | wc -l) -gt 0 ]; then
     grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get'| sort -u > $WORKSPACE/llvm-analysis/cmsclangtidy.txt
     echo "CMS_CLANG_TIDY_CHECKS_ESRGET;ERROR,CMS clang-tidy checks EventSetupRecord::get warnings,See clang-tidy warnings log,llvm-analysis/cmsclangtidy.txt" >> ${RESULTS_DIR}/clangtidy.txt

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -698,24 +698,25 @@ if [ "X$DO_STATIC_CHECKS" = "Xtrue" -a "X$CMSSW_PR" != X -a "$RUN_TESTS" = "true
   fi
   echo 'END OF STATIC CHECKS'
   echo '--------------------------------------'
-
-  echo 'CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See clang-tidy log,llvm-analysis/runCMSClangTidyChecks.log' >> ${RESULTS_DIR}/clangtidy.txt
-  echo '--------------------------------------'
-  echo "Changed files:"
-  echo ""
-  cat $WORKSPACE/changed-files
-  echo ""
-  USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' scram b -k -j ${NCPU2} code-checks USER_CODE_CHECKS_FILE="$WORKSPACE/changed-files" SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
-  warncount=$(grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get' | wc -l) 
-  if $IS_DEV_BRANCH && [ $warncount -gt 0 ]; then
-    grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get'| sort -u > $WORKSPACE/llvm-analysis/cmsclangtidy.txt
-    echo "CMS_CLANG_TIDY_CHECKS_ESRGET;ERROR,CMS clang-tidy checks EventSetupRecord::get warnings,See clang-tidy warnings log,llvm-analysis/cmsclangtidy.txt" >> ${RESULTS_DIR}/clangtidy.txt
-    echo "**CMS Clang-Tidy warnings**: There are $warncount Clang-Tidy warnings. See ${PR_RESULT_URL}/llvm-analysis/cmsclangtidy.txt for details." >> ${RESULTS_DIR}/09-report.res
-  else
-    echo "CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See clang-tidy log,llvm-analysis/runCMSClangTidyChecks.log" >> ${RESULTS_DIR}/clangtidy.txt
+  if $IS_DEV_BRANCH ;then 
+    echo 'CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See clang-tidy log,llvm-analysis/runCMSClangTidyChecks.log' >> ${RESULTS_DIR}/clangtidy.txt
+    echo '--------------------------------------'
+    echo "Changed files:"
+    echo ""
+    cat $WORKSPACE/changed-files
+    echo ""
+    USER_CXXFLAGS='-Wno-register -DEDM_ML_DEBUG -w' SCRAM_IGNORE_PACKAGES="Fireworks/% Utilities/StaticAnalyzers" USER_CODE_CHECKS='cms*' scram b -k -j ${NCPU2} code-checks USER_CODE_CHECKS_FILE="$WORKSPACE/changed-files" SCRAM_IGNORE_SUBDIRS=test 2>&1 | tee -a $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log
+    warncount=$(grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get' | wc -l) 
+    if [ $warncount -gt 0 ]; then
+      grep ': warning: ' $WORKSPACE/llvm-analysis/runCMSClangTidyChecks.log | grep 'call of function EventSetupRecord::get'| sort -u > $WORKSPACE/llvm-analysis/cmsclangtidy.txt
+      echo "CMS_CLANG_TIDY_CHECKS_ESRGET;ERROR,CMS clang-tidy checks EventSetupRecord::get warnings,See clang-tidy warnings log,llvm-analysis/cmsclangtidy.txt" >> ${RESULTS_DIR}/clangtidy.txt
+      echo "**CMS Clang-Tidy warnings**: There are $warncount Clang-Tidy warnings. See ${PR_RESULT_URL}/llvm-analysis/cmsclangtidy.txt for details." >> ${RESULTS_DIR}/09-report.res
+    else
+      echo "CMS_CLANG_TIDY_CHECKS;OK,CMS clang-tidy checks output,See clang-tidy log,llvm-analysis/runCMSClangTidyChecks.log" >> ${RESULTS_DIR}/clangtidy.txt
+    fi
+    echo 'END OF CLANG-TIDY CHECKS'
+    echo '--------------------------------------'
   fi
-  echo 'END OF CLANG-TIDY CHECKS'
-  echo '--------------------------------------'
   popd
 fi
 


### PR DESCRIPTION
Alternative way to run EventSetupRecord::get checker.
Resolves makortel/framework#69