### PR TITLE
enable cms deprecated warnings for master's branch PR tests

### DIFF
--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -902,7 +902,7 @@ if [ -e $WORKSPACE/new-build-warnings.log ]  ; then
 fi
 if [ -e $WORKSPACE/deprecated-warnings.log ] ; then
   echo 'BUILD_DEPRECATED_WARNINGS;ERROR,CMS Deprecated Warnings,See Log,deprecated-warnings.log' >> ${RESULTS_DIR}/buildrules.txt
-  echo "**CMS deprecated warnings**: $(cat ${WORKSPACE}/deprecated-warnings.log | grep 'Wdeprecated-declarations' | wc -l) CMS deprecated warnings found, see summary page for details." >> ${RESULTS_DIR}/09-report.res
+  echo "**CMS deprecated warnings**: $(cat ${WORKSPACE}/deprecated-warnings.log | grep 'Wdeprecated-declarations' | wc -l) CMS deprecated warnings found, see [summary page](${PR_RESULT_URL}/deprecated-warnings.log) for details." >> ${RESULTS_DIR}/09-report.res
 fi
 
 BUILD_LOG_RES="ERROR"

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -914,10 +914,8 @@ if [ "X$TEST_ERRORS" != "X" -o "X$GENERAL_ERRORS" = "X" ]; then
 else
     echo "the build had no errors!!"
     echo 'COMPILATION_RESULTS;OK,Compilation log,See Log,build.log' >> ${RESULTS_DIR}/build.txt
-    if [ -e ${WORKSPACE}/build-logs/index.html ] ; then
-      if [ $(grep '<td> *[1-9][0-9]* *</td>' ${WORKSPACE}/build-logs/index.html  | grep -iv ' href' | grep -v 'ignoreWarning' | wc -l) -eq 0 ] ; then
-        BUILD_LOG_RES="OK"
-      fi
+    if [ ! -e $WORKSPACE/new-build-warnings.log ] ; then
+      BUILD_LOG_RES="OK"
     elif [ ! -d ${BUILD_LOG_DIR}/src ] ; then
       BUILD_LOG_RES="OK"
     fi

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -902,6 +902,7 @@ if [ -e $WORKSPACE/new-build-warnings.log ]  ; then
 fi
 if [ -e $WORKSPACE/deprecated-warnings.log ] ; then
   echo 'BUILD_DEPRECATED_WARNINGS;ERROR,CMS Deprecated Warnings,See Log,deprecated-warnings.log' >> ${RESULTS_DIR}/buildrules.txt
+  echo "**CMS deprecated warnings**: $(cat ${WORKSPACE}/deprecated-warnings.log | grep 'Wdeprecated-declarations' | wc -l) CMS deprecated warnings found, see summary page for details." >> ${RESULTS_DIR}/09-report.res
 fi
 
 BUILD_LOG_RES="ERROR"

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -882,11 +882,11 @@ for i in $(grep ": warning: " $WORKSPACE/build.log | grep "/$CMSSW_IB/" | sed "s
     echo $i > $WORKSPACE/warning.log
     grep ": warning: " $WORKSPACE/build.log | grep "/$i" >> $WORKSPACE/warning.log
     if $IS_DEV_BRANCH ; then
-      if [ $(grep ": warning: "$WORKSPACE/warning.log | grep 'Wdeprecated-declarations' | wc -l) -gt 0 ] ; then
+      if [ $(grep ": warning: " $WORKSPACE/warning.log | grep 'Wdeprecated-declarations' | wc -l) -gt 0 ] ; then
         cat $WORKSPACE/warning.log >>  $WORKSPACE/deprecated-warnings.log
       fi
     fi
-    if [ $(grep ": warning: "$WORKSPACE/warning.log | grep -v 'Wdeprecated-declarations' | wc -l) -gt 0 ] ; then
+    if [ $(grep ": warning: " $WORKSPACE/warning.log | grep -v 'Wdeprecated-declarations' | wc -l) -gt 0 ] ; then
       cat $WORKSPACE/warning.log >> $WORKSPACE/new-build-warnings.log
     fi
     rm -f $WORKSPACE/warning.log


### PR DESCRIPTION
This PR enable USE_CMS_DEPRECATED macro for PR tests ( only for master cmssw IBs). For now it will only add a new link in the summary page but PR tests will not be marked failed due to these warnings.

CMS deprecated warnings are only reported for the file which are changed in the cmssw PR