### PR TITLE
Added watcher giovanni-mocellin

### DIFF
--- a/watchers.yaml
+++ b/watchers.yaml
@@ -1408,6 +1408,18 @@ dildick:
 - CondFormats/CSCObjects
 - Geometry/GEMGeometryBuilder
 - Geometry/GEMGeometry
+giovanni-mocellin:
+- L1Trigger/CSCTriggerPrimitives
+- L1Trigger/CSCCommonTrigger
+- L1Trigger/ME0Trigger
+- SimMuon/GEMDigitizer
+- SimMuon/CSCDigitizer
+- SimMuon/Configuration
+- DataFormats/CSCDigi
+- DataFormats/GEMDigi
+- CondFormats/CSCObjects
+- Geometry/GEMGeometryBuilder
+- Geometry/GEMGeometry
 echabert:
 - CalibTracker/Configuration
 - CalibTracker/Records


### PR DESCRIPTION
As GEM-CSC trigger co-coordinator, giovanni-mocellin needs to follow the changes in some CMSSW packages