### PR TITLE
increase max length of `addOnTests` log-file names

### DIFF
--- a/report-pull-request-results.py
+++ b/report-pull-request-results.py
@@ -141,7 +141,7 @@ def read_matrix_log_file(matrix_log):
 #
 def cmd_to_addon_test(command, addon_dir):
   commandbase = command.replace(' ','_').replace('/','_')
-  logfile='%s.log' % commandbase[:150].replace("'",'').replace('"','').replace('../','')
+  logfile='%s.log' % commandbase[:160].replace("'",'').replace('"','').replace('../','')
   e, o = run_cmd("ls -d %s/*/%s 2>/dev/null | tail -1" % (addon_dir, logfile))
   if e or (o==""):
     print("ERROR: %s -> %s" % (command, o))


### PR DESCRIPTION
Increases the maximum length of the log-file names of the `addOnTests`, as discussed in https://github.com/cms-sw/cmssw/pull/36423. More details on why this might help can be found in the latter PR.

Depends on https://github.com/cms-sw/cmssw/pull/36423.
