### PR TITLE
Remove Attilio from analysis signature

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -71,7 +71,6 @@ CMSSW_L2 = {
   "epalencia":        ["l1"],
   "rekovic":          ["l1"],
   "rvenditti":        ["dqm"],
-  "santocch":         ["analysis"],
   "Saptaparna":       ["generators"],
   "sbein":            ["fastsim"],
   "SiewYan":          ["generators"], 


### PR DESCRIPTION
Please @santocch confirm that this corresponds to what you were asking.
analysis category will remain fully uncovered after this removal: remaing packages in that catecory should be re-assigned to other categories to allow the PRs being signed