### PR TITLE
[Jenkins parser] Fix continuous notifications and code refactor

### DIFF
--- a/jenkins/parser/actions.py
+++ b/jenkins/parser/actions.py
@@ -1,0 +1,227 @@
+import functools
+import os
+import time
+
+import helpers
+
+
+email_addresses = "cms-sdt-logs@cern.ch"
+
+
+def send_email(email_msg, email_subject, email_addresses):
+    email_cmd = (
+        'echo "' + email_msg + '" | mail -s "' + email_subject + '" ' + email_addresses
+    )
+    print(email_cmd)
+    os.system(email_cmd)
+
+
+def trigger_retry_action(
+    job_to_retry, build_to_retry, build_dir_path, action, regex, force_retry_regex
+):
+    # Skip autoretry if Jenkins already retries, unless connection issue.
+    if regex not in force_retry_regex:
+        if helpers.grep(
+            os.path.join(build_dir_path, "build.xml"), "<maxSchedule>", True
+        ):
+            print("... Jenkins already takes care of retrying. Skipping ...")
+            if helpers.grep(
+                os.path.join(build_dir_path, "build.xml"), "<retryCount>", True
+            ):
+                return
+            # Update description of the failed job
+            update_label = (
+                os.environ.get("JENKINS_CLI_CMD")
+                + " set-build-description "
+                + job_to_retry
+                + " "
+                + build_to_retry
+                + " 'Retried\ by\ Jenkins'"
+            )
+            print(update_label)
+            os.system(update_label)
+            return
+
+    trigger_retry = (
+        os.environ.get("JENKINS_CLI_CMD")
+        + " build jenkins-test-retry -p JOB_TO_RETRY="
+        + job_to_retry
+        + " -p BUILD_TO_RETRY="
+        + build_to_retry
+        + " -p ACTION="
+        + action
+        + ' -p ERROR="'
+        + str(regex.replace(" ", "&"))
+        + '"'
+    )
+    print(trigger_retry)
+    os.system(trigger_retry)
+
+
+def trigger_nodeoff_action(job_to_retry, build_to_retry, job_url, node_name):
+    nodeoff_msg = "'Node\ marked\ as\ offline\ beacuse\ of\ " + job_url + "'"
+    take_nodeoff = (
+        os.environ.get("JENKINS_CLI_CMD")
+        + " offline-node "
+        + node_name
+        + " -m "
+        + nodeoff_msg
+    )
+    print(take_nodeoff)
+    os.system(take_nodeoff)
+
+    # Update description of the failed job
+    update_label = (
+        os.environ.get("JENKINS_CLI_CMD")
+        + " set-build-description "
+        + job_to_retry
+        + " "
+        + build_to_retry
+        + " 'Node\ marked\ as\ offline\ and\ job\ retried.\ Please,\ take\ the\ appropiate\ action\ and\ relaunch\ the\ node.\ Also,\ make\ sure\ that\ the\ job\ is\ running\ fine\ now.\ It\ might\ be\ queueing.'"
+    )
+    print(update_label)
+    os.system(update_label)
+
+
+def trigger_reconnect_action(job_to_retry, build_to_retry, job_url, node_name):
+    nodeoff_msg = "'Node\ reconnected\ by\ " + job_url + "'"
+    disconnect_node = (
+        os.environ.get("JENKINS_CLI_CMD")
+        + " disconnect-node "
+        + node_name
+        + " -m "
+        + nodeoff_msg
+    )
+    connect_node = (
+        os.environ.get("JENKINS_CLI_CMD") + " connect-node " + node_name + " -f"
+    )
+    print(disconnect_node)
+    os.system(disconnect_node)
+    time.sleep(10)
+    print(connect_node)
+    os.system(connect_node)
+
+    # Update description of the failed job
+    update_label = (
+        os.environ.get("JENKINS_CLI_CMD")
+        + " set-build-description "
+        + job_to_retry
+        + " "
+        + build_to_retry
+        + " 'Node\ has\ been\ forced\ to\ reconnect\ and\ job\ has\ been\ retried.\ Please,\ make\ sure\ that\ the\ node\ is\ in\ good\ state\ and job\ is\ running\ fine\ now.\ It\ might\ be\ queueing.'"
+    )
+    print(update_label)
+    os.system(update_label)
+
+
+def notify_nodeoff(
+    node_name, regex, job_to_retry, build_to_retry, job_url, node_url, parser_url
+):
+    email_msg = (
+        "Node "
+        + node_name
+        + " has been disconnected because of an error of type <"
+        + regex
+        + "> in job "
+        + job_to_retry
+        + " build number "
+        + build_to_retry
+        + ".\nPlease, take the appropiate action.\n\nFailed job: "
+        + job_url
+        + "\n\nDisconnected node: "
+        + node_url
+        + "\n\nParser job: "
+        + parser_url
+    )
+    email_subject = "Node " + node_name + " disconnected by jenkins-test-parser job"
+    send_email(email_msg, email_subject, email_addresses)
+
+
+def notify_nodereconnect(
+    node_name, regex, job_to_retry, build_to_retry, job_url, node_url, parser_url
+):
+    email_msg = (
+        "Node "
+        + node_name
+        + " has been forced to reconnect because of an error of type <"
+        + regex
+        + "> in job "
+        + job_to_retry
+        + " build number "
+        + build_to_retry
+        + ".\nPlease, take the appropiate action.\n\nFailed job: "
+        + job_url
+        + "\n\nAffected node: "
+        + node_url
+        + "\n\nParser job: "
+        + parser_url
+    )
+    email_subject = "Node " + node_name + " reconnected by jenkins-test-parser job"
+    send_email(email_msg, email_subject, email_addresses)
+
+
+def notify_pendingbuild(
+    display_name, build_to_retry, job_to_retry, duration, job_url, parser_url
+):
+    email_msg = (
+        "Build"
+        + display_name
+        + " (#"
+        + build_to_retry
+        + ") from job "
+        + job_to_retry
+        + " has been running for an unexpected amount of time.\nTotal running time: "
+        + str(duration)
+        + ".\nPlease, take the appropiate action.\n\nPending job: "
+        + job_url
+        + "\n\nParser job: "
+        + parser_url
+    )
+
+    email_subject = (
+        "Pending build "
+        + display_name
+        + " (#"
+        + build_to_retry
+        + ") from job "
+        + job_to_retry
+    )
+
+    email_cmd = (
+        'echo "' + email_msg + '" | mail -s "' + email_subject + '" ' + email_addresses
+    )
+    send_email(email_msg, email_subject, email_addresses)
+
+
+def mark_build_as_retried(job_dir, job_to_retry, build_to_retry):
+    if helpers.grep(
+        functools.reduce(os.path.join, [job_dir, build_to_retry, "build.xml"]),
+        "jenkins-test-retry",
+        verbose=False,
+    ):
+        label = "Retried'\ 'build"
+
+        update_label = (
+            os.environ.get("JENKINS_CLI_CMD")
+            + " set-build-description "
+            + job_to_retry
+            + " "
+            + build_to_retry
+            + " "
+            + label
+        )
+        print(update_label)
+        os.system(update_label)
+
+
+def update_no_action_label(job_to_retry, build_to_retry):
+    update_label = (
+        os.environ.get("JENKINS_CLI_CMD")
+        + " set-build-description "
+        + job_to_retry
+        + " "
+        + build_to_retry
+        + " '[No\ action\ has\ been\ taken\ by\ the\ parser\ job]'"
+    )
+    print(update_label)
+    os.system(update_label)

