### PR TITLE
move `MuonAnalysis/MomentumScaleCalibration` from analysis to alca, in absence of an analysis signature

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -154,6 +154,7 @@ CMSSW_CATEGORIES = {
     "IORawData/DTCommissioning",
     "IORawData/HcalTBInputService",
     "IORawData/SiPixelInputSources",
+    "MuonAnalysis/MomentumScaleCalibration",
     "RecoVertex/BeamSpotProducer",
   ],
   "analysis": [
@@ -204,7 +205,6 @@ CMSSW_CATEGORIES = {
     "JetMETCorrections/MinBias",
     "JetMETCorrections/TauJet",
     "MuonAnalysis/Configuration",
-    "MuonAnalysis/MomentumScaleCalibration",
     "MuonAnalysis/MuonAssociators",
     "PhysicsTools/CandAlgos",
     "PhysicsTools/CandUtils",


### PR DESCRIPTION
As per comment https://github.com/cms-sw/cmssw/pull/39029#issuecomment-1211900500
and as it is close enough.
@cms-sw/alca-l2 please confirm if you agree.