### PR TITLE
plots for ticlTrackstersHFNose* products 

### DIFF
--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -3411,6 +3411,14 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
 
       ticlCands("ticlCandidateFromTracksters_");
       ticlCands("ticlTrackstersMerge_");
+
+      //HFNose
+      tracksters("ticlTrackstersHFNoseEM_");
+      tracksters("ticlTrackstersHFNoseHAD_");
+      tracksters("ticlTrackstersHFNoseMIP_");
+      tracksters("ticlTrackstersHFNoseTrkEM_");
+      tracksters("ticlTrackstersHFNoseTrk_");
+
       // miniaod
       superClusters("reducedEgamma_reducedSuperClusters");
       superClusters("reducedEgamma_reducedOOTSuperClusters");


### PR DESCRIPTION
(these are currently present only in special HFNose workflows; one in the short matrix)

there is no coverage for these in the DQM; so this monitoring would be a good addition.

This PR is also in sync with cms-sw/cmssw#34605
