### PR TITLE
[CRAB IB] Store crab information in json file

### DIFF
--- a/crab/ib-monitor-crab.sh
+++ b/crab/ib-monitor-crab.sh
@@ -1,4 +1,16 @@
 #!/bin/bash -ex
+
+trap report EXIT
+
+report() {
+   exit_code=$?
+   if [ ${exit_code} -eq 0 ]; then
+       echo "PASSED" > $WORKSPACE/results/statusfile
+   else
+       echo "FAILED" > $WORKSPACE/results/statusfile
+   fi
+}
+
 [ "${WORKSPACE}" != "" ] || export WORKSPACE=$(pwd) && cd $WORKSPACE
 export ID=$(id -u)
 
@@ -20,4 +32,3 @@ do
     status=$(grep -o "'State': 'finished'" $WORKSPACE/status.log || echo "")
   fi
 done
-echo "PASSED" > $WORKSPACE/results/statusfile

--- a/crab/ib-run-crab.sh
+++ b/crab/ib-run-crab.sh
@@ -1,7 +1,18 @@
 #!/bin/bash -ex
+
+trap report EXIT
+
+report() {
+   exit_code=$?
+   if [ ${exit_code} -ne 0 ]; then
+       echo "FAILED" > $WORKSPACE/crab/statusfile
+   fi
+}
+
 [ "${CRABCLIENT_TYPE}" != "" ]   || export CRABCLIENT_TYPE="prod"
 [ "${BUILD_ID}" != "" ]          || export BUILD_ID=$(date +%s)
 [ "${WORKSPACE}" != "" ]         || export WORKSPACE=$(pwd) && cd $WORKSPACE
+
 if [ "${SINGULARITY_IMAGE}" = "" ] ; then
   osver=$(echo ${SCRAM_ARCH} | tr '_' '\n' | head -1 | sed 's|^[a-z][a-z]*||')
   ls /cvmfs/singularity.opensciencegrid.org >/dev/null 2>&1 || true

--- a/report-summary-merged-prs
+++ b/report-summary-merged-prs
@@ -672,6 +672,7 @@ def print_results(results):
             print(comp['compared_tags'])
 
             print('\t' + 'HLT Tests: ' + comp['hlt_tests'])
+            print('\t' + 'Crab Tests: ' + comp['crab_tests'])
             print('\t' + 'HEADER Tests:' + comp['check-headers'])
             print('\t' + 'DQM Tests: ' + comp['dqm_tests'])
             print('\t' + 'Static Checks: ' + comp['static_checks'])
@@ -841,6 +842,8 @@ def add_tests_to_results(results, unit_tests, relvals_results,
                 comp['static_checks'] = 'not-found'
             if not comp.get('hlt_tests'):
                 comp['hlt_tests'] = 'not-found'
+            if not comp.get('crab_tests'):
+                comp['crab_tests'] = 'not-found'
             if not comp.get('check-headers'):
                 comp['check-headers'] = 'not-found'
             if not comp.get('valgrind'):
@@ -1057,6 +1060,13 @@ def find_check_hlt(comparisons, architecture):
         rel_name = comp['compared_tags'].split('-->')[1]
         print("Looking for {0} results for {1}.".format('hlt', rel_name))
         comp['hlt_tests'] = find_and_check_result(rel_name, architecture, CHECK_HLT_PATH, 'grep -c "exit status: *[1-9]" {0}')
+
+
+def find_check_crab(comparisons, architecture):
+    for comp in comparisons:
+        rel_name = comp['compared_tags'].split('-->')[1]
+        print("Looking for {0} results for {1}.".format('crab', rel_name))
+        comp['crab_tests'] = find_and_check_result(rel_name, architecture, CHECK_CRAB_PATH, 'grep -c "FAILED" {0}')
 
 
 def find_check_headers(comparisons, architecture):
@@ -1449,6 +1459,7 @@ if __name__ == "__main__":
     MAGIC_COMMAND_COMPARISON_BASELINE_ERRORS = 'cat ' + JENKINS_ARTIFACTS_DIR + '/ib-baseline-tests/RELEASE_NAME/ARCHITECTURE/-GenuineIntel/matrix-results/wf_errors.txt'
     COMPARISON_BASELINE_TESTS_URL = 'https://cmssdt.cern.ch/' + JENKINS_ARTIFACTS_SUBDIR + '/ib-baseline-tests/RELEASE_NAME/ARCHITECTURE/-GenuineIntel/matrix-results'
     CHECK_HLT_PATH = JENKINS_ARTIFACTS_DIR + '/HLT-Validation/RELEASE_NAME/ARCHITECTURE/jenkins.log'
+    CHECK_CRAB_PATH = JENKINS_ARTIFACTS_DIR + 'ib-run-crab/RELEASE_NAME/ARCHITECTURE/*/statusfile'
     MAGIC_COMMAND_FIND_DQM_TESTS = 'test -d ' + JENKINS_ARTIFACTS_DIR + '/ib-dqm-tests/RELEASE_NAME'
     MAGIC_COMMAND_FIND_LIZARD = 'test -d ' + JENKINS_ARTIFACTS_DIR + '/lizard/RELEASE_NAME/ARCHITECTURE'
     MAGIC_COMMAND_FIND_CHECK_HEADERS = 'test -d ' + JENKINS_ARTIFACTS_DIR + '/check_headers/RELEASE_NAME/ARCHITECTURE'
@@ -1589,6 +1600,8 @@ if __name__ == "__main__":
                 tests_to_find = additional_tests[arch]
                 if 'HLT' in tests_to_find:
                     find_check_hlt(release_queue_results['comparisons'], arch)
+                if 'crab' in tests_to_find:
+                    find_check_crab(release_queue_results['comparisons'], arch)
                 if 'static-checks' in tests_to_find:
                     find_static_results(release_queue_results['comparisons'], arch)
                 if 'material-budget' in tests_to_find:


### PR DESCRIPTION
Hi,

I have modified the `.sh` files since the reporting of the FAILED status was missing. If `ib-run-crab.sh` fails, `ib-monitor-crab.sh` doesn't run, so I am not sure if we want to report a FAILED status if the monitoring fails.

Many thanks,
Andrea.