### PR TITLE
[Jenkins parser job] Add new git error to parser and remove ib-tag-and-schdule

### DIFF
--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -83,7 +83,7 @@
       },
       {
         "jobName": "ib-tag-and-schdule",
-        "errorType": ["gitErrors"],
+        "errorType": [],
         "maxTime": "18"
       }
     ],

--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -110,7 +110,8 @@
         "errorStr": [
           "fatal: repository .* not found",
           "Tag already exist",
-          "Connection to github\\.com closed by remote host."
+          "Connection to github\\.com closed by remote host.",
+	  "Error while downloading sources from github\\.com"
         ],
         "action": "retryBuild"
       },


### PR DESCRIPTION
Based on failure in [`build-any-ib` CMSSW_12_6_X_2022-09-06-2300 - el8_ppc64le_gcc10](https://cmssdt.cern.ch/jenkins/job/build-any-ib/136942/)