### PR TITLE
Access MariaDB with no password; use consistent unit test db name

### DIFF
--- a/DMWM/install-wmcore.sh
+++ b/DMWM/install-wmcore.sh
@@ -22,7 +22,7 @@ export PYTHONPATH=$WMCORE_ROOT/test/python:$PYTHONPATH
 echo "Sourcing secrets and setting DB connectors"
 set +x # don't echo secrets
 . $WMAGENT_SECRETS_LOCATION
-export DATABASE=mysql://${MYSQL_USER}:${MYSQL_PASS}@localhost/WMCore_unit_test
+export DATABASE=mysql://${MYSQL_USER}@localhost/wmcore_unittest
 export COUCHURL="http://${COUCH_USER}:${COUCH_PASS}@${COUCH_HOST}:${COUCH_PORT}"
 set -x
 

--- a/DMWM/install-wmcorepy3.sh
+++ b/DMWM/install-wmcorepy3.sh
@@ -27,7 +27,7 @@ export PYTHONPATH=$WMCORE_ROOT/test/python:$PYTHONPATH
 echo "Sourcing secrets and setting DB connectors"
 set +x # don't echo secrets
 . $WMAGENT_SECRETS_LOCATION
-export DATABASE=mysql://${MYSQL_USER}:${MYSQL_PASS}@localhost/WMCore_unit_test
+export DATABASE=mysql://${MYSQL_USER}@localhost/wmcore_unittest
 export COUCHURL="http://${COUCH_USER}:${COUCH_PASS}@${COUCH_HOST}:${COUCH_PORT}"
 set -x
 

--- a/DMWM/test-wmcore.sh
+++ b/DMWM/test-wmcore.sh
@@ -3,7 +3,8 @@
 start=`date +%s`
 
 # ensure db exists
-echo "CREATE DATABASE IF NOT EXISTS WMCore_unit_test" | mysql -u ${MYSQL_USER} --password=${MYSQL_PASS} --socket=${DBSOCK}
+MYSQL_UNITTEST_DB=wmcore_unittest
+mysql -u ${MYSQL_USER} --socket=${DBSOCK} --execute "CREATE DATABASE IF NOT EXISTS ${MYSQL_UNITTEST_DB}"
 set -x
 
 # working dir includes entire python source - ignore

--- a/DMWM/test-wmcorepy3.sh
+++ b/DMWM/test-wmcorepy3.sh
@@ -3,7 +3,8 @@
 start=`date +%s`
 
 # ensure db exists
-echo "CREATE DATABASE IF NOT EXISTS WMCore_unit_test" | mysql -u ${MYSQL_USER} --password=${MYSQL_PASS} --socket=${DBSOCK}
+MYSQL_UNITTEST_DB=wmcore_unittest
+mysql -u ${MYSQL_USER} --socket=${DBSOCK} --execute "CREATE DATABASE IF NOT EXISTS ${MYSQL_UNITTEST_DB}"
 set -x
 
 ### Some tweaks for the nose run (in practice, there is nothing to change in setup_test.py...)


### PR DESCRIPTION
Starting with MariaDB 10.6.5, we no longer define a user password.
It also changes the MariaDB database name to the same defined within WMCore unittests, to avoid inconsistencies and surprises when testing things.

Further info can be found at: https://github.com/dmwm/WMCore/issues/10926