### PR TITLE
Add new muon MVA value from #36179

### DIFF
--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -1066,6 +1066,7 @@ void muonVars(TString cName = "muons_", TString tName = "recoMuons_"){
     muonVar("mvaValue", cName,tName);
     muonVar("lowptMvaValue", cName,tName);
     muonVar("softMvaValue", cName,tName);
+    muonVar("mvaIDValue", cName,tName);
     muonVar("inverseBeta", cName,tName);
     muonVar("inverseBetaErr", cName,tName);
 


### PR DESCRIPTION
Based on the new branch `pat::Muon::mvaIDValue()` from https://github.com/cms-sw/cmssw/pull/36179, add this to `validate.C`.

cc @slava77 @clacaputo