### PR TITLE
Adding Stephanie and Thiago to upgrade watchers

### DIFF
--- a/category-watchers.yaml
+++ b/category-watchers.yaml
@@ -7,3 +7,7 @@ mmusich:
 - db
 silviodonato:
 - hlt
+beaucero:
+- upgrade
+trtomei:
+- upgrade


### PR DESCRIPTION
As conveners of the HLT-Upgrade group, we need to make sure any changes to Upgrade code do not break the HLT Phase-2 menu that has now been integrated in CMSSW.