### PR TITLE
run wf 101.0,102.0 in multithreading mode for cmssw 12 and above

### DIFF
--- a/RelValArgs.py
+++ b/RelValArgs.py
@@ -107,6 +107,8 @@ def GetMatrixOptions(release, arch, dasfile=None):
 
 def FixWFArgs(release, arch, wf, args):
   if isThreaded(release, arch):
+    if int(release.split("_")[1])>=12:
+      return args
     NonThreadedWF = ["101.0","102.0"]
     if wf in NonThreadedWF:
       for k in [ "THREADED", "enableIMT" ]:


### PR DESCRIPTION
In past workflow 101.0,102.0  were not ready to run in multi-threaded mode, so we were always running these in single thread mode. This PR changes this behavior and for cmssw 12.X and above it run these in multi-threaded mode.