### PR TITLE
Adding Chris to alca watchers

### DIFF
--- a/category-watchers.yaml
+++ b/category-watchers.yaml
@@ -11,3 +11,5 @@ beaucero:
 - upgrade
 trtomei:
 - upgrade
+ChrisMisan:
+- alca


### PR DESCRIPTION
Adding @ChrisMisan as watcher of `alca` since he will soon start as AlCa L3 Software Coordinator (once he will officially start we will update `categories.py` as well).

FYI @malbouis @tvami 