### PR TITLE
ignore 0C402854-EECC-E311-AE34-E0CB4E553656.root file from workflow 4.76

### DIFF
--- a/das-utils/ibeos-lfn-sort
+++ b/das-utils/ibeos-lfn-sort
@@ -4,6 +4,7 @@ NON_IBEOS_FILES=""
 if [ -f ${LOCALRT}/ibeos_cache.txt ] ; then
   while read LFN ; do
     case $LFN in
+      */0C402854-EECC-E311-AE34-E0CB4E553656.root) ;;
       /store/* )
         if [ $(grep "^${LFN}$" ${LOCALRT}/ibeos_cache.txt | wc -l) -gt 0 ] ; then
           IBEOS_FILES="$IBEOS_FILES $LFN"


### PR DESCRIPTION
This PR is work around to ignore `0C402854-EECC-E311-AE34-E0CB4E553656.root` file which is not available any more and causes workflow 4.76 to fail in all IBs. This change should allow to run workflow 4.76 in all IBs. Proper fix should be to fix workflow 4.76 configuration and use an available dataset