### PR TITLE
updated list of "configdb-owners"

### DIFF
--- a/gh-teams.py
+++ b/gh-teams.py
@@ -58,7 +58,7 @@ REPO_TEAMS["cms-sw"]["Dqm-Integration-developers"] = {
   "repositories" : { "DQM-Integration": "push"}
 }
 REPO_TEAMS["cms-sw"]["configdb-owners"] = {
-  "members" : ["fwyzard", "Martin-Grunewald", "vinnie87", "Sam-Harper"],
+  "members" : ["fwyzard", "Martin-Grunewald", "Sam-Harper", "silviodonato", "missirol"],
   "repositories" : { "hlt-confdb":"admin", "web-confdb":"admin"}
 }
 REPO_TEAMS["cms-sw"]["cmsdist-writers"] = {


### PR DESCRIPTION
Update of the list `configdb-owners` for HLT, including new L1 (@silviodonato) and L2 (@missirol), plus removing developer who left.

FYI: @fwyzard @Martin-Grunewald @Sam-Harper
