### PR TITLE
Update reco release profiling

### DIFF
--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -9,6 +9,8 @@ import shutil
 def prepareMatrixWF(workflow_number, num_events):
     cmd = [
          "runTheMatrix.py",
+         "-w",
+         "upgrade",
          "-l",
          workflow_number,
          "--command",
@@ -53,7 +55,6 @@ echo "{}"
     return s
 
 def configureProfilingSteps(cmsdriver_lines, num_events):
-    assert(len(cmsdriver_lines) == 4)
     assert("step1" in cmsdriver_lines[0])
     assert("step2" in cmsdriver_lines[1])
     assert("step3" in cmsdriver_lines[2])

--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -114,6 +114,9 @@ def writeProfilingScript(wfdir, runscript, cmdlist):
 
         #abort on error
         fi.write("set -e\n")
+        
+        #print commands verbosely
+        fi.write("set -x\n")
         for cmd in cmdlist:
             fi.write(cmd + '\n')
 


### PR DESCRIPTION
This has already been tested at https://cmssdt.cern.ch/jenkins/job/release-run-reco-profiling/76/console.
We now profile both 23434.21 (100 events) and 11834.21 (400 events).