### PR TITLE
New SimPPS/DirectSimProducer subpackage for simulation 

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1560,6 +1560,7 @@ CMSSW_CATEGORIES = {
     "SimMuon/Neutron",
     "SimMuon/RPCDigitizer",
     "SimPPS/Configuration",
+    "SimPPS/DirectSimProducer",
     "SimPPS/PPSPixelDigiProducer",
     "SimPPS/PPSSimTrackProducer",
     "SimPPS/RPDigiProducer",


### PR DESCRIPTION
Adding `SimPPS/DirectSimProducer` to the `simulation` category, in line with https://github.com/cms-sw/cmssw/pull/38280