### PR TITLE
support for adding new type labels

### DIFF
--- a/githublabels.py
+++ b/githublabels.py
@@ -12,14 +12,24 @@ LABEL_TYPES = {
   "rejected": LABEL_COLORS["rejected"],
 }
 
+#TYPE_COMMANDS[LABEL_NAME]=[LABEL_COLOR,
+#                           REGEXP_TO_MATCH_CCOMMENT",
+#                           TYPE
+#                                type: only apply the last comment
+#                                mtype: accomulate all comments]
+TYPE_COMMANDS = {
+  "bug-fix" :                  ["b8860b",             "bug(-fix|fix|)",             "type"],
+  "new-feature" :              [LABEL_COLORS["info"], "(new-|)feature|(new-|)idea", "type"],
+  "documentation" :            ["257fdb",             "doc(umentation|)",           "mtype"],
+  "performance-improvements" : ["5b9ee3",             "performance|improvements|performance-improvements", "mtype"],
+}
+
 COMMON_LABELS = {
   "tests-started": LABEL_COLORS["hold"],
   "fully-signed": LABEL_COLORS["approved"],
   "pending-signatures": LABEL_COLORS["hold"],
   "pending-assignment": LABEL_COLORS["hold"],
   "new-package-pending" : LABEL_COLORS["rejected"],
-  "bug-fix" : "b8860b",
-  "new-feature" : LABEL_COLORS["info"],
   "backport" : LABEL_COLORS["info"],
   "backport-ok" : LABEL_COLORS["approved"],
   "urgent"   : "cc317c",
@@ -28,6 +38,9 @@ COMMON_LABELS = {
   "compilation-warnings": LABEL_COLORS["hold"],
   "requires-external" : LABEL_COLORS["info"],
 }
+
+for lab in TYPE_COMMANDS:
+  COMMON_LABELS[lab] = TYPE_COMMANDS[lab][0]
 
 COMPARISON_LABELS = {
   "comparison-notrun" : "bfe5bf",

--- a/process_pr.py
+++ b/process_pr.py
@@ -227,9 +227,9 @@ def ignore_issue(repo_config, repo, issue):
     return True
   if re.match(BUILD_REL, issue.title):
     return True
-  #if issue.body:
-  #  if re.search(CMSBOT_IGNORE_MSG, issue.body.encode("ascii", "ignore").split("\n",1)[0].strip() ,re.I):
-  #    return True
+  if issue.body:
+    if re.search(CMSBOT_IGNORE_MSG, issue.body.encode("ascii", "ignore").split("\n",1)[0].strip() ,re.I):
+      return True
   return False
 
 def notify_user(issue):

--- a/process_pr.py
+++ b/process_pr.py
@@ -253,7 +253,7 @@ def check_type_labels(first_line, extra_labels):
         lab_type = TYPE_COMMANDS[lab][2]
         if lab_type not in extra_labels: extra_labels[lab_type] = []
         extra_labels[lab_type].append(lab)
-      continue
+        break
   return
 
 def check_ignore_bot_tests(first_line, *args):


### PR DESCRIPTION
This allows bot to add new type labels e.g. `type name1(,name2|)` . Existing type labels were `bug-fix` and `new-feature`. This PR also added 
- `documentation`
- `performance-improvements`
- `new-idea` : but may be we do not need this in favor of existing `new-feature`

FYI @qliphy  @perrotta 