### PR TITLE
[Parser] Add `retryLate` action to delay parser retries

### DIFF
--- a/jenkins/parser/actions.py
+++ b/jenkins/parser/actions.py
@@ -88,8 +88,8 @@ def trigger_retry_action(
         + str(regex.replace(" ", "&"))
         + '"'
     )
-    print(trigger_retry)
     if action == "retryNow":
+        print(trigger_retry)
         os.system(trigger_retry)
         update_cmssdt_page(
             html_file_path, job_to_retry, build_to_retry, regex, job_url, "", "Retry"
@@ -125,6 +125,7 @@ def trigger_retry_action(
         print(update_label)
         os.system(update_label)
     else:
+        print(trigger_retry)
         os.system(trigger_retry)
 
 

--- a/jenkins/parser/actions.py
+++ b/jenkins/parser/actions.py
@@ -15,7 +15,6 @@ html_file_path = (
 retry_url_file = (
     os.environ.get("HOME") + "/builds/jenkins-test-parser-monitor/json-retry-info.json"
 )
-queue_file_path = os.environ.get("HOME") + "/builds/jenkins-test-parser/retry_queue"
 retry_queue_path = (
     os.environ.get("HOME") + "/builds/jenkins-test-parser/retry_queue.json"
 )
@@ -99,9 +98,6 @@ def trigger_retry_action(
         print(
             "This failure will be retried with a delay of " + str(delay_time) + " min"
         )
-        with open(queue_file_path, "a") as retry_queue_file:
-            retry_queue_file.write(trigger_retry + "\n")
-
         retry_entry = job_to_retry + "#" + build_to_retry
         retry_time = datetime.datetime.now().replace(
             microsecond=0
@@ -127,15 +123,6 @@ def trigger_retry_action(
     else:
         print(trigger_retry)
         os.system(trigger_retry)
-
-
-def trigger_late_retries():
-    print("Triggering delayed retries ...")
-    with open(queue_file_path, "r+") as retry_queue_file:
-        for line in retry_queue_file:
-            print(line)
-            os.system(line)
-        retry_queue_file.truncate(0)
 
 
 def trigger_nodeoff_action(job_to_retry, build_to_retry, job_url, node_name):

--- a/jenkins/parser/helpers.py
+++ b/jenkins/parser/helpers.py
@@ -63,9 +63,12 @@ def append_actions(error_keys, jenkins_errors):
     error_list = []
     # We append the action to perform to the error message
     for ii in error_keys:
-        if jenkins_errors[ii]["action"] == "retryBuild":
+        if jenkins_errors[ii]["action"] == "retryNow":
             for error in jenkins_errors[ii]["errorStr"]:
-                error_list.append(error + " - retryBuild")
+                error_list.append(error + " - retryNow")
+        elif jenkins_errors[ii]["action"] == "retryLate":
+            for error in jenkins_errors[ii]["errorStr"]:
+                error_list.append(error + " - retryLate")
         elif jenkins_errors[ii]["action"] == "nodeOff":
             for error in jenkins_errors[ii]["errorStr"]:
                 error_list.append(error + " - nodeOff")

--- a/jenkins/parser/jenkins-parser-job.py
+++ b/jenkins/parser/jenkins-parser-job.py
@@ -24,6 +24,7 @@ def process_build(build, job_dir, job_to_retry, error_list, retry_object, retry_
     else:
         # Mark as retried
         actions.mark_build_as_retried(job_dir, job_to_retry, build)
+        print("[" + job_to_retry + "] ... OK")
 
 
 def check_and_trigger_action(
@@ -465,7 +466,9 @@ if __name__ == "__main__":
                     < datetime.datetime.now()
                 ):
                     print("Triggering delayed retry for " + entry)
-                    os.system(retry_entries[entry]["retryCommand"])
+                    trigger_retry = retry_entries[entry]["retryCommand"]
+                    print(trigger_retry)
+                    os.system(trigger_retry)
                     retry_object["retryQueue"].pop(entry)
 
             # Reset copy

--- a/jenkins/parser/jenkins-parser-job.py
+++ b/jenkins/parser/jenkins-parser-job.py
@@ -479,7 +479,6 @@ if __name__ == "__main__":
         # Enable time check and delayed retries every 10 min
         if elapsed_time / (datetime.timedelta(minutes=10) * T) > 1:
             time_check = True
-            actions.trigger_late_retries()
             T += 1
         else:
             time_check = False

--- a/jenkins/parser/jenkins-retry-job.py
+++ b/jenkins/parser/jenkins-retry-job.py
@@ -168,7 +168,7 @@ nodereconnect_label = (
     + str(current_build_number)
 )
 
-if parser_action == "retryBuild":
+if "retry" in parser_action:
     label = retry_label
 elif parser_action == "nodeOff":
     label = nodeoff_label

--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -121,6 +121,13 @@
           "gitErrors"
         ],
         "maxTime": "1"
+      },
+      {
+        "jobName": "ib-run-pr-addon",
+        "errorType": [
+          "cvmfsFailure"
+        ],
+        "maxTime": "1"
       }
     ],
     "errorMsg": {
@@ -128,13 +135,13 @@
         "errorStr": [
           "Build timed out"
         ],
-        "action": "retryBuild"
+        "action": "retryNow"
       },
       "hudsonConnection": {
         "errorStr": [
           "Remote call on .* failed. The channel is closing down or has closed down"
         ],
-        "action": "retryBuild",
+        "action": "retryNow",
         "forceRetry": "true",
         "allJobs": "true"
       },
@@ -142,7 +149,7 @@
         "errorStr": [
           "unexpected fault address"
         ],
-        "action": "retryBuild"
+        "action": "retryNow"
       },
       "gitErrors": {
         "errorStr": [
@@ -154,7 +161,7 @@
 	  "Empty reply from server",
 	  "The requested URL returned error: 503"
         ],
-        "action": "retryBuild",
+        "action": "retryLate",
 	"allJobs": "true"
       },
       "busError": {
@@ -169,7 +176,7 @@
         "errorStr": [
           "Unexpected exception occurred while performing connect-node command"
         ],
-        "action": "retryBuild"
+        "action": "retryNow"
       },
       "afsFailure": {
         "errorStr": [
@@ -187,7 +194,8 @@
       "cvmfsFailure": {
         "errorStr": [
           "Error: No such directory: /cvmfs/.*cern.ch$",
-	  "cannot open directory /cvmfs/.*cern.ch:"
+	  "cannot open directory /cvmfs/.*cern.ch:",
+          "cannot access /cvmfs/.*cern.ch"
         ],
         "action": "nodeOff",
         "allJobs": "true"

--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -13,7 +13,8 @@
           "busError",
           "workspaceFailure"
         ],
-        "maxTime": "1"
+        "maxTime": "1",
+        "retryTime": "5"
       },
       {
         "jobName": "ib-run-igprof",

--- a/jenkins/parser/paser-config-unittest.py
+++ b/jenkins/parser/paser-config-unittest.py
@@ -44,7 +44,7 @@ print("[TEST 2]: ... OK")
 print("[TEST 3]: Checking that the defined actions are valid ...")
 valid_actions = [
     "retryNow",
-    "retryLate"
+    "retryLate",
     "nodeOff",
     "nodeReconnect",
 ]  # TODO: Find a better way to get all valid actions

--- a/jenkins/parser/paser-config-unittest.py
+++ b/jenkins/parser/paser-config-unittest.py
@@ -43,7 +43,8 @@ print("[TEST 2]: ... OK")
 
 print("[TEST 3]: Checking that the defined actions are valid ...")
 valid_actions = [
-    "retryBuild",
+    "retryNow",
+    "retryLate"
     "nodeOff",
     "nodeReconnect",
 ]  # TODO: Find a better way to get all valid actions


### PR DESCRIPTION
This PR adds a new action `retryLate` that will delay the retry by 10 min. This is useful when the failure is due to server error, where an immediate retry will fail as well.

It also adds new failures and jobs to the config file.

The option for triggering the creation of grid nodes is disabled for debugging purposes.