### PR TITLE
Add new heterogeneous packages

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -856,6 +856,7 @@ CMSSW_CATEGORIES = {
     "DataFormats/SoATemplate",
     "HeterogeneousCore/AlpakaCore",
     "HeterogeneousCore/AlpakaInterface",
+    "HeterogeneousCore/AlpakaServices",
     "HeterogeneousCore/AlpakaTest",
     "HeterogeneousCore/CUDACore",
     "HeterogeneousCore/CUDAServices",


### PR DESCRIPTION
Add new packages related to Alpaka and portable data formats to the "heterogeneous" category:
  - `HeterogeneousCore/AlpakaServices`