### PR TITLE
clean-up TRK DPG / POG categories

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -85,8 +85,8 @@ CMSSW_L2 = {
   "saumyaphor4252":   ["alca","db"],
   CMSBUILD_USER:      ["tests" ],
   # dpgs
-  "tsusa":            ["trk-dpg"],
   "connorpa":         ["trk-dpg"],
+  "sroychow":         ["trk-dpg"],
   "simonepigazzini":  ["ecal-dpg"],
   "jainshilpi":       ["ecal-dpg"],
   "thomreis":         ["ecal-dpg"],
@@ -132,8 +132,7 @@ CMSSW_L2 = {
   "kandrosov":        ["tau-pog"],
   "alebihan":         ["tau-pog"],
   "slava77":          ["tracking-pog"],
-  "vmariani":         ["tracking-pog"],
-  "mmusich":          ["tracking-pog","trk-dpg"],
+  "mmusich":          ["tracking-pog"],
 }
 
 #All CMS_SDT members can sign externals ( e.g Pull Requests in cms-sw/cmsdist , cms-data and cms-externals


### PR DESCRIPTION
update TRK DPG and TRK POG lists with conveners as of 1st Sept 2022.
@vmariani @sroychow @tsusa please shout if you disagree ;)