### PR TITLE
Remove EventFilter/Utilities from reco

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1135,7 +1135,6 @@ CMSSW_CATEGORIES = {
     "EventFilter/SiPixelRawToDigi",
     "EventFilter/SiStripRawToDigi",
     "EventFilter/TotemRawToDigi",
-    "EventFilter/Utilities",
     "JetMETCorrections/Configuration",
     "JetMETCorrections/JetCorrector",
     "JetMETCorrections/Modules",


### PR DESCRIPTION
In https://github.com/cms-sw/cms-bot/pull/485 reco was added as a signature to EventFilter/Utilities, but it is my understanding that we only follow one file in this package: https://github.com/cms-sw/cmssw/blob/master/EventFilter/Utilities/plugins/TcdsRawToDigi.cc.

Here I propose to remove the reco sig from the full package.
Is there a way to follow automatically only one file from the package?

@cms-sw/reconstruction-l2