### PR TITLE
Added workflow 573.0 in to known failure for ppc64le and aarch64

### DIFF
--- a/cmssw_known_errors.py
+++ b/cmssw_known_errors.py
@@ -110,7 +110,7 @@ KNOWN_ERRORS["relvals"][RelFilter][".+_aarch64_.+"] = deepcopy(KNOWN_ERRORS["rel
 RelFilter="CMSSW_(10_([4-9]|[1-9][0-9]+)|1[1-9]|[2-9][0-9]|[1-9][0-9][0-9]+)_.+"
 KNOWN_ERRORS["relvals"][RelFilter]={}
 KNOWN_ERRORS["relvals"][RelFilter][".+_aarch64_.+"] = deepcopy(KNOWN_ERRORS["relvals"]["CMSSW_10_[0-1]_.+"][".+_aarch64_.+"])
-for wf in ["535.0", "536.0", "537.0", "538.0", "547.0", "548.0", "1361.18", "1361.181", "1362.18", "1363.18", "25211.18", "25212.18", "25213.18"]:
+for wf in ["535.0", "536.0", "537.0", "538.0", "547.0", "548.0", "573.0", "1361.18", "1361.181", "1362.18", "1363.18", "25211.18", "25212.18", "25213.18"]:
   KNOWN_ERRORS["relvals"][RelFilter][".+_aarch64_.+"][wf] = deepcopy(KNOWN_ERRORS["relvals"][RelFilter][".+_aarch64_.+"]["512.0"])
 KNOWN_ERRORS["relvals"][RelFilter][".+_ppc64le_.+"] = deepcopy(KNOWN_ERRORS["relvals"][RelFilter][".+_aarch64_.+"])
 


### PR DESCRIPTION
This tries to load a shared library bundled in gridpacks (built for x86_64)
```
Matrix_Element_Handler::BuildProcesses(): Looking for processes Library_Loader::LoadLibrary(): /home/cmsbuild/jenkins_a/workspace/ib-run-relvals/CMSSW_12_1_X_2021-09-26-2300/pyRelval/573.0_sherpa_ttbar_2j_MENLOPS_13TeV_MASTER_ExtGen+sherpa_ttbar_2j_MENLOPS_13TeV_MASTER_ExtGen+HARVESTGEN/thread122997_0/Process/Amegic/lib/libProc_P2_2.so: cannot open shared object file: No such file or directory
Library_Loader::LoadLibrary(): Failed to load library 'libProc_P2_2.so'.
Library_Loader::LoadLibrary(): /home/cmsbuild/jenkins_a/workspace/ib-run-relvals/CMSSW_12_1_X_2021-09-26-2300/pyRelval/573.0_sherpa_ttbar_2j_MENLOPS_13TeV_MASTER_ExtGen+sherpa_ttbar_2j_MENLOPS_13TeV_MASTER_ExtGen+HARVESTGEN/thread122997_0/Process/Amegic/lib/libProc_P2_2.so: cannot open shared object file: No such file or directory
Library_Loader::LoadLibrary(): Failed to load library 'libProc_P2_2.so'.

```