### PR TITLE
Move to slc7_amd64_gcc530 as production arch for CMSSW_8_0_36_patch1

### DIFF
--- a/releases.map
+++ b/releases.map
@@ -3204,5 +3204,5 @@ architecture=cc8_amd64_gcc9;label=CMSSW_12_2_0;type=Production;state=Announced;p
 architecture=slc7_aarch64_gcc9;label=CMSSW_12_2_0;type=Production;state=Announced;prodarch=0;
 architecture=slc7_amd64_gcc900;label=CMSSW_12_2_0;type=Production;state=Announced;prodarch=1;
 architecture=slc7_ppc64le_gcc9;label=CMSSW_12_2_0;type=Production;state=Announced;prodarch=0;
-architecture=slc6_amd64_gcc530;label=CMSSW_8_0_36_patch1;type=Production;state=Announced;prodarch=1;
-architecture=slc7_amd64_gcc530;label=CMSSW_8_0_36_patch1;type=Production;state=Announced;prodarch=0;
+architecture=slc6_amd64_gcc530;label=CMSSW_8_0_36_patch1;type=Production;state=Announced;prodarch=0;
+architecture=slc7_amd64_gcc530;label=CMSSW_8_0_36_patch1;type=Production;state=Announced;prodarch=1;


### PR DESCRIPTION
see https://github.com/cms-sw/cmssw/issues/36708
FYI @qliphy @perrotta @cms-sw/pdmv-l2