### PR TITLE
Add `db` signature to DQM/BeamMonitor

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -470,6 +470,7 @@ CMSSW_CATEGORIES = {
     "CondTools/SiPixel",
     "CondTools/SiStrip",
     "CondTools/Utilities",
+    "DQM/BeamMonitor",
     "OnlineDB/CSCCondDB",
     "OnlineDB/EcalCondDB",
     "OnlineDB/HcalCondDB",

--- a/watchers.yaml
+++ b/watchers.yaml
@@ -1760,8 +1760,9 @@ sscruz:
 - Validation/MuonIsolation
 - Validation/RecoMuon
 francescobrivio:
-- RecoVertex/BeamSpotProducer
+- DQM/BeamMonitor
 - DQM/Integration
+- RecoVertex/BeamSpotProducer
 valsdav:
 - RecoEcal
 - RecoEgamma


### PR DESCRIPTION
**PR Description**
This PR adds the `db` signature to the `DQM/BeamMonitor` package.
The rational behind this addition is that the BeamMonitor code is currently the only DQM client running live in P5 that has directl access to upload payloads to CondDB, hence we (@cms-sw/db-l2) would like to add the `db` signature in order to be informed of any possible change.

I hope our DQM colleagues (@cms-sw/dqm-l2) agree with this proposal.


**EDIT**
I profit of this PR to update my personal watchlist.