### PR TITLE
reco release profiling: run igprof after everything else

### DIFF
--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -98,11 +98,18 @@ def configureProfilingSteps(cmsdriver_lines, num_events):
         step4 + " &> step4.log"
     ]
 
-    #add step3 profiling
+    #add step3 and step4 basic profiles
     new_cmdlist += [
         echoBefore(step3_tmi, "step3 TimeMemoryInfo"),
         echoBefore(step3_ft, "step3 FastTimer"),
         echoBefore(step3_ig, "step3 IgProf conf"),
+        echoBefore(step4_tmi, "step4 TimeMemoryInfo"),
+        echoBefore(step4_ft, "step4 FastTimer"),
+        echoBefore(step4_ig, "step4 IgProf conf"),
+    ]
+
+    #add step3 igprof profiling
+    new_cmdlist += [
         echoBefore(igprof_s3_pp, "step3 IgProf pp"),
         "mv IgProf.1.gz step3_igprofCPU.1.gz",
         "mv IgProf.{nev}.gz step3_igprofCPU.{nev}.gz".format(nev=int(num_events/2)),
@@ -112,11 +119,8 @@ def configureProfilingSteps(cmsdriver_lines, num_events):
         "mv IgProf.{nev}.gz step3_igprofMEM.{nev}.gz".format(nev=int(num_events/2)),
         "mv IgProf.{nev}.gz step3_igprofMEM.{nev}.gz".format(nev=int(num_events-1)),
     ]
-    #add step4 profiling
+    #add step4 igprof profiling
     new_cmdlist += [
-        echoBefore(step4_tmi, "step4 TimeMemoryInfo"),
-        echoBefore(step4_ft, "step4 FastTimer"),
-        echoBefore(step4_ig, "step4 IgProf conf"),
         echoBefore(igprof_s4_pp, "step4 IgProf pp"),
         "mv IgProf.1.gz step4_igprofCPU.1.gz",
         "mv IgProf.{nev}.gz step4_igprofCPU.{nev}.gz".format(nev=int(num_events/2)),
@@ -135,8 +139,8 @@ def writeProfilingScript(wfdir, runscript, cmdlist):
         fi.write("#!/bin/bash\n")
         fi.write("ulimit -a\n")
 
-        #abort on error
-        fi.write("set -e\n")
+        #don't abort on error
+        #fi.write("set -e\n")
         
         #print commands verbosely
         fi.write("set -x\n")

--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -172,12 +172,12 @@ def copyProfilingOutputs(wfdir, out_dir, num_events):
         "step4.log",
         "step3_TimeMemoryInfo.log",
         "step3_circles.json",
+        "step4_TimeMemoryInfo.log",
+        "step4_circles.json",
         "step3_igprofCPU.gz",
         "step3_igprofMEM.1.gz",
         "step3_igprofMEM.{}.gz".format(int(num_events-1)),
         "step3_igprofMEM.{}.gz".format(int(num_events/2)),
-        "step4_TimeMemoryInfo.log",
-        "step4_circles.json",
         "step4_igprofCPU.gz",
         "step4_igprofMEM.1.gz",
         "step4_igprofMEM.{}.gz".format(int(num_events-1)),
@@ -190,7 +190,7 @@ def copyProfilingOutputs(wfdir, out_dir, num_events):
             print("copying {} to {}".format(path, out_dir))
             shutil.copy(path, out_dir)
         else:
-            raise Exception("Output {} not found or is broken".format(path))
+            print("ERROR: Output {} not found or is broken, skipping".format(path))
     return
 
 def main(wf, num_events, out_dir):


### PR DESCRIPTION
- Only changes the [reco release profiling](https://cmssdt.cern.ch/jenkins/job/release-run-reco-profiling/) functionality in the bot.
- For release-run-reco-profiling, now runs igprof after everything else (step3 and step4 circles, TimeMemory etc).
- Do not abort the jenkins job in case of missing outputs.
- Motivated by the issues with igprof in 12_0_0_pre4: https://github.com/cms-sw/cmssw/pull/34517
- Tested successfully in https://cmssdt.cern.ch/jenkins/job/release-run-reco-profiling/119

cc @cms-sw/reconstruction-l2 