### PR TITLE
Add heavy ion workflows to profiling

### DIFF
--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -8,6 +8,24 @@ import os
 import shutil
 
 workflow_configs = {
+    #Run3 HI workflow
+    "159.03": {
+        "num_events": 100,
+        "steps": {
+            "step4": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+            "step5": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+         },
+        "nThreads": 1,
+        "matrix": "standard"
+    },
     #Run3 workflow
     "11834.21": {
         "num_events": 400,

--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -9,7 +9,7 @@ import shutil
 
 workflow_configs = {
     #Run3 HI workflow
-    "159": {
+    "159.0": {
         "num_events": 100,
         "steps": {
             "step3": {

--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -10,7 +10,7 @@ import shutil
 workflow_configs = {
     #Run3 HI workflow
     "159.0": {
-        "num_events": 100,
+        "num_events": 400,
         "steps": {
             "step3": {
                 "TimeMemoryInfo": True,
@@ -19,11 +19,11 @@ workflow_configs = {
             },
         },
         "nThreads": 1,
-        "matrix": "upgrade"
+        "matrix": "standard"
     },
     #2018 HI T0-like workflow
     "140.56": {
-        "num_events": 400,
+        "num_events": 1000,
         "steps": {
             "step3": {
                 "TimeMemoryInfo": True,

--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -8,6 +8,42 @@ import os
 import shutil
 
 workflow_configs = {
+    #Run3 HI workflow
+    "159": {
+        "num_events": 100,
+        "steps": {
+            "step3": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+            "step4": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+            "step5": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+         },
+        "nThreads": 1,
+        "matrix": "upgrade"
+    },
+    #2018 HI T0-like workflow
+    "140.56": {
+        "num_events": 400,
+        "steps": {
+            "step3": {
+                "TimeMemoryInfo": True,
+                "FastTimer": False,
+                "igprof": False,
+            },
+         },
+        "nThreads": 8,
+        "matrix": "standard"
+    },
     #Run3 workflow
     "11834.21": {
         "num_events": 400,

--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -17,17 +17,7 @@ workflow_configs = {
                 "FastTimer": True,
                 "igprof": True,
             },
-            "step4": {
-                "TimeMemoryInfo": True,
-                "FastTimer": True,
-                "igprof": True,
-            },
-            "step5": {
-                "TimeMemoryInfo": True,
-                "FastTimer": True,
-                "igprof": True,
-            },
-         },
+        },
         "nThreads": 1,
         "matrix": "upgrade"
     },

--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -8,32 +8,6 @@ import os
 import shutil
 
 workflow_configs = {
-    #Run3 HI workflow
-    "159.0": {
-        "num_events": 100,
-        "steps": {
-            "step3": {
-                "TimeMemoryInfo": True,
-                "FastTimer": True,
-                "igprof": True,
-            },
-        },
-        "nThreads": 1,
-        "matrix": "standard"
-    },
-    #2018 HI T0-like workflow
-    "140.56": {
-        "num_events": 1000,
-        "steps": {
-            "step3": {
-                "TimeMemoryInfo": True,
-                "FastTimer": False,
-                "igprof": False,
-            },
-         },
-        "nThreads": 8,
-        "matrix": "standard"
-    },
     #Run3 workflow
     "11834.21": {
         "num_events": 400,
@@ -146,7 +120,20 @@ workflow_configs = {
          },
         "nThreads": 8,
         "matrix": "standard"
-    } 
+    },
+    #2018 HI T0-like workflow
+    "140.56": {
+        "num_events": 1000,
+        "steps": {
+            "step2": {
+                "TimeMemoryInfo": True,
+                "FastTimer": False,
+                "igprof": False,
+            },
+         },
+        "nThreads": 8,
+        "matrix": "standard"
+    },
 }
 
 #Prepare cmdLog and execute the workflow steps to get e.g. DAS entries, but call cmsRun with --no_exec

--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -10,7 +10,7 @@ import shutil
 workflow_configs = {
     #Run3 HI workflow
     "159.0": {
-        "num_events": 400,
+        "num_events": 100,
         "steps": {
             "step3": {
                 "TimeMemoryInfo": True,


### PR DESCRIPTION
Add two new workflows to profileRunner:
140.56:  real data with 8 threads
159.03:  Production-like MC workflow (i.e., no validation) with memory profiling enabled

These workflows have already been run using my own fork/branch and the output added to the results webpage.