### PR TITLE
[Jenkins parser] Add options to force retry and to check concrete error message in all jobs

### DIFF
--- a/jenkins/parser/jenkins-parser-job.py
+++ b/jenkins/parser/jenkins-parser-job.py
@@ -36,7 +36,7 @@ def get_errors_list(jobs_object, job_id):
                 jobs_object["jobsConfig"]["errorMsg"][ii]["errorStr"]
             )
     # Get the error keys of the concrete job ii
-    error_keys = jobs_object["jobsConfig"]["jenkinsJobs"][job_id]["errorType"]
+    error_keys = jobs_object["jobsConfig"]["jenkinsJobs"][job_id]["errorType"][:]
     error_keys.extend(common_keys)
     error_keys = list(set(error_keys))
 

--- a/jenkins/parser/jenkins-parser-job.py
+++ b/jenkins/parser/jenkins-parser-job.py
@@ -23,10 +23,22 @@ def grep(filename, pattern, verbose=False):
 def get_errors_list(jobs_object, job_id):
     """Get list of errors to check for a concrete job with the corresponding action."""
 
-    # Get the error keys of the concrete job ii
+    # Get errorMsg object
     jenkins_errors = jobs_object["jobsConfig"]["errorMsg"]
-
+    # Get common error messages and regex that must be force retried
+    common_keys = []
+    force_retry_regex = []
+    for ii in jobs_object["jobsConfig"]["errorMsg"].keys():
+        if jobs_object["jobsConfig"]["errorMsg"][ii]["allJobs"] == "true":
+            common_keys.append(ii)
+        if jobs_object["jobsConfig"]["errorMsg"][ii]["forceRetry"] == "true":
+            force_retry_regex.extend(
+                jobs_object["jobsConfig"]["errorMsg"][ii]["errorStr"]
+            )
+    # Get the error keys of the concrete job ii
     error_keys = jobs_object["jobsConfig"]["jenkinsJobs"][job_id]["errorType"]
+    error_keys.extend(common_keys)
+    error_keys = list(set(error_keys))
 
     # Get the error messages of the error keys
     error_list = []
@@ -46,7 +58,7 @@ def get_errors_list(jobs_object, job_id):
                 "Action not defined. Please define a valid action in "
                 + jobs_config_path
             )
-    return error_list
+    return error_list, force_retry_regex
 
 
 def get_finished_builds(job_dir, last_processed_log):
@@ -136,9 +148,11 @@ def get_running_builds(job_dir, last_processed_log):
     ]
 
 
-def trigger_retry_action(job_to_retry, build_to_retry, build_dir_path, action, regex):
+def trigger_retry_action(
+    job_to_retry, build_to_retry, build_dir_path, action, regex, force_retry_regex
+):
     # Skip autoretry if Jenkins already retries, unless connection issue.
-    if "Remote call on .* failed" not in regex:
+    if regex not in force_retry_regex:
         if grep(os.path.join(build_dir_path, "build.xml"), "<maxSchedule>", True):
             print("... Jenkins already takes care of retrying. Skipping ...")
             if grep(os.path.join(build_dir_path, "build.xml"), "<retryCount>", True):
@@ -347,7 +361,12 @@ def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_a
                 )
                 if action == "retryBuild":
                     trigger_retry_action(
-                        job_to_retry, build_to_retry, build_dir_path, action, regex
+                        job_to_retry,
+                        build_to_retry,
+                        build_dir_path,
+                        action,
+                        regex,
+                        force_retry_regex,
                     )
                 else:
                     # Take action on the nodes
