### PR TITLE
Add `CUDADataFormats/PortableTestObjects` under `heterogeneous`

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -845,6 +845,7 @@ CMSSW_CATEGORIES = {
     "CUDADataFormats/HGCal",
     "CUDADataFormats/HcalDigi",
     "CUDADataFormats/HcalRecHitSoA",
+    "CUDADataFormats/PortableTestObjects",
     "CUDADataFormats/SiPixelCluster",
     "CUDADataFormats/SiPixelDigi",
     "CUDADataFormats/SiStripCluster",


### PR DESCRIPTION
Adds the new package `CUDADataFormats/PortableTestObjects` introduced in https://github.com/cms-sw/cmssw/pull/39319 .