### PR TITLE
run-ib-igprof script: check if workflow exists in release 

### DIFF
--- a/run-ib-igprof
+++ b/run-ib-igprof
@@ -15,6 +15,10 @@ for prof in ${PROFILES} ; do
   mkdir -p $WORKSPACE/igprof/${prof}
   cd $WORKSPACE/igprof/${prof}
   for WORKFLOW in `echo $WORKFLOWS | sed 's|-l ||;s|,| |g;s|-i all||'`;do
+    if [ $(runTheMatrix.py -n | grep "^$WORKFLOW " | wc -l) -eq 0 ]; then
+       echo "Workflow $WORKFLOW is not defined in this IB release"
+       continue
+    fi
     if [[ $WORKFLOWS = *all* ]];  then
         WF="-i all -l $WORKFLOW"
     else


### PR DESCRIPTION
This will check if a workflow is defined in an IB release and warn if it is not, skipping the runTheMatrix.py command.

fixes https://github.com/cms-sw/cms-bot/issues/1854
