### PR TITLE
Revert to memory profiling with cmsRun instead of cmsRunGlibC

### DIFF
--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -19,10 +19,10 @@ for prof in ${PROFILES} ; do
       runTheMatrix.py $WF --command " -n $EVENTS --profile $prof --no_exec" 2>&1 | tee  ./runTheMatrix.log
       cd $WORKFLOW*
       for f in $(ls *GEN_SIM.py); do
-         igprof -mp -t cmsRunGlibC -- cmsRunGlibC $f 2>&1 | tee ${f//.py/.log}
+         igprof -mp -t cmsRun -- cmsRun $f 2>&1 | tee ${f//.py/.log}
       done
       for f in $(ls -1 step*.py| sort); do
-         igprof -mp -t cmsRunGlibC -- cmsRunGlibC $f 2>&1 | tee ${f//.py/.log}
+         igprof -mp -t cmsRun -- cmsRun $f 2>&1 | tee ${f//.py/.log}
       done
       cd -
     else

--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -17,7 +17,7 @@ for prof in ${PROFILES} ; do
     fi
     if [ "$prof" = "mp" ];then
       GLIBC="GlibC"
-      if [ "SCRAM_ARCH" = "el8*"]; then
+      if ( echo $SCRAM_ARCH | grep -Eq "^el8*" ) ; then
           GLIBC=""
       fi
       runTheMatrix.py $WF --command " -n $EVENTS --profile $prof --no_exec" 2>&1 | tee  ./runTheMatrix.log

--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -16,13 +16,17 @@ for prof in ${PROFILES} ; do
         WF="-w upgrade -l $WORKFLOW"
     fi
     if [ "$prof" = "mp" ];then
+      GLIBC="GlibC"
+      if [ "SCRAM_ARCH" = "el8*"]; then
+          GLIBC=""
+      fi
       runTheMatrix.py $WF --command " -n $EVENTS --profile $prof --no_exec" 2>&1 | tee  ./runTheMatrix.log
       cd $WORKFLOW*
       for f in $(ls *GEN_SIM.py); do
-         igprof -mp -t cmsRun -- cmsRun $f 2>&1 | tee ${f//.py/.log}
+         igprof -mp -t cmsRun$GLIBC -- cmsRun$GLIBC $f 2>&1 | tee ${f//.py/.log}
       done
       for f in $(ls -1 step*.py| sort); do
-         igprof -mp -t cmsRun -- cmsRun $f 2>&1 | tee ${f//.py/.log}
+         igprof -mp -t cmsRun$GLIBC -- cmsRun$GLIBC $f 2>&1 | tee ${f//.py/.log}
       done
       cd -
     else


### PR DESCRIPTION
On el8 igprof memory profiling with cmsRunGlibC produces empty results. 
This is possibly because of a difference in glibc memory functions.