### PR TITLE
remove kpedro88 as upgrade L2 

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -51,7 +51,6 @@ CMSSW_L2 = {
   "jordan-martins":   ["pdmv"],
   "jpata":            ["reconstruction"],
   "kmaeshima":        ["dqm"],
-  "kpedro88":         ["upgrade"],
   "kskovpen":         ["pdmv"],
   "lveldere":         ["fastsim"],
   "makortel":         ["heterogeneous", "core", "visualization", "geometry"],

--- a/watchers.yaml
+++ b/watchers.yaml
@@ -1499,6 +1499,9 @@ sobhatta:
 kpedro88:
 - HeterogeneousCore/SonicCore
 - HeterogeneousCore/SonicTriton
+- SLHCUpgradeSimulations/Configuration
+- Configuration/Geometry
+- Configuration/PyReleaseValidation
 fabiocos:
 - CondFormats/GeometryObjects
 - Configuration


### PR DESCRIPTION
Now that we have two active upgrade L2s, I'm no longer needed as a backup L2.

I've added a few packages to my watch list to keep an eye on them (where I did a lot of the setup - upgrade workflows, geometry scripts).

attn: @cms-sw/upgrade-l2 