--- a/jenkins/parser/helpers.py
+++ b/jenkins/parser/helpers.py
@@ -1,0 +1,98 @@
+import functools
+import os
+import re
+
+
+def grep(filename, pattern, verbose=False):
+    """Bash-like grep function. Set verbose=True to print the line match."""
+    with open(filename, "r") as file:
+        for line in file:
+            if re.search(pattern, line):
+                if verbose:
+                    return line
+                else:
+                    return True
+
+
+def get_errors_list(jobs_object, job_id):
+    """Get list of errors to check for a concrete job with the corresponding action."""
+
+    # Get errorMsg object
+    jenkins_errors = jobs_object["jobsConfig"]["errorMsg"]
+    # Get common error messages and regex that must be force retried
+    common_keys = []
+    force_retry_regex = []
+
+    for ii in jobs_object["jobsConfig"]["errorMsg"].keys():
+        # Check if allJobs field has been set
+        if jobs_object["jobsConfig"]["errorMsg"][ii].get("allJobs") == "true":
+            common_keys.append(ii)
+        else:
+            # If not, check value from defaultConfig section
+            if jobs_object["defaultConfig"]["allJobs"] == "true":
+                common_keys.append(ii)
+
+        # Check if forceRetry field has been set
+        if jobs_object["jobsConfig"]["errorMsg"][ii].get("forceRetry") == "true":
+            force_retry_regex.extend(
+                jobs_object["jobsConfig"]["errorMsg"][ii]["errorStr"]
+            )
+        else:
+            # If not, check value from defaultConfig section
+            if jobs_object["defaultConfig"]["forceRetry"] == "true":
+                force_retry_regex.extend(
+                    jobs_object["jobsConfig"]["errorMsg"][ii]["errorStr"]
+                )
+
+    # Get the error keys of the concrete job ii
+    error_keys = jobs_object["jobsConfig"]["jenkinsJobs"][job_id]["errorType"][:]
+    error_keys.extend(common_keys)
+    error_keys = list(set(error_keys))
+
+    error_list = append_actions(error_keys, jenkins_errors)
+
+    return error_list, force_retry_regex
+
+
+def append_actions(error_keys, jenkins_errors):
+    """ Match error regex with the action to perform."""
+    # Get the error messages of the error keys
+    error_list = []
+    # We append the action to perform to the error message
+    for ii in error_keys:
+        if jenkins_errors[ii]["action"] == "retryBuild":
+            for error in jenkins_errors[ii]["errorStr"]:
+                error_list.append(error + " - retryBuild")
+        elif jenkins_errors[ii]["action"] == "nodeOff":
+            for error in jenkins_errors[ii]["errorStr"]:
+                error_list.append(error + " - nodeOff")
+        elif jenkins_errors[ii]["action"] == "nodeReconnect":
+            for error in jenkins_errors[ii]["errorStr"]:
+                error_list.append(error + " - nodeReconnect")
+    return error_list
+
+
+def get_finished_builds(job_dir, running_builds):
+    """Check if any build has finished."""
+    return [
+        build
+        for build in running_builds
+        if grep(
+            functools.reduce(os.path.join, [job_dir, build, "build.xml"]), "<result>",
+        )
+    ]
+
+
+def get_running_builds(job_dir):
+    """Get list of new running builds that have been started after the last processed log."""
+    return [
+        dir.name
+        for dir in os.scandir(job_dir)
+        if dir.name.isdigit()
+        and os.path.isfile(
+            functools.reduce(os.path.join, [job_dir, dir.name, "build.xml"])
+        )
+        and not grep(
+            functools.reduce(os.path.join, [job_dir, dir.name, "build.xml"]), "<result>"
+        )
+    ]

--- a/jenkins/parser/jenkins-parser-job.py
+++ b/jenkins/parser/jenkins-parser-job.py
@@ -8,326 +8,12 @@ import os
 import re
 import time
 
-
-def grep(filename, pattern, verbose=False):
-    """Bash-like grep function. Set verbose=True to print the line match."""
-    with open(filename, "r") as file:
-        for line in file:
-            if re.search(pattern, line):
-                if verbose:
-                    return line
-                else:
-                    return True
-
-
-def get_errors_list(jobs_object, job_id):
-    """Get list of errors to check for a concrete job with the corresponding action."""
-
-    # Get errorMsg object
-    jenkins_errors = jobs_object["jobsConfig"]["errorMsg"]
-    # Get common error messages and regex that must be force retried
-    common_keys = []
-    force_retry_regex = []
-    for ii in jobs_object["jobsConfig"]["errorMsg"].keys():
-        if jobs_object["jobsConfig"]["errorMsg"][ii]["allJobs"] == "true":
-            common_keys.append(ii)
-        if jobs_object["jobsConfig"]["errorMsg"][ii]["forceRetry"] == "true":
-            force_retry_regex.extend(
-                jobs_object["jobsConfig"]["errorMsg"][ii]["errorStr"]
-            )
-    # Get the error keys of the concrete job ii
-    error_keys = jobs_object["jobsConfig"]["jenkinsJobs"][job_id]["errorType"][:]
-    error_keys.extend(common_keys)
-    error_keys = list(set(error_keys))
-
-    # Get the error messages of the error keys
-    error_list = []
-    # We append the action to perform to the error message
-    for ii in error_keys:
-        if jenkins_errors[ii]["action"] == "retryBuild":
-            for error in jenkins_errors[ii]["errorStr"]:
-                error_list.append(error + " - retryBuild")
-        elif jenkins_errors[ii]["action"] == "nodeOff":
-            for error in jenkins_errors[ii]["errorStr"]:
-                error_list.append(error + " - nodeOff")
-        elif jenkins_errors[ii]["action"] == "nodeReconnect":
-            for error in jenkins_errors[ii]["errorStr"]:
-                error_list.append(error + " - nodeReconnect")
-        else:
-            print(
-                "Action not defined. Please define a valid action in "
-                + jobs_config_path
-            )
-    return error_list, force_retry_regex
-
-
-def get_finished_builds(job_dir, last_processed_log):
-    """Get list of finished builds for a concrete job.
-       A build is finished if there is the <results> keyword in build.xml.
-       Some sanity checks are also performed."""
-    return [
-        dir.name
-        for dir in os.scandir(job_dir)
-        if dir.name.isdigit()
-        and int(dir.name) > int(last_processed_log)
-        and os.path.isfile(
-            functools.reduce(os.path.join, [job_dir, dir.name, "build.xml"])
-        )
-        and grep(
-            functools.reduce(os.path.join, [job_dir, dir.name, "build.xml"]),
-            "<result>",
-        )
-    ]
-
-
-def get_pending_builds(
-    job_dir, job_to_retry, last_processed_log, parser_info_path, running_builds
-):
-    """Get list of long running builds that are left behind in the trend list.
-       Report the value from the last run and update it."""
-    pending_builds = [
-        dir.name
-        for dir in os.scandir(job_dir)
-        if dir.name.isdigit()
-        and int(dir.name) <= int(last_processed_log)
-        and os.path.isfile(
-            functools.reduce(os.path.join, [job_dir, dir.name, "build.xml"])
-        )
-        and not grep(
-            functools.reduce(os.path.join, [job_dir, dir.name, "build.xml"]), "<result>"
-        )
-    ]
-
-    # We first check for the old running builds of last run
-    with open(parser_info_path, "r") as rotation_file:
-        last_pending_builds_object = json.load(rotation_file)
-        last_pending_builds_dict = last_pending_builds_object["parserInfo"][
-            "runningBuilds"
-        ]
-
-    if job_to_retry not in last_pending_builds_dict:
-        last_pending_builds_dict[job_to_retry] = dict()
-        last_pending_builds = dict()
-    else:
-        last_pending_builds = last_pending_builds_dict[job_to_retry]
-
-    # Remove new running builds from list of old builds:
-    last_pending_builds = list(set(last_pending_builds.keys()) - set(running_builds))
-
-    # Update value of old running builds in the original object to store it again
-    for build_number in pending_builds:
-        if (
-            build_number
-            not in last_pending_builds_object["parserInfo"]["runningBuilds"][
-                job_to_retry
-            ].keys()
-        ):
-            last_pending_builds_object["parserInfo"]["runningBuilds"][job_to_retry][
-                build_number
-            ] = ""
-
-    with open(parser_info_path, "w") as rotation_file:
-        json.dump(last_pending_builds_object, rotation_file)
-
-    return pending_builds, last_pending_builds
-
-
-def get_running_builds(job_dir, last_processed_log):
-    """Get list of new running builds that have been started after the last processed log."""
-    return [
-        dir.name
-        for dir in os.scandir(job_dir)
-        if dir.name.isdigit()
-        and int(dir.name) > int(last_processed_log)
-        and os.path.isfile(
-            functools.reduce(os.path.join, [job_dir, dir.name, "build.xml"])
-        )
-        and not grep(
-            functools.reduce(os.path.join, [job_dir, dir.name, "build.xml"]), "<result>"
-        )
-    ]
-
-
-def trigger_retry_action(
-    job_to_retry, build_to_retry, build_dir_path, action, regex, force_retry_regex
-):
-    # Skip autoretry if Jenkins already retries, unless connection issue.
-    if regex not in force_retry_regex:
-        if grep(os.path.join(build_dir_path, "build.xml"), "<maxSchedule>", True):
-            print("... Jenkins already takes care of retrying. Skipping ...")
-            if grep(os.path.join(build_dir_path, "build.xml"), "<retryCount>", True):
-                return
-            # Update description of the failed job
-            update_label = (
-                os.environ.get("JENKINS_CLI_CMD")
-                + " set-build-description "
-                + job_to_retry
-                + " "
-                + build_to_retry
-                + " 'Retried\ by\ Jenkins'"
-            )
-            print(update_label)
-            os.system(update_label)
-            return
-
-    trigger_retry = (
-        os.environ.get("JENKINS_CLI_CMD")
-        + " build jenkins-test-retry -p JOB_TO_RETRY="
-        + job_to_retry
-        + " -p BUILD_TO_RETRY="
-        + build_to_retry
-        + " -p ACTION="
-        + action
-    )
-    print(trigger_retry)
-    os.system(trigger_retry)
-
-
-def trigger_nodeoff_action(job_to_retry, build_to_retry, job_url, node_name):
-    nodeoff_msg = "'Node\ marked\ as\ offline\ beacuse\ of\ " + job_url + "'"
-    take_nodeoff = (
-        os.environ.get("JENKINS_CLI_CMD")
-        + " offline-node "
-        + node_name
-        + " -m "
-        + nodeoff_msg
-    )
-    print(take_nodeoff)
-    os.system(take_nodeoff)
-
-    # Update description of the failed job
-    update_label = (
-        os.environ.get("JENKINS_CLI_CMD")
-        + " set-build-description "
-        + job_to_retry
-        + " "
-        + build_to_retry
-        + " 'Node\ marked\ as\ offline\ and\ job\ retried.\ Please,\ take\ the\ appropiate\ action\ and\ relaunch\ the\ node.\ Also,\ make\ sure\ that\ the\ job\ is\ running\ fine\ now.\ It\ might\ be\ queueing.'"
-    )
-    print(update_label)
-    os.system(update_label)
-
-
-def trigger_reconnect_action(job_ro_retry, build_to_retry, job_url, node_name):
-    nodeoff_msg = "'Node\ reconnected\ by\ " + job_url + "'"
-    disconnect_node = (
-        os.environ.get("JENKINS_CLI_CMD")
-        + " disconnect-node "
-        + node_name
-        + " -m "
-        + nodeoff_msg
-    )
-    connect_node = (
-        os.environ.get("JENKINS_CLI_CMD") + " connect-node " + node_name + " -f"
-    )
-    print(disconnect_node)
-    os.system(disconnect_node)
-    time.sleep(10)
-    print(connect_node)
-    os.system(connect_node)
-
-    # Update description of the failed job
-    update_label = (
-        os.environ.get("JENKINS_CLI_CMD")
-        + " set-build-description "
-        + job_to_retry
-        + " "
-        + build_to_retry
-        + " 'Node\ has\ been\ forced\ to\ reconnect\ and\ job\ has\ been\ retried.\ Please,\ make\ sure\ that\ the\ node\ is\ in\ good\ state\ and job\ is\ running\ fine\ now.\ It\ might\ be\ queueing.'"
-    )
-    print(update_label)
-    os.system(update_label)
-
-
-def send_email(email_msg, email_subject, email_addresses):
-    email_cmd = (
-        'echo "' + email_msg + '" | mail -s "' + email_subject + '" ' + email_addresses
-    )
-    print(email_cmd)
-    os.system(email_cmd)
-
-
-def notify_nodeoff(
-    node_name, regex, job_to_retry, build_to_retry, job_url, node_url, parser_url
-):
-    email_msg = (
-        "Node "
-        + node_name
-        + " has been disconnected because of an error of type <"
-        + regex
-        + "> in job "
-        + job_to_retry
-        + " build number "
-        + build_to_retry
-        + ".\nPlease, take the appropiate action.\n\nFailed job: "
-        + job_url
-        + "\n\nDisconnected node: "
-        + node_url
-        + "\n\nParser job: "
-        + parser_url
-    )
-    email_subject = "Node " + node_name + " disconnected by jenkins-test-parser job"
-    send_email(email_msg, email_subject, email_addresses)
-
-
-def notify_nodereconnect(
-    node_name, regex, job_to_retry, build_to_retry, job_url, node_url, parser_url
-):
-    email_msg = (
-        "Node "
-        + node_name
-        + " has been forced to reconnect because of an error of type <"
-        + regex
-        + "> in job "
-        + job_to_retry
-        + " build number "
-        + build_to_retry
-        + ".\nPlease, take the appropiate action.\n\nFailed job: "
-        + job_url
-        + "\n\nAffected node: "
-        + node_url
-        + "\n\nParser job: "
-        + parser_url
-    )
-    email_subject = "Node " + node_name + " reconnected by jenkins-test-parser job"
-    send_email(email_msg, email_subject, email_addresses)
-
-
-def notify_pendingbuild(
-    display_name, build_to_retry, job_to_retry, duration, job_url, parser_url
-):
-    email_msg = (
-        "Build"
-        + display_name
-        + " (#"
-        + build_to_retry
-        + ") from job "
-        + job_to_retry
-        + " has been running for an unexpected amount of time.\nTotal running time: "
-        + str(duration)
-        + ".\nPlease, take the appropiate action.\n\nPending job: "
-        + job_url
-        + "\n\nParser job: "
-        + parser_url
-    )
-
-    email_subject = (
-        "Pending build "
-        + display_name
-        + " (#"
-        + build_to_retry
-        + ") from job "
-        + job_to_retry
-    )
-
-    email_cmd = (
-        'echo "' + email_msg + '" | mail -s "' + email_subject + '" ' + email_addresses
-    )
-    send_email(email_msg, email_subject, email_addresses)
+import helpers
+import actions
 
 
 def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_action):
-    """Check failed build logs and trigger the appropiate action if a known error is found."""
+    """Check build logs and trigger the appropiate action if a known error is found."""
     build_dir_path = os.path.join(job_dir, build_to_retry)
     log_file_path = os.path.join(build_dir_path, "log")
     envvars_file_path = os.path.join(build_dir_path, "injectedEnvVars.txt")
@@ -360,7 +46,7 @@ def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_a
                     + ". Taking action ..."
                 )
                 if action == "retryBuild":
-                    trigger_retry_action(
+                    actions.trigger_retry_action(
                         job_to_retry,
                         build_to_retry,
                         build_dir_path,
@@ -371,7 +57,7 @@ def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_a
                 else:
                     # Take action on the nodes
                     node_name = (
-                        grep(envvars_file_path, "NODE_NAME=", True)
+                        helpers.grep(envvars_file_path, "NODE_NAME=", True)
                         .split("=")[1]
                         .replace("\n", "")
                     )
@@ -390,10 +76,10 @@ def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_a
                     )
 
                     if action == "nodeOff":
-                        trigger_nodeoff_action(
+                        actions.trigger_nodeoff_action(
                             job_to_retry, build_to_retry, job_url, node_name
                         )
-                        trigger_retry_action(
+                        actions.trigger_retry_action(
                             job_to_retry,
                             build_to_retry,
                             build_dir_path,
@@ -401,7 +87,7 @@ def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_a
                             regex,
                             force_retry_regex,
                         )
-                        notify_nodeoff(
+                        actions.notify_nodeoff(
                             node_name,
                             regex,
                             job_to_retry,
@@ -411,10 +97,10 @@ def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_a
                             parser_url,
                         )
                     elif action == "nodeReconnect":
-                        trigger_reconnect_action(
-                            job_ro_retry, build_to_retry, job_url, node_name
+                        actions.trigger_reconnect_action(
+                            job_to_retry, build_to_retry, job_url, node_name
                         )
-                        trigger_retry_action(
+                        actions.trigger_retry_action(
                             job_to_retry,
                             build_to_retry,
                             build_dir_path,
@@ -422,7 +108,7 @@ def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_a
                             regex,
                             force_retry_regex,
                         )
-                        notify_nodereconnect(
+                        actions.notify_nodereconnect(
                             node_name,
                             regex,
                             job_to_retry,
@@ -438,62 +124,51 @@ def check_and_trigger_action(build_to_retry, job_dir, job_to_retry, error_list_a
                 break
         if regex_flag == 1:
             break
+
+    # Mark as retried
+    actions.mark_build_as_retried(job_dir, job_to_retry, build_to_retry)
+
     if regex_flag == 0:
         print("... no known errors were found.")
-
-        if grep(os.path.join(build_dir_path, "build.xml"), "<result>FAILURE"):
+        if helpers.grep(os.path.join(build_dir_path, "build.xml"), "<result>FAILURE"):
             # Update description to inform that no action has been taken
-            update_label = (
-                os.environ.get("JENKINS_CLI_CMD")
-                + " set-build-description "
-                + job_to_retry
-                + " "
-                + build_to_retry
-                + " '[No\ action\ has\ been\ taken\ by\ the\ parser\ job]'"
-            )
-
-            print(update_label)
-            os.system(update_label)
+            actions.update_no_action_label(job_to_retry, build_to_retry)
 
 
-def get_last_processed_log(parser_info_path, job_to_retry):
-    """Get value of the last processed log from the workspace."""
-    with open(parser_info_path, "r") as processed_file:
-        processed_object = json.load(processed_file)
-        try:
-            last_processed_log = processed_object["parserInfo"]["lastRevision"][
-                job_to_retry
-            ]
-        except KeyError:
-            # If last processed log not defined, all logs will be parsed
-            last_processed_log = 1
-            processed_object["parserInfo"]["lastRevision"][
-                job_to_retry
-            ] = last_processed_log
+def check_running_time(job_dir, build_to_retry, job_to_retry, max_running_time=18):
+    """Check builds running time and notify in case it exceeds the maximum time defined (default max time = 18h)."""
+    job_url = (
+        os.environ.get("JENKINS_URL") + "job/" + job_to_retry + "/" + build_to_retry
+    )
+    parser_url = (
+        os.environ.get("JENKINS_URL") + "job/jenkins-test-parser/" + parser_build_id
+    )
 
-    return last_processed_log, processed_object
+    if (
+        processed_object["parserInfo"]["runningBuilds"][job_to_retry][build_to_retry]
+        == "emailSent"
+    ):
+        print(
+            "... Email notification already send for build #"
+            + build_to_retry
+            + " ("
+            + job_url
+            + ")."
+        )
+        return
 
+    build_file_path = functools.reduce(
+        os.path.join, [job_dir, build_to_check, "build.xml"]
+    )
 
-def update_last_processed_log(processed_object, job_to_retry, finished_builds):
-    """Update build number value of the parser's last processed log."""
-    processed_object["parserInfo"]["lastRevision"][job_to_retry] = max(finished_builds)
-
-    with open(parser_info_path, "w") as processed_file:
-        json.dump(processed_object, processed_file)
-
-
-def check_running_time(
-    build_file_path, build_to_retry, job_to_retry, max_running_time=18
-):
-    """Check running time of a build and send a notification if it exceeds the 18h."""
     start_timestamp = (
-        grep(build_file_path, "<startTime>", True)
+        helpers.grep(build_file_path, "<startTime>", True)
         .replace("<startTime>", "")
         .replace("</startTime>", "")
     )
 
     display_name = (
-        grep(build_file_path, "<displayName>", True)
+        helpers.grep(build_file_path, "<displayName>", True)
         .replace("<displayName>", "")
         .replace("</displayName>", "")
         .replace("\n", "")
@@ -503,68 +178,27 @@ def check_running_time(
     now = datetime.datetime.now()
     duration = now - start_datetime
 
-    job_url = (
-        os.environ.get("JENKINS_URL") + "job/" + job_to_retry + "/" + build_to_retry
-    )
-    parser_url = (
-        os.environ.get("JENKINS_URL") + "job/jenkins-test-parser/" + parser_build_id
-    )
-
-    with open(parser_info_path, "r") as rotation_file:
-        last_pending_builds_object = json.load(rotation_file)
-
-    if (
-        build_to_retry
-        not in last_pending_builds_object["parserInfo"]["runningBuilds"][job_to_retry]
-    ):
-        last_pending_builds_object["parserInfo"]["runningBuilds"][job_to_retry][
-            build_to_retry
-        ] = ""
-        with open(parser_info_path, "w") as rotation_file:
-            json.dump(last_pending_builds_object, rotation_file)
-
     if duration > datetime.timedelta(hours=max_running_time):
 
-        if (
-            last_pending_builds_object["parserInfo"]["runningBuilds"][job_to_retry][
-                build_to_retry
-            ]
-            == ""
-        ):
-            print(
-                "Build #"
-                + build_to_retry
-                + " ("
-                + job_url
-                + ") has been running for more than "
-                + str(max_running_time)
-                + " hours!"
-            )
+        print(
+            "Build #"
+            + build_to_retry
+            + " ("
+            + job_url
+            + ") has been running for more than "
+            + str(max_running_time)
+            + " hours!"
+        )
 
-            notify_pendingbuild(
-                display_name,
-                build_to_retry,
-                job_to_retry,
-                duration,
-                job_url,
-                parser_url,
-            )
+        processed_object["parserInfo"]["runningBuilds"][job_to_retry][
+            build_to_retry
+        ] = "emailSent"
 
-            last_pending_builds_object["parserInfo"]["runningBuilds"][job_to_retry][
-                build_to_retry
-            ] = "emailSent"
-            with open(parser_info_path, "w") as rotation_file:
-                json.dump(last_pending_builds_object, rotation_file)
-        else:
-            print(
-                "... Email notification already send for build #"
-                + build_to_retry
-                + " ("
-                + job_url
-                + "). It has been running for "
-                + str(duration)
-                + " hours ... Waiting for action"
-            )
+        # Mark as notified
+        actions.notify_pendingbuild(
+            display_name, build_to_retry, job_to_retry, duration, job_url, parser_url,
+        )
+
     else:
         print(
             "... Build #"
@@ -578,30 +212,67 @@ def check_running_time(
         )
 
 
-def mark_build_as_retried(job_dir, job_to_retry, build_to_retry):
-    if grep(
-        functools.reduce(os.path.join, [job_dir, build_to_retry, "build.xml"]),
-        "jenkins-test-retry",
-        verbose=False,
-    ):
-        label = "Retried'\ 'build"
+def first_iter_check(job_to_retry, job_dir, error_list, processed_object):
+    print("Checking first run for", job_to_retry)
+    # Check if some builds have finished in the mean time
+    try:
+        last_processed_log = processed_object["parserInfo"]["lastRevision"][
+            job_to_retry
+        ]
+    except KeyError:
+        # If last processed log not defined, all logs will be parsed
+        last_processed_log = 1
+        processed_object["parserInfo"]["lastRevision"][
+            job_to_retry
+        ] = last_processed_log
 
-        update_label = (
-            os.environ.get("JENKINS_CLI_CMD")
-            + " set-build-description "
-            + job_to_retry
-            + " "
-            + build_to_retry
-            + " "
-            + label
+    finished_builds = [
+        dir.name
+        for dir in os.scandir(job_dir)
+        if dir.name.isdigit()
+        and int(dir.name) > int(last_processed_log)
+        and os.path.isfile(
+            functools.reduce(os.path.join, [job_dir, dir.name, "build.xml"])
         )
-        print(update_label)
-        os.system(update_label)
+        and helpers.grep(
+            functools.reduce(os.path.join, [job_dir, dir.name, "build.xml"]), "<result>"
+        )
+    ]
+
+    if finished_builds:
+        print(
+            "Builds " + str(finished_builds) + " have already finished. Processing ..."
+        )
+        for build in sorted(finished_builds):
+            check_and_trigger_action(build, job_dir, job_to_retry, error_list)
+            # Cleaning bellow -->
+        processed_object["parserInfo"]["lastRevision"][job_to_retry] = max(
+            finished_builds
+        )
+
+    # If a build has finished, remove it from tracking
+    try:
+        running_builds = processed_object["parserInfo"]["runningBuilds"][
+            job_to_retry
+        ].keys()
+    except KeyError:
+        processed_object["parserInfo"]["runningBuilds"][job_to_retry] = dict()
+        running_builds = []
+
+    # --> Clean object from already parsed builds:
+    for build in list(running_builds):
+        if build in finished_builds:
+            processed_object["parserInfo"]["runningBuilds"][job_to_retry].pop(build)
+
+    return [build for build in running_builds if build not in finished_builds]
 
 
 if __name__ == "__main__":
 
-    # Parsing the build id of the current job
+    # Set start time
+    start_time = datetime.datetime.now()
+
+    # Parse the build id of the current job
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "parser_build_id", help="Input current build id from Jenkins env vars"
@@ -611,17 +282,27 @@ if __name__ == "__main__":
 
     # Define paths:
     jobs_config_path = "cms-bot/jenkins/parser/jobs-config.json"  # This file matches job with their known errors and the action to perform
+    builds_dir = os.environ.get("HOME") + "/builds"  # Path to the actual build logs
     parser_info_path = (
         os.environ.get("HOME") + "/builds/jenkins-test-parser/parser-info.json"
     )  # This file keeps track of the last log processed and the pending builds
-    builds_dir = os.environ.get("HOME") + "/builds"  # Path to the actual build logs
 
-    # Define e-mails to notify
-    email_addresses = "cms-sdt-logs@cern.ch"
-
+    # Get jobs-config info
     with open(jobs_config_path, "r") as jobs_file:
         jobs_object = json.load(jobs_file)
         jenkins_jobs = jobs_object["jobsConfig"]["jenkinsJobs"]
+
+    # Get parser-info from previous run
+    with open(
+        parser_info_path, "r"
+    ) as processed_file:  # Get last parsed object just once
+        processed_object = json.load(processed_file)
+
+    first_iter = True
+
+    while True:
+        current_time = datetime.datetime.now()
+        elapsed_time = current_time - start_time
 
         # Iterate over all the jobs jobs_object["jobsConfig"]["jenkinsJobs"][ii]["jobName"]
         for job_id in range(len(jenkins_jobs)):
@@ -634,106 +315,74 @@ if __name__ == "__main__":
 
             print("[" + job_to_retry + "] Processing ...")
             job_dir = os.path.join(builds_dir, job_to_retry)
+            error_list, force_retry_regex = helpers.get_errors_list(jobs_object, job_id)
 
-            error_list, force_retry_regex = get_errors_list(jobs_object, job_id)
+            # If first run, we make sure we are not missing any finished build from previous run
+            if first_iter == True:
+                running_builds = first_iter_check(
+                    job_to_retry, job_dir, error_list, processed_object
+                )
 
-            last_processed_log, processed_object = get_last_processed_log(
-                parser_info_path, job_to_retry
-            )
+            try:
+                running_builds = processed_object["parserInfo"]["runningBuilds"][
+                    job_to_retry
+                ].keys()
+            except KeyError:
+                processed_object["parserInfo"]["runningBuilds"][job_to_retry] = dict()
+                running_builds = []
 
-            finished_builds = get_finished_builds(job_dir, last_processed_log)
-            running_builds = get_running_builds(job_dir, last_processed_log)
+            finished_builds = helpers.get_finished_builds(job_dir, running_builds)
+            running_builds = helpers.get_running_builds(job_dir)
 
-            # Check for running builds left behind and store them to keep track
-            pending_builds, last_pending_builds = get_pending_builds(
-                job_dir,
-                job_to_retry,
-                last_processed_log,
-                parser_info_path,
-                running_builds,
-            )
+            # Update running builds in the original object
+            for build in running_builds:
+                if (
+                    build
+                    not in processed_object["parserInfo"]["runningBuilds"][
+                        job_to_retry
+                    ].keys()
+                ):
+                    processed_object["parserInfo"]["runningBuilds"][job_to_retry][
+                        build
+                    ] = ""
 
-            if pending_builds or running_builds:
+            # Parse logs of finished builds
+            if finished_builds:
                 print(
                     "Builds "
-                    + str(pending_builds + running_builds)
+                    + str(finished_builds)
+                    + " have already finished. Processing ..."
+                )
+                for build in sorted(finished_builds):
+                    check_and_trigger_action(build, job_dir, job_to_retry, error_list)
+                    # Pop build number from the tracking
+                    processed_object["parserInfo"]["runningBuilds"][job_to_retry].pop(
+                        build
+                    )
+                # Update last processed log
+                processed_object["parserInfo"]["lastRevision"][job_to_retry] = max(
+                    finished_builds
+                )
+
+            if running_builds:
+                print(
+                    "Builds "
+                    + str(running_builds)
                     + " are still running for job "
                     + job_to_retry
                 )
-
-            if not last_pending_builds and not running_builds:
-                print("No builds running for " + job_to_retry)
-                pass
-            elif sorted(pending_builds) != sorted(last_pending_builds):
-                extra_list = [
-                    build
-                    for build in last_pending_builds
-                    if build not in pending_builds
-                ]
-
-                print(
-                    "Builds "
-                    + str(extra_list)
-                    + " have already finished. Processing ..."
-                )
-                # Trigger the parsing in these builds
-                for build_to_retry in extra_list:
-                    check_and_trigger_action(
-                        build_to_retry, job_dir, job_to_retry, error_list
-                    )
-                    # Remove from rotation dict
-                    with open(parser_info_path, "r") as rotation_file:
-                        last_pending_builds_object = json.load(rotation_file)
-
-                    last_pending_builds_object["parserInfo"]["runningBuilds"][
-                        job_to_retry
-                    ].pop(build_to_retry)
-
-                    with open(parser_info_path, "w") as rotation_file:
-                        json.dump(last_pending_builds_object, rotation_file)
-            else:
-                print(
-                    "Checking for how long the pending builds have been running (maximum running time: "
-                    + str(max_running_time)
-                    + " hours) ..."
-                )
-                for build_to_check in sorted(last_pending_builds + running_builds):
+                for build_to_check in sorted(running_builds):
                     check_running_time(
-                        functools.reduce(
-                            os.path.join, [job_dir, build_to_check, "build.xml"]
-                        ),
-                        build_to_check,
-                        job_to_retry,
-                        max_running_time,
+                        job_dir, build_to_check, job_to_retry, max_running_time
                     )
 
-            if not finished_builds:
-                print("No new finished builds for job " + job_to_retry + " to parse")
-                continue
+        first_iter = False
 
-            print(
-                "Job "
-                + job_to_retry
-                + " has the following new builds to process: "
-                + str(finished_builds)
-            )
+        with open(parser_info_path, "w") as processed_file:
+            json.dump(processed_object, processed_file)
+        print("[Parser information updated]")
 
-            with open(parser_info_path, "r") as rotation_file:
-                last_pending_builds_object = json.load(rotation_file)
+        if elapsed_time > datetime.timedelta(hours=2):
+            break
 
-            # Process logs of failed builds
-            for build_to_retry in finished_builds:
-                check_and_trigger_action(
-                    build_to_retry, job_dir, job_to_retry, error_list
-                )
-
-                # Mark as retried
-                mark_build_as_retried(job_dir, job_to_retry, build_to_retry)
-
-            with open(parser_info_path, "w") as rotation_file:
-                json.dump(last_pending_builds_object, rotation_file)
-
-            # Update the value of the last log processed
-            update_last_processed_log(processed_object, job_to_retry, finished_builds)
-
-    print("All jobs have been checked!")
+        time.sleep(10)

--- a/jenkins/parser/jenkins-retry-job.py
+++ b/jenkins/parser/jenkins-retry-job.py
@@ -5,17 +5,20 @@ import functools
 import re
 import os
 import xml.etree.ElementTree as ET
+import datetime
 
 # Get job name and build number to retry
 parser = argparse.ArgumentParser()
 parser.add_argument("job_to_retry", help="Jenkins job to retry")
 parser.add_argument("build_to_retry", help="Build number to retry")
 parser.add_argument("parser_action", help="Action taken by parser job")
+parser.add_argument("error_message", type=str, help="Error message found in build log")
 parser.add_argument("current_build_number", help="Current build number")
 args = parser.parse_args()
 job_to_retry = args.job_to_retry
 build_to_retry = args.build_to_retry
 parser_action = args.parser_action
+regex = args.error_message.replace("&", " ")
 current_build_number = args.current_build_number
 
 retry_counter_value = ""
@@ -115,6 +118,46 @@ with open("parameters.txt", "w") as propfile:
         print(param + "\n")
         propfile.write(param + "\n")
 
+
+# Update static webpage
+tracker_path = (
+    os.environ.get("HOME") + "/builds/jenkins-test-parser-monitor/parser-web-info.html"
+)
+job_url = os.environ.get("JENKINS_URL") + "job/" + job_to_retry + "/" + build_to_retry
+retry_url = (
+    os.environ.get("JENKINS_URL") + "job/jenkins-test-retry/" + current_build_number
+)
+
+with open(tracker_path, "r+") as summary:
+    content = summary.readlines()
+    # Each entry has 8, we keep a maximum of 100 entries
+    # TODO: Cleanup by date
+    if len(content) > 800:
+        content = content[0:800]
+    retry_time = datetime.datetime.now().replace(microsecond=0)
+    summary.seek(0)
+    summary.write(
+        "<tr>\n<td>"
+        + str(retry_time)
+        + "</td>\n<td>"
+        + str(job_to_retry)
+        + "</td>\n<td>"
+        + str(build_to_retry)
+        + "</td>\n<td>"
+        + str(regex)
+        + '</td>\n<td><a href="'
+        + str(job_url)
+        + '">'
+        + str(job_url)
+        + '</a></td>\n<td><a href="'
+        + str(retry_url)
+        + '">'
+        + str(retry_url)
+        + "</a></td>\n</tr>\n"
+        + "".join(content)
+    )
+
+
 # Format retry label depending on parser action
 times = "time" if retry_counter_update == 1 else "times"
 
@@ -149,7 +192,7 @@ if parser_action == "retryBuild":
     label = retry_label
 elif parser_action == "nodeOff":
     label = nodeoff_label
-else: # nodeReconnect
+else:  # nodeReconnect
     label = nodereconnect_label
 
 update_label = (

--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -1,4 +1,8 @@
 {
+  "defaultConfig": {
+    "forceRetry": "false",
+    "allJobs": "false"
+  },
   "jobsConfig": {
     "jenkinsJobs": [
       {
@@ -9,7 +13,7 @@
           "busError",
           "workspaceFailure"
         ],
-        "maxTime": "2"
+        "maxTime": "1"
       },
       {
         "jobName": "ib-run-igprof",
@@ -68,23 +72,34 @@
       },
       {
         "jobName": "build-any-ib",
-        "errorType": ["gitErrors"],
+        "errorType": [
+          "gitErrors"
+        ],
         "maxTime": "18"
       },
       {
         "jobName": "ib-run-pr-tests",
-        "errorType": ["gitErrors"],
+        "errorType": [
+          "gitErrors"
+        ],
         "maxTime": "12"
       },
       {
         "jobName": "update-github-pages",
-        "errorType": ["gitErrors"],
+        "errorType": [
+          "gitErrors"
+        ],
         "maxTime": "2"
       },
       {
         "jobName": "ib-tag-and-schdule",
         "errorType": [],
         "maxTime": "18"
+      },
+      {
+        "jobName": "ib-run-static-checks",
+        "errorType": [],
+        "maxTime": "6"
       }
     ],
     "errorMsg": {
@@ -92,9 +107,7 @@
         "errorStr": [
           "Build timed out"
         ],
-        "action": "retryBuild",
-	"forceRetry": "false",
-	"allJobs": "false"
+        "action": "retryBuild"
       },
       "hudsonConnection": {
         "errorStr": [
@@ -108,52 +121,48 @@
         "errorStr": [
           "unexpected fault address"
         ],
-        "action": "retryBuild",
-        "forceRetry": "false",
-        "allJobs": "false"
+        "action": "retryBuild"
       },
       "gitErrors": {
         "errorStr": [
           "fatal: repository .* not found",
           "Tag already exist",
           "Connection to github\\.com closed by remote host.",
-	  "Error while downloading sources from github\\.com"
+          "Error while downloading sources from github\\.com"
         ],
-        "action": "retryBuild",
-        "forceRetry": "false",
-        "allJobs": "false"
+        "action": "retryBuild"
       },
       "busError": {
         "errorStr": [
           "Bus error",
           "Transport endpoint is not connected"
         ],
-        "action": "nodeOff",
-        "forceRetry": "false",
-        "allJobs": "false"
+        "action": "nodeOff"
       },
       "gridConnection": {
         "errorStr": [
           "Unexpected exception occurred while performing connect-node command"
         ],
-        "action": "retryBuild",
-        "forceRetry": "false",
-        "allJobs": "false"
+        "action": "retryBuild"
       },
       "afsFailure": {
         "errorStr": [
           "no such identity: .* Permission denied"
         ],
-        "action": "nodeOff",
-        "forceRetry": "false",
-        "allJobs": "false"
+        "action": "nodeOff"
       },
       "workspaceFailure": {
         "errorStr": [
           "Cannot delete workspace: Remote call on .* failed"
         ],
         "action": "nodeReconnect",
-        "forceRetry": "false",
+        "allJobs": "true"
+      },
+      "cvmfsFailure": {
+        "errorStr": [
+          "Error: No such directory: /cvmfs/.*cern.ch$"
+        ],
+        "action": "nodeOff",
         "allJobs": "true"
       }
     }

--- a/jenkins/parser/paser-config-unittest.py
+++ b/jenkins/parser/paser-config-unittest.py
@@ -55,3 +55,11 @@ assert all(
     item in valid_actions for item in defined_actions
 ), "Defined action does not correspond to a valid action"
 print("[TEST 3]: ... OK")
+
+print("[TEST 4]: Checking that default sections are present ...")
+default_fields = jobs_object["defaultConfig"].keys()
+valid_fields = ["forceRetry", "allJobs"]  # TODO: Find a better way to get valid fields
+assert all(
+    item in valid_fields for item in default_fields
+), "Defined default field does not correspond to a valid field. Only forceRetry and allJobs fields should be defined under defaultConfig."
+print("[TEST 4]: ... OK")


### PR DESCRIPTION
Refactor of the jenkins parser into modules.

The retry logic is the same, but we loop inside the parser file doing just one read operation of `parser-info.json` at the beginning of the run (`parser-info.json` is the file where we keep information of the running builds and the last parsed log of each job).

Notification information is stored in memory and saved at the end of each iteration.

There is a default section in `jobs-config.json` with two new options:
- `forceRetry`: You can force retry the failed build even if Jenkins already retries it.
- `allJobs`: Check a concrete error regex in all the jobs.

These modifications are already running in Jenkins.