### PR TITLE
Skip search for ubsan_ib-->non_ubsan

### DIFF
--- a/report-summary-merged-prs
+++ b/report-summary-merged-prs
@@ -1068,7 +1068,7 @@ def find_check_headers(comparisons, architecture):
 
 def find_ubsan_logs(comparisons, arch):
     for c in comparisons:
-        if c['compared_tags'].find('UBSAN') < 2: continue
+        if c['compared_tags'].count('UBSAN') < 2: continue
         rel_name = c['compared_tags'].split('-->')[1]
         print('Looking for ubsan results for', rel_name, '.')
         c['ubsan-logs'] = find_and_check_result(rel_name, arch, CHECK_UBSANLOG_PATH, 'wc -l {0} | cut -d " " -f1')

--- a/report-summary-merged-prs
+++ b/report-summary-merged-prs
@@ -1068,6 +1068,7 @@ def find_check_headers(comparisons, architecture):
 
 def find_ubsan_logs(comparisons, arch):
     for c in comparisons:
+        if c['compared_tags'].find('UBSAN') < 2: continue
         rel_name = c['compared_tags'].split('-->')[1]
         print('Looking for ubsan results for', rel_name, '.')
         c['ubsan-logs'] = find_and_check_result(rel_name, arch, CHECK_UBSANLOG_PATH, 'wc -l {0} | cut -d " " -f1')


### PR DESCRIPTION
the first case in this json where compared_tags is "compared_tags": "CMSSW_12_1_UBSAN_X_2021-09-22-1600-->CMSSW_12_1_X", 
https://raw.githubusercontent.com/cms-sw/cms-sw.github.io/master/data/CMSSW_12_1_UBSAN_X.json
should be skipped because it resolves to searching for CMSSW_12_1_X in ubsan_logs which will never be there
the release folder to be searched in has to be always the second  element of `rel_name = c['compared_tags'].split('-->')[1]`
and in this case will search with `find` into never existing path
