### PR TITLE
clean-up tracking-pog configuration in watchers.yaml

### DIFF
--- a/watchers.yaml
+++ b/watchers.yaml
@@ -76,6 +76,7 @@ tracking-pog:
 - RecoLocalTracker
 - RecoPixelVertexing
 - RecoTracker
+- RecoLocalTracker
 - RecoVertex
 - SimDataFormats/DigiSimLinks
 - SimDataFormats/Track
@@ -925,11 +926,6 @@ threus:
 - Validation/Tracker
 thuer:
 - GeneratorInterface/SherpaInterface
-tracking-pog:
-- RecoTracker
-- RecoLocalTracker
-- TrackingTools
-- TrackPropagation
 trocino:
 - Alignment/MuonAlignment
 - Alignment/MuonAlignmentAlgorithms


### PR DESCRIPTION
Merging two occurrences of `tracking-pog` in `watchers.yaml`.
Was preventing me to be tagged (see https://github.com/cms-sw/cms-bot/pull/1571#issuecomment-870471591).

@VinInn, @mtosi @JanFSchulte FYI.

@vmariani, you might want to be added in here as well.