### PR TITLE
Update the reco profiling script to support an 8-threaded workflow

### DIFF
--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -74,7 +74,7 @@ workflow_configs = {
     } ,
     #8-thread T0-like promptreco workflow
     "136.889": {
-        "num_events": 100,
+        "num_events": 5000,
         "steps": {
             "step3": {
                 "TimeMemoryInfo": True,

--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -8,24 +8,80 @@ import os
 import shutil
 
 workflow_configs = {
+    #Run3 workflow
     "11834.21": {
         "num_events": 400,
-        "steps_to_profile": [3,4,5],
+        "steps": {
+            "step3": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+            "step4": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+            "step5": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+         },
+        "nThreads": 1,
         "matrix": "upgrade"
     },
+    #Phase2 workflow used in mid-2021
     "23434.21": {
         "num_events": 100,
-        "steps_to_profile": [3,4],
+        "steps": {
+            "step3": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+            "step4": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+            "step5": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+         },
+        "nThreads": 1,
         "matrix": "upgrade"
     },
+    #Phase2 workflow used in late-2021
     "34834.21": {
         "num_events": 100,
-        "steps_to_profile": [3,4],
+        "steps": {
+            "step3": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+            "step4": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+         },
+        "nThreads": 1,
         "matrix": "upgrade"
     } ,
+    #8-thread T0-like promptreco workflow
     "136.889": {
         "num_events": 100,
-        "steps_to_profile": [],
+        "steps": {
+            "step3": {
+                "TimeMemoryInfo": True,
+                "FastTimer": False,
+                "igprof": False,
+            },
+         },
         "nThreads": 8,
         "matrix": "standard"
     } 
@@ -41,6 +97,7 @@ def fixIgProfExe():
 
     return "igprof"
 
+#Prepare cmdLog and execute the workflow steps to get e.g. DAS entries, but call cmsRun with --no_exec
 def prepareMatrixWF(workflow_number, num_events, matrix="upgrade", nthreads=1):
     cmd = [
          "runTheMatrix.py",
@@ -48,32 +105,24 @@ def prepareMatrixWF(workflow_number, num_events, matrix="upgrade", nthreads=1):
          matrix,
          "-l",
          str(workflow_number),
-         "--dryRun",
+         "--command=\"--no_exec\"",
+         "--ibeos",
          "--nThreads",
          str(nthreads),
     ]
-    print(" ".join(cmd))
-    out = subprocess.check_output(cmd)
+    cmd = " ".join(cmd)
+    os.system(cmd)
 
 #extracts the cmsdriver lines from the cmdLog
 def parseCmdLog(filename):
-    init_lines = []
-    with open(filename) as fi:
-        for line in fi.readlines():
-            line = line.strip()
-            if line.startswith("#"):
-                continue
-            if line.startswith("cmsDriver"):
-                break
-            init_lines.append(line)
- 
     cmsdriver_lines = []
     with open(filename) as fi:
         for line in fi.readlines():
             line = line.strip()
             if line.strip().startswith("cmsDriver"):
+                line = line.replace("--no_exec", "")
                 cmsdriver_lines.append(stripPipe(line))
-    return init_lines, cmsdriver_lines
+    return cmsdriver_lines
 
 def stripPipe(cmsdriver_line):
     return cmsdriver_line[:cmsdriver_line.index(">")]
@@ -113,11 +162,20 @@ def prepIgprof(cmd, istep):
     cmd_ig = cmd + " --customise Validation/Performance/IgProfInfo.customise --no_exec --python_filename step{istep}_igprof.py &> step{istep}_igprof_conf.txt".format(istep=istep)
     return cmd_ig 
 
-def configureProfilingSteps(cmsdriver_lines, num_events, steps_to_profile):
+def configureProfilingSteps(cmsdriver_lines, num_events, steps_config):
     igprof_exe = fixIgProfExe()
 
-    steps_to_run = [i for i in range(1, len(cmsdriver_lines)+1)]
-    steps = {istep: cmsdriver_lines[istep-1]+" -n {num_events} --suffix \"-j step{istep}_JobReport.xml\"".format(istep=istep, num_events=num_events) for istep in steps_to_run}
+    steps = {}
+    for line in cmsdriver_lines:
+        spl = line.split()[1]
+        #step1 has the format `cmsDriver.py fragment`, otherwise it's `cmsDriver.py stepN`
+        if "step" in spl:
+            istep = int(spl.replace("step", ""))
+        else:
+            istep = 1
+        steps[istep] = line + " -n {num_events} --suffix \"-j step{istep}_JobReport.xml\"".format(istep=istep, num_events=num_events)
+
+    steps_to_run = list(sorted(steps.keys()))
     outfiles = [
         "step{}_JobReport.xml".format(istep) for istep in steps_to_run
     ]
@@ -128,58 +186,62 @@ def configureProfilingSteps(cmsdriver_lines, num_events, steps_to_profile):
         "step{}.log".format(istep) for istep in steps_to_run
     ]
 
+    #First run all the steps without any special options 
     new_cmdlist = [steps[istep]+"&>step{istep}.log".format(istep=istep) for istep in steps_to_run]
 
     igprof_commands = []
-    for istep in steps_to_profile:
+    for step_name in steps_config.keys():
+        istep = int(step_name.replace("step", ""))
         step = steps[istep]
 
         #strip the JobReport from the step command
         step = step[:step.index("--suffix")-1]
 
-        step_tmi = prepTimeMemoryInfo(step, istep)
-        step_ft = prepFastTimer(step, istep)
-        step_ig = prepIgprof(step, istep)
+        if steps_config[step_name]["TimeMemoryInfo"]:
+            step_tmi = prepTimeMemoryInfo(step, istep)
+            outfiles += ["step{}_TimeMemoryInfo.log".format(istep)]
+            new_cmdlist += [
+                echoBefore(step_tmi, "step{istep} TimeMemoryInfo".format(istep=istep))
+            ]
+        if steps_config[step_name]["FastTimer"]:
+            step_ft = prepFastTimer(step, istep)
+            outfiles += ["step{}_FastTimerService.log".format(istep), "step{}_circles.json".format(istep)]
+            new_cmdlist += [
+                echoBefore(step_ft, "step{istep} FastTimer".format(istep=istep)),
+            ]
+        if steps_config[step_name]["igprof"]:
+            step_ig = prepIgprof(step, istep)
+            new_cmdlist += [
+                echoBefore(step_ig, "step{istep} IgProf conf".format(istep=istep))
+            ]
+            
+            igprof_pp = wrapInRetry(igprof_exe + " -d -pp -z -o step{istep}_igprofCPU.gz -t cmsRun cmsRun step{istep}_igprof.py &> step{istep}_igprof_cpu.txt".format(istep=istep))
+            igprof_mp = wrapInRetry(igprof_exe + " -d -mp -z -o step{istep}_igprofMEM.gz -t cmsRunGlibC cmsRunGlibC step{istep}_igprof.py &> step{istep}_igprof_mem.txt".format(istep=istep))
+            outfiles += [
+                "step{istep}_igprof_cpu.txt".format(istep=istep), 
+                "step{istep}_igprof_mem.txt".format(istep=istep)
+            ]
+            
+            igprof_commands += [
+                echoBefore(igprof_pp, "step{istep} IgProf pp".format(istep=istep)),
+                "mv IgProf.1.gz step{istep}_igprofCPU.1.gz".format(istep=istep),
+                "mv IgProf.{nev}.gz step{istep}_igprofCPU.{nev}.gz".format(nev=int(num_events/2), istep=istep),
+                "mv IgProf.{nev}.gz step{istep}_igprofCPU.{nev}.gz".format(nev=int(num_events-1), istep=istep),
+                echoBefore(igprof_mp, "step{istep} IgProf mp".format(istep=istep)),
+                "mv IgProf.1.gz step{istep}_igprofMEM.1.gz".format(istep=istep),
+                "mv IgProf.{nev}.gz step{istep}_igprofMEM.{nev}.gz".format(nev=int(num_events/2), istep=istep),
+                "mv IgProf.{nev}.gz step{istep}_igprofMEM.{nev}.gz".format(nev=int(num_events-1), istep=istep),
+            ]
 
-        outfiles += [
-            "step{}_TimeMemoryInfo.log".format(istep),
-            "step{}_FastTimerService.log".format(istep),
-            "step{}_circles.json".format(istep),
-        ]
-
-        new_cmdlist += [
-            echoBefore(step_tmi, "step{istep} TimeMemoryInfo".format(istep=istep)),
-            echoBefore(step_ft, "step{istep} FastTimer".format(istep=istep)),
-            echoBefore(step_ig, "step{istep} IgProf conf".format(istep=istep))
-        ]
-
-        igprof_pp = wrapInRetry(igprof_exe + " -d -pp -z -o step{istep}_igprofCPU.gz -t cmsRun cmsRun step{istep}_igprof.py &> step{istep}_igprof_cpu.txt".format(istep=istep))
-        igprof_mp = wrapInRetry(igprof_exe + " -d -mp -z -o step{istep}_igprofMEM.gz -t cmsRunGlibC cmsRunGlibC step{istep}_igprof.py &> step{istep}_igprof_mem.txt".format(istep=istep))
-        outfiles += [
-            "step{istep}_igprof_cpu.txt".format(istep=istep), 
-            "step{istep}_igprof_mem.txt".format(istep=istep)
-        ]
-        
-        igprof_commands += [
-            echoBefore(igprof_pp, "step{istep} IgProf pp".format(istep=istep)),
-            "mv IgProf.1.gz step{istep}_igprofCPU.1.gz".format(istep=istep),
-            "mv IgProf.{nev}.gz step{istep}_igprofCPU.{nev}.gz".format(nev=int(num_events/2), istep=istep),
-            "mv IgProf.{nev}.gz step{istep}_igprofCPU.{nev}.gz".format(nev=int(num_events-1), istep=istep),
-            echoBefore(igprof_mp, "step{istep} IgProf mp".format(istep=istep)),
-            "mv IgProf.1.gz step{istep}_igprofMEM.1.gz".format(istep=istep),
-            "mv IgProf.{nev}.gz step{istep}_igprofMEM.{nev}.gz".format(nev=int(num_events/2), istep=istep),
-            "mv IgProf.{nev}.gz step{istep}_igprofMEM.{nev}.gz".format(nev=int(num_events-1), istep=istep),
-        ]
-
-        outfiles += [
-            "step{istep}_igprofCPU.{nev}.gz".format(istep=istep, nev=nev) for nev in [1,int(num_events/2), int(num_events-1)]
-        ]
-        outfiles += [
-            "step{istep}_igprofMEM.{nev}.gz".format(istep=istep, nev=nev) for nev in [1,int(num_events/2), int(num_events-1)]
-        ]
-        outfiles += [
-            "step{istep}_igprofCPU.gz".format(istep=istep)
-        ]
+            outfiles += [
+                "step{istep}_igprofCPU.{nev}.gz".format(istep=istep, nev=nev) for nev in [1,int(num_events/2), int(num_events-1)]
+            ]
+            outfiles += [
+                "step{istep}_igprofMEM.{nev}.gz".format(istep=istep, nev=nev) for nev in [1,int(num_events/2), int(num_events-1)]
+            ]
+            outfiles += [
+                "step{istep}_igprofCPU.gz".format(istep=istep)
+            ]
 
     new_cmdlist = new_cmdlist + igprof_commands
 
@@ -188,7 +250,9 @@ def configureProfilingSteps(cmsdriver_lines, num_events, steps_to_profile):
 def writeProfilingScript(wfdir, runscript, cmdlist):
     runscript_path = "{}/{}".format(wfdir, runscript)
     with open(runscript_path, "w") as fi:
-        fi.write("#!/bin/bash\n")
+        fi.write("#!/bin/sh\n")
+
+        #this is required for igprof
         fi.write("ulimit -a\n")
 
         #don't abort on error
@@ -196,6 +260,8 @@ def writeProfilingScript(wfdir, runscript, cmdlist):
         
         #print commands verbosely
         fi.write("set -x\n")
+
+        fi.write("\n")
         for cmd in cmdlist:
             fi.write(cmd + '\n')
 
@@ -228,23 +294,23 @@ def main(wf, num_events, out_dir):
 
     prepareMatrixWF(wf, num_events, matrix=workflow_configs[wf]["matrix"], nthreads=workflow_configs[wf]["nThreads"])
     wfdir = getWFDir(wf)
-    init_lines, cmsdriver_lines = parseCmdLog("{}/cmdLog".format(wfdir))
-    new_cmdlist, outfiles = configureProfilingSteps(cmsdriver_lines, num_events, workflow_configs[wf]["steps_to_profile"])
+    cmsdriver_lines = parseCmdLog("{}/cmdLog".format(wfdir))
+    new_cmdlist, outfiles = configureProfilingSteps(cmsdriver_lines, num_events, workflow_configs[wf]["steps"])
 
     runscript = "cmdLog_profiling.sh"
     outfiles += ["cmdLog_profiling.sh"]
-    writeProfilingScript(wfdir, runscript, init_lines + new_cmdlist)
+    writeProfilingScript(wfdir, runscript, new_cmdlist)
     runProfiling(wfdir, runscript)
     copyProfilingOutputs(wfdir, out_dir, outfiles)
 
 def parse_args():
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument("--workflow", type=str, default="23434.21", help="The workflow to use for profiling")
-    parser.add_argument("--num-events", type=int, default=None, help="Number of events to use")
+    parser.add_argument("--workflow", type=str, default="34834.21", help="The workflow to use for profiling")
+    parser.add_argument("--num-events", type=int, default=-1, help="Number of events to use, -1 to use the default")
     parser.add_argument("--out-dir", type=str, help="The output directory where to copy the profiling results", required=True)
     args = parser.parse_args()
-    if args.num_events is None:
+    if args.num_events==-1:
         args.num_events = workflow_configs[args.workflow]["num_events"]
     return args
 


### PR DESCRIPTION
In order to profile a T0-like workflow (see https://github.com/cms-sw/cmssw/issues/36282) for each release, we needed to update the reco profiling script. The changes were successfully tested for 12_3_0_pre1 and pre2: https://cmssdt.cern.ch/jenkins/job/release-run-reco-profiling/
 
This has no effect on other functionality of the bot outside the reco profiling.