### PR TITLE
Update ib script for crab to wait for the results

### DIFF
--- a/crab/ib-run-crab.sh
+++ b/crab/ib-run-crab.sh
@@ -20,7 +20,7 @@ echo "Keep checking job information until grid site has been assigned"
 GRIDSITE=""
 while [ "${GRIDSITE}" = "" ]
 do
-  export GRIDSITE=$(curl -X GET --cert "/tmp/x509up_u${ID}" --key "/tmp/x509up_u${ID}" --capath "/etc/grid-security/certificates/" "https://cmsweb.cern.ch:8443/crabserver/prod/task?subresource=search&workflow=${TASK_ID}" | grep -o "http://.*${TASK_ID}")
+  export GRIDSITE=$(curl -X GET --cert "/tmp/x509up_u${ID}" --key "/tmp/x509up_u${ID}" --capath "/etc/grid-security/certificates/" "https://cmsweb.cern.ch:8443/crabserver/prod/task?subresource=search&workflow=${TASK_ID}" | grep -o "http.*/${TASK_ID}")
   sleep 5
 done
 
@@ -31,7 +31,7 @@ echo "Wait until job has finished"
 status=""
 while [ "${status}" = "" ]
 do
-  output=$(curl -L -X GET --cert "/tmp/x509up_u${ID}" --key "/tmp/x509up_u${ID}" --capath "/etc/grid-security/certificates/" "http://${GRIDSITE}/mon/cmsbot/${TASK_ID}/status_cache")
+  output=$(curl -L -X GET --cert "/tmp/x509up_u${ID}" --key "/tmp/x509up_u${ID}" --capath "/etc/grid-security/certificates/" "${GRIDSITE}/status_cache")
   errval=$(echo $output | grep -o "404 Not Found" || echo "")
   if [ "$errval" = "" ] ; then
     echo -e "["$(date)"]:" $output "\n" >> crab_${CRAB_REQUEST}/results/logfile

--- a/crab/ib-run-crab.sh
+++ b/crab/ib-run-crab.sh
@@ -18,10 +18,10 @@ export TASK_ID=$(grep crab_${CRAB_REQUEST} crab_${CRAB_REQUEST}/.requestcache | 
 sleep 10
 
 echo "Keep checking job information until grid site has been assigned"
-GRIDSITE=""
-while [ "${GRIDSITE}" = "" ]
+GRIDSITE="N/A"
+while [ "${GRIDSITE}" = "N/A" ]
 do
-  export GRIDSITE=$(crab status -d crab_${CRAB_REQUEST} | grep -o "vocms.*cern.ch" || echo "")
+  export GRIDSITE=$(crab status -d crab_${CRAB_REQUEST} | grep "Grid scheduler - Task Worker:" | awk '{print $6}')
   sleep 5
 done
 

--- a/crab/ib-run-crab.sh
+++ b/crab/ib-run-crab.sh
@@ -18,6 +18,7 @@ export TASK_ID=$(grep crab_${CRAB_REQUEST} crab_${CRAB_REQUEST}/.requestcache | 
 sleep 10
 
 echo "Keep checking job information until grid site has been assigned"
+GRIDSITE=""
 while [ "${GRIDSITE}" = "" ]
 do
   export GRIDSITE=$(crab status -d crab_${CRAB_REQUEST} | grep -o "vocms.*cern.ch" || echo "")
@@ -28,6 +29,7 @@ done
 sleep 10
 
 echo "Wait until job has finished"
+status=""
 while [ "${status}" = "" ]
 do
   output=$(curl -L -X GET --cert "/tmp/x509up_u${ID}" --key "/tmp/x509up_u${ID}" --capath "/etc/grid-security/certificates/" "http://${GRIDSITE}/mon/cmsbot/${TASK_ID}/status_cache")

--- a/crab/ib-run-crab.sh
+++ b/crab/ib-run-crab.sh
@@ -18,10 +18,10 @@ export TASK_ID=$(grep crab_${CRAB_REQUEST} crab_${CRAB_REQUEST}/.requestcache | 
 sleep 10
 
 echo "Keep checking job information until grid site has been assigned"
-GRIDSITE="N/A"
-while [ "${GRIDSITE}" = "N/A" ]
+GRIDSITE=""
+while [ "${GRIDSITE}" = "" ]
 do
-  export GRIDSITE=$(crab status -d crab_${CRAB_REQUEST} | grep "Grid scheduler - Task Worker:" | awk '{print $6}')
+  export GRIDSITE=$(curl  -X GET  --cert "/tmp/x509up_u${ID}" --key "/tmp/x509up_u${ID}" --capath "/etc/grid-security/certificates/" "https://cmsweb.cern.ch:8443/crabserver/prod/task?subresource=search&workflow=${TASK_ID}" | grep -o "http://.*${TASK_ID}")
   sleep 5
 done
 

--- a/crab/ib-run-crab.sh
+++ b/crab/ib-run-crab.sh
@@ -9,7 +9,6 @@ fi
 export CRAB_REQUEST="Jenkins_${CMSSW_VERSION}_${SCRAM_ARCH}_${BUILD_ID}"
 voms-proxy-init -voms cms
 crab submit -c $(dirname $0)/task.py
-crab status -d crab_${CRAB_REQUEST}
 
 export ID=$(id -u)
 export TASK_ID=$(grep crab_${CRAB_REQUEST} crab_${CRAB_REQUEST}/.requestcache | sed 's|^V||')
@@ -21,7 +20,7 @@ echo "Keep checking job information until grid site has been assigned"
 GRIDSITE=""
 while [ "${GRIDSITE}" = "" ]
 do
-  export GRIDSITE=$(curl  -X GET  --cert "/tmp/x509up_u${ID}" --key "/tmp/x509up_u${ID}" --capath "/etc/grid-security/certificates/" "https://cmsweb.cern.ch:8443/crabserver/prod/task?subresource=search&workflow=${TASK_ID}" | grep -o "http://.*${TASK_ID}")
+  export GRIDSITE=$(curl -X GET --cert "/tmp/x509up_u${ID}" --key "/tmp/x509up_u${ID}" --capath "/etc/grid-security/certificates/" "https://cmsweb.cern.ch:8443/crabserver/prod/task?subresource=search&workflow=${TASK_ID}" | grep -o "http://.*${TASK_ID}")
   sleep 5
 done
 
@@ -37,7 +36,7 @@ do
   if [ "$errval" = "" ] ; then
     echo -e "["$(date)"]:" $output "\n" >> crab_${CRAB_REQUEST}/results/logfile
     # Keep checking until job finishes
-    status=$( echo $output | grep -o "'State': 'finished'" || echo "")
+    status=$(echo $output | grep -o "'State': 'finished'" || echo "")
     echo $status
   else
     echo -e "["$(date)"]: ERROR: Failed to curl job status\n" >> crab_${CRAB_REQUEST}/results/logfile


### PR DESCRIPTION
Currently _ib-run-crab.sh_ only submit the job but does not wait for the results. This change consists of a loop to keep checking the status of the job until it finishes.