@@ -375,7 +394,12 @@ def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_a
                             job_to_retry, build_to_retry, job_url, node_name
                         )
                         trigger_retry_action(
-                            job_to_retry, build_to_retry, build_dir_path, action, regex
+                            job_to_retry,
+                            build_to_retry,
+                            build_dir_path,
+                            action,
+                            regex,
+                            force_retry_regex,
                         )
                         notify_nodeoff(
                             node_name,
@@ -391,7 +415,12 @@ def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_a
                             job_ro_retry, build_to_retry, job_url, node_name
                         )
                         trigger_retry_action(
-                            job_to_retry, build_to_retry, build_dir_path, action, regex
+                            job_to_retry,
+                            build_to_retry,
+                            build_dir_path,
+                            action,
+                            regex,
+                            force_retry_regex,
                         )
                         notify_nodereconnect(
                             node_name,
@@ -575,7 +604,7 @@ if __name__ == "__main__":
     # Parsing the build id of the current job
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "parser_build_id", help="input current build id from Jenkins env vars"
+        "parser_build_id", help="Input current build id from Jenkins env vars"
     )
     args = parser.parse_args()
     parser_build_id = args.parser_build_id
@@ -606,7 +635,7 @@ if __name__ == "__main__":
             print("[" + job_to_retry + "] Processing ...")
             job_dir = os.path.join(builds_dir, job_to_retry)
 
-            error_list = get_errors_list(jobs_object, job_id)
+            error_list, force_retry_regex = get_errors_list(jobs_object, job_id)
 
             last_processed_log, processed_object = get_last_processed_log(
                 parser_info_path, job_to_retry

--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -92,19 +92,25 @@
         "errorStr": [
           "Build timed out"
         ],
-        "action": "retryBuild"
+        "action": "retryBuild",
+	"forceRetry": "false",
+	"allJobs": "false"
       },
       "hudsonConnection": {
         "errorStr": [
           "Remote call on .* failed. The channel is closing down or has closed down"
         ],
-        "action": "retryBuild"
+        "action": "retryBuild",
+        "forceRetry": "true",
+        "allJobs": "true"
       },
       "segmentationFault": {
         "errorStr": [
           "unexpected fault address"
         ],
-        "action": "retryBuild"
+        "action": "retryBuild",
+        "forceRetry": "false",
+        "allJobs": "false"
       },
       "gitErrors": {
         "errorStr": [
@@ -113,32 +119,42 @@
           "Connection to github\\.com closed by remote host.",
 	  "Error while downloading sources from github\\.com"
         ],
-        "action": "retryBuild"
+        "action": "retryBuild",
+        "forceRetry": "false",
+        "allJobs": "false"
       },
       "busError": {
         "errorStr": [
           "Bus error",
           "Transport endpoint is not connected"
         ],
-        "action": "nodeOff"
+        "action": "nodeOff",
+        "forceRetry": "false",
+        "allJobs": "false"
       },
       "gridConnection": {
         "errorStr": [
           "Unexpected exception occurred while performing connect-node command"
         ],
-        "action": "retryBuild"
+        "action": "retryBuild",
+        "forceRetry": "false",
+        "allJobs": "false"
       },
       "afsFailure": {
         "errorStr": [
           "no such identity: .* Permission denied"
         ],
-        "action": "nodeOff"
+        "action": "nodeOff",
+        "forceRetry": "false",
+        "allJobs": "false"
       },
       "workspaceFailure": {
         "errorStr": [
           "Cannot delete workspace: Remote call on .* failed"
         ],
-        "action": "nodeReconnect"
+        "action": "nodeReconnect",
+        "forceRetry": "false",
+        "allJobs": "true"
       }
     }
   }


### PR DESCRIPTION
The fix is already running in Jenkins for testing purposes in https://cmssdt.cern.ch/jenkins/job/jenkins-test-parser/17230/ and runs successfully.

It fixes jobs like [ib-run-HLT](https://cmssdt.cern.ch/jenkins/job/ib-run-HLT/), where Jenkins is configured to self-retry if the build fails, but it doesn't schedule the retry if the build fails because of connection issues.

@smuzaffar, do you have any other suggestion rather than hardcoding the regex _Remote call on .* failed_?
 