### PR TITLE
reco comparisons: add plots for new MTD value maps; add basic monitoring of JECs in pat::Jets

### DIFF
--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -351,6 +351,9 @@ void jets(TString type,TString algo){
         plotvar("min(2,max(-2,"+jetBName+Form(".obj[].pairDiscriVector_[%d].second))",i), jetBName+".obj[].pt()>200", true);
       }
     }
+    jet(type, algo, "jec_@.size");
+    jet(type, algo, "currentJECSet_", false, false, true);
+    jet(type, algo, "currentJECLevel_", false, false, true);
   }
 }
 
@@ -2568,6 +2571,9 @@ void validateEvents(TString step, TString file, TString refFile, TString r="RECO
       plotvar(tbr+"generalTrackt0_"+recoS+".obj.values_");
       plotvar(tbr+"generalTracksigmat0_"+recoS+".obj.values_");
       plotvar(tbr+"generalTracktmtd_"+recoS+".obj.values_");
+      plotvar(tbr+"generalTrackTofP_"+recoS+".obj.values_");
+      plotvar(tbr+"generalTrackTofK_"+recoS+".obj.values_");
+      plotvar(tbr+"generalTrackTofPi_"+recoS+".obj.values_");
       plotvar(tbr+"pathLength_"+recoS+".obj.values_");
       plotvar(tbr+"tmtd_"+recoS+".obj.values_");
       plotvar(tbr+"btlMatchChi2_"+recoS+".obj.values_");


### PR DESCRIPTION
- add plots for new MTD value maps following updates in cms-sw/cmssw#36202
- pat::Jet JEC counters in connection with cms-sw/cmssw#36559

I will test in cms-sw/cmssw#36559
