### PR TITLE
When running igprof ensure that compiler include paths are added to ROOT_INCLUDE_PATH 

### DIFF
--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -273,6 +273,11 @@ def writeProfilingScript(wfdir, runscript, cmdlist):
         #print commands verbosely
         fi.write("set -x\n")
 
+        # ensure that compiler include paths are added to ROOT_INCLUDE_PATH 
+        fi.write("for path in $(LC_ALL=C g++   -xc++ -E -v /dev/null 2>&1 | sed -n -e '/^.include/,${' -e '/^ \/.*++/p' -e '}');do ROOT_INCLUDE_PATH=$path:$ROOT_INCLUDE_PATH; done")
+        fi.write("\n")
+
+        fi.write("")
         fi.write("\n")
         for cmd in cmdlist:
             fi.write(cmd + '\n')

--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -5,6 +5,10 @@ WORKFLOWS=$1
 PROFILES=$2
 EVENTS=$3
 PROFILING_WORKFLOWS=$(grep "PR_TEST_MATRIX_EXTRAS_PROFILING=" $CMS_BOT_DIR/cmssw-pr-test-config | sed 's|.*=||;s|,| |g')
+
+# ensure that compiler include paths are added to ROOT_INCLUDE_PATH 
+for path in $(LC_ALL=C g++   -xc++ -E -v /dev/null 2>&1 | sed -n -e '/^.include/,${' -e '/^ \/.*++/p' -e '}');do ROOT_INCLUDE_PATH=$path:$ROOT_INCLUDE_PATH; done
+
 if [ "X$EVENTS" = "X" ] ; then EVENTS=100; fi
 for prof in ${PROFILES} ; do
   mkdir -p $WORKSPACE/igprof/${prof}


### PR DESCRIPTION
Something in Igprof's instrumenting of fork causes an error in `cling::CIFactory::createCI()`
The workaround for now is to execute the command that createCI runs to get the compiler paths and add those to ROOT_INCLUDE_PATH.

```
ERROR in cling::CIFactory::createCI(): cannot extract standard library include paths!
Invoking:
  LC_ALL=C g++   -xc++ -E -v /dev/null 2>&1 | sed -n -e '/^.include/,${' -e '/^ \/.*++/p' -e '}'
Results was:
 /cvmfs/cms-ib.cern.ch/nweek-02734/el8_amd64_gcc10/external/gcc/10.3.0-84898dea653199466402e67d73657f10/bin/../lib/gcc/x86_64-redhat-linux-gnu/10.3.0/../../../../include/c++/10.3.0
 /cvmfs/cms-ib.cern.ch/nweek-02734/el8_amd64_gcc10/external/gcc/10.3.0-84898dea653199466402e67d73657f10/bin/../lib/gcc/x86_64-redhat-linux-gnu/10.3.0/../../../../include/c++/10.3.0/x86_64-redhat-linux-gn
u
 /cvmfs/cms-ib.cern.ch/nweek-02734/el8_amd64_gcc10/external/gcc/10.3.0-84898dea653199466402e67d73657f10/bin/../lib/gcc/x86_64-redhat-linux-gnu/10.3.0/../../../../include/c++/10.3.0/backward
With exit code 0
```
This leads to a dictionary error when loading root files
```
In file included from DataFormatsCandidate_xr dictionary payload:82:
In file included from /cvmfs/cms-ib.cern.ch/nweek-02735/el8_amd64_gcc10/cms/cmssw-patch/CMSSW_12_5_X_2022-05-31-1100/src/DataFormats/Common/interface/AssociationMap.h:41:
In file included from /cvmfs/cms-ib.cern.ch/nweek-02735/el8_amd64_gcc10/external/tbb/v2021.5.0-e966a5acb1e4d5fd7605074bafbb079c/include/oneapi/tbb/concurrent_unordered_map.h:22:
/cvmfs/cms-ib.cern.ch/nweek-02735/el8_amd64_gcc10/external/tbb/v2021.5.0-e966a5acb1e4d5fd7605074bafbb079c/include/oneapi/tbb/tbb_allocator.h:26:10: fatal error: 'memory_resource' file not found
#include <memory_resource>
         ^~~~~~~~~~~~~~~~~
31-May-2022 10:51:58 UTC  Closed file root://eoscms.cern.ch//eos/cms/store/user/cmsbuild/store/relval/CMSSW_12_1_0_pre2/RelValMinBias_14TeV/GEN-SIM/113X_mcRun4_realistic_v7_2026D77noPU-v1/10000/3cb96e45-120e-4060-980c-2f6292ae3edb.root
31-May-2022 10:51:58 UTC  Closed file file:step1.root
```