### PR TITLE
drop usage of python3or2 and find the correct python to run

### DIFF
--- a/comparisons/analyzeFWComparison.py
+++ b/comparisons/analyzeFWComparison.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from optparse import OptionParser
 from os import listdir
 import re

--- a/comparisons/filter-failed-comparison.py
+++ b/comparisons/filter-failed-comparison.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 import sys, glob
 from os.path import basename,join

--- a/gen-relval-jobs.py
+++ b/gen-relval-jobs.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 import sys
 import json

--- a/jobs/create-relval-jobs.py
+++ b/jobs/create-relval-jobs.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 import glob
 import os

--- a/jobs/jobscheduler.py
+++ b/jobs/jobscheduler.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 from operator import itemgetter
 from time import sleep, time

--- a/jobs/stats.py
+++ b/jobs/stats.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 import sys
 from os.path import getmtime, join, dirname, abspath

--- a/jobs/workflow_final.py
+++ b/jobs/workflow_final.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 import sys, json, glob, os, re
 SCRIPT_DIR = os.path.dirname(os.path.abspath(sys.argv[0]))

--- a/logUpdater.py
+++ b/logUpdater.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
 
 from __future__ import print_function
 import os

--- a/mark_commit_status.py
+++ b/mark_commit_status.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 from optparse import OptionParser
 from github_utils import api_rate_limits, mark_commit_status, get_combined_statuses, get_pr_latest_commit

--- a/pr_testing/get-merged-prs.py
+++ b/pr_testing/get-merged-prs.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 from os import environ
 from os.path import dirname,basename,abspath,join

--- a/pr_testing/run-das-query.py
+++ b/pr_testing/run-das-query.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 import os, sys
 BOT_DIR=os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))

--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -287,7 +287,7 @@ if [ "X$RUN_JR_COMP" = Xtrue ]; then
     JRHTML=$WORKSPACE/upload/validateJR.html
     mark_commit_status_all_prs "${GH_COMP_CONTEXT}" 'pending' -u "${BUILD_URL}" -d "Generating comparison summary" || true
     echo 'Doing histogram, log and root comparison:'
-    (python3or2 $CMS_BOT_DIR/logRootQA.py $WORKSPACE/data/${COMPARISON_RELEASE} $WORKSPACE/data/PR-${PR_NUM} ${JR_COMP_DIR} $WORKSPACE/results/default-comparison  >> $QALOG 2>&1) || true
+    (${CMSBOT_PYTHON_CMD} $CMS_BOT_DIR/logRootQA.py $WORKSPACE/data/${COMPARISON_RELEASE} $WORKSPACE/data/PR-${PR_NUM} ${JR_COMP_DIR} $WORKSPACE/results/default-comparison  >> $QALOG 2>&1) || true
     (grep -a SUMMARY $QALOG | cut -d' ' -f2-100 >> $JR_COMP_DIR/qaResultsSummary.log 2>&1) || true
     echo "<html><body><h3>Default comparison: Workflows with failed comparisons</h3>" > $JRHTML
     echo "<table><tr><td>WF #</td><td>Failed</td></tr>" >> $JRHTML

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -88,7 +88,7 @@ DO_DAS_QUERY=false
 PRODUCTION_RELEASE=false
 CMSSW_BRANCH=$(echo "${CONFIG_LINE}" | sed 's|.*RELEASE_BRANCH=||;s|;.*||')
 
-if [ "${CMSSW_BRANCH}" = "master" ] ; then CMSSW_BRANCH=$(cd $CMS_BOT_DIR; python3or2 -c 'from releases import CMSSW_DEVEL_BRANCH; print(CMSSW_DEVEL_BRANCH)') ; fi
+if [ "${CMSSW_BRANCH}" = "master" ] ; then CMSSW_BRANCH=$(cd $CMS_BOT_DIR; ${CMSBOT_PYTHON_CMD} -c 'from releases import CMSSW_DEVEL_BRANCH; print(CMSSW_DEVEL_BRANCH)') ; fi
 if [ $(echo "${CONFIG_LINE}" | grep "PROD_ARCH=1" | wc -l) -gt 0 ] ; then
   if [ $(echo "${CONFIG_LINE}" | grep "ADDITIONAL_TESTS=" | wc -l) -gt 0 ] ; then
     PRODUCTION_RELEASE=true
@@ -139,7 +139,7 @@ ls /cvmfs/cms-ib.cern.ch || true
 which scram 2>/dev/null || source /cvmfs/cms.cern.ch/cmsset_default.sh
 
 # Put hashcodes of last commits to a file. Mostly used for commenting back
-COMMIT=$(python3or2 ${CMS_BOT_DIR}/process-pull-request -c -r ${PR_REPO} ${PR_NUMBER})
+COMMIT=$(${CMSBOT_PYTHON_CMD} ${CMS_BOT_DIR}/process-pull-request -c -r ${PR_REPO} ${PR_NUMBER})
 echo "${PULL_REQUEST}=${COMMIT}" > ${WORKSPACE}/prs_commits
 cp ${WORKSPACE}/prs_commits ${WORKSPACE}/prs_commits.txt
 

--- a/report-pull-request-results.py
+++ b/report-pull-request-results.py
@@ -1,4 +1,11 @@
-#! /usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 from io import open
 from os.path import expanduser, dirname, join, exists, abspath

--- a/run-ib-addon.py
+++ b/run-ib-addon.py
@@ -1,4 +1,11 @@
-#! /usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 from sys import exit, argv
 from os import environ

--- a/run-ib-relval.py
+++ b/run-ib-relval.py
@@ -1,4 +1,11 @@
-#! /usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
+
 from __future__ import print_function
 from sys import exit, argv
 from optparse import OptionParser

--- a/run-ib-testbase.sh
+++ b/run-ib-testbase.sh
@@ -27,10 +27,10 @@ cd ${RELEASE_FORMAT}
 if [ -f config/SCRAM/linkexternal.py ] ; then
   sed -i -e 's|%s build|echo %s build|'  config/SCRAM/linkexternal.py || true
 fi
-[ -e "\${HOME}/bin/python3or2" ] && export PATH="\${HOME}/bin:\${PATH}"
 eval \$(scram runtime -sh)
 echo $PATH | tr ':' '\n'
 export CMS_PATH="/cvmfs/cms-ib.cern.ch"
+export CMSBOT_PYTHON_CMD=\$(which python3 >/dev/null 2>&1 && echo python3 || echo python)
 if [ "${NO_IBEOS_UPDATES}" = "" ] ; then
   cp $WORKSPACE/cms-bot/das-utils/das_client $WORKSPACE/cms-bot/das-utils/das_client.py
   $WORKSPACE/cms-bot/das-utils/use-ibeos-sort

--- a/runTests.py
+++ b/runTests.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3or2
+#!/bin/bash
+
+""":"
+python_cmd="python"
+python3 -V >/dev/null 2>&1 && python_cmd="python3"
+exec ${python_cmd} $0 ${1+"$@"}
+"""
 
 from __future__ import print_function
 import os, sys, platform, glob


### PR DESCRIPTION
these script are those which we run during PR tests and IB build. We are missing `python3` on `slc6` and `python` on `rhel8 & cs9` . So initially we created a wrapper script `python3or2` and include it in `PATH` now we propose to replace it with this special code fragment to avoid dependency on external `python3or2` 