### PR TITLE
Jenkins log parser: additional string for git failures

### DIFF
--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -100,7 +100,7 @@
         "errorStr": [
           "fatal: repository .* not found",
           "Tag already exist",
-          "Connection to github\.com closed by remote host."
+          "Connection to github\\.com closed by remote host."
         ],
         "action": "retryBuild"
       },

--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -99,7 +99,8 @@
       "gitErrors": {
         "errorStr": [
           "fatal: repository .* not found",
-          "Tag already exist"
+          "Tag already exist",
+          "Connection to github\.com closed by remote host."
         ],
         "action": "retryBuild"
       },


### PR DESCRIPTION
Detect `Connection to github.com closed by remote host.` message and treat it as git failure.