### PR TITLE
[Jenkins parser] Remove new running builds from list of pending builds 

### DIFF
--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -18,7 +18,7 @@
           "timedOut",
           "segmentationFault"
         ],
-        "maxTime": "5"
+        "maxTime": "10"
       },
       {
         "jobName": "ib-run-profiling",
@@ -74,7 +74,7 @@
       {
         "jobName": "ib-run-pr-tests",
         "errorType": ["gitErrors"],
-        "maxTime": "10"
+        "maxTime": "12"
       },
       {
         "jobName": "update-github-pages",


### PR DESCRIPTION
This PR solves the issue of the parser job sending multiple emails if a new running build (having a build number grater than the parser's last processed build) runs for more than the specified maximum running time (`maxTime` in `jobs-config.json`).

Maximum running times for `ib-run-igprof` and `ib-run-pr-tests` have been also extended.