### PR TITLE
Allow character ' in relvals options

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -39,7 +39,7 @@ CMSSW_QUEUE_PATTERN='CMSSW_[0-9]+_[0-9]+_([A-Z][A-Z0-9]+_|)X'
 CMSSW_PACKAGE_PATTERN='[A-Z][a-zA-Z0-9]+(/[a-zA-Z0-9]+|)'
 ARCH_PATTERN='[a-z0-9]+_[a-z0-9]+_[a-z0-9]+'
 CMSSW_RELEASE_QUEUE_PATTERN=format('(%(cmssw)s|%(arch)s|%(cmssw)s/%(arch)s)', cmssw=CMSSW_QUEUE_PATTERN, arch=ARCH_PATTERN)
-RELVAL_OPTS="^[-][a-zA-Z0-9_.,\s-]+$"
+RELVAL_OPTS="^[-][a-zA-Z0-9_.,\s-]+$'"
 CLOSE_REQUEST=re.compile('^\s*((@|)cmsbuild\s*[,]*\s+|)(please\s*[,]*\s+|)close\s*$',re.I)
 CMS_PR_PATTERN=format('(#[1-9][0-9]*|(%(cmsorgs)s)/+[a-zA-Z0-9_-]+#[1-9][0-9]*|https://+github.com/+(%(cmsorgs)s)/+[a-zA-Z0-9_-]+/+pull/+[1-9][0-9]*)',
                       cmsorgs='|'.join(EXTERNAL_REPOS))


### PR DESCRIPTION
This PR allows the character `'` in relvals options.
As pointed out in https://github.com/cms-sw/cmssw/pull/34599#issuecomment-890328605 this PR is not sufficient to run `--command` because of https://github.com/cms-sw/cms-bot/blob/master/pr_testing/test_multiple_prs.sh#L1002