### PR TITLE
Nodes `/afs`, `/cvmfs` and `singularity` sanity check

### DIFF
--- a/jenkins/connect.sh
+++ b/jenkins/connect.sh
@@ -31,7 +31,7 @@ if [ $(echo $SLAVE_TYPE | grep '^lxplus\|^aiadm' | wc -l) -gt 0 ] ; then
   for ip in $(host $SLAVE_TYPE | grep 'has address' | sed 's|^.* ||'); do
     hname=$(host $ip | grep 'domain name' | sed 's|^.* ||;s|\.$||')
     if [ $(grep "${hname}" ${SCRIPT_DIR}/blacklist-lxplus.txt | wc -l) -gt 0 ] ; then continue ; fi
-    if [ $(find ${BLACKLIST_DIR}/* -name ${hname} | wc -l) -gt 0 ] ; then continue ; fi
+    if [ -e ${BLACKLIST_DIR}/${hname} ] ; then continue ; fi
     NEW_TARGET=$(echo $TARGET | sed "s|@.*|@$hname|")
     ${SCRIPT_DIR}/start-slave.sh "${NEW_TARGET}" "$@" || [ "X$?" = "X99" ] && sleep 5 && continue
     exit 0

--- a/jenkins/connect.sh
+++ b/jenkins/connect.sh
@@ -21,6 +21,8 @@ klist || true
 export SLAVE_UNIQUE_TARGET=""
 export SLAVE_MAX_WORKSPACE_SIZE=""
 SCRIPT_DIR=$(cd $(dirname $0); /bin/pwd)
+BLACKLIST_DIR="${HOME}/workspace/cache/blacklist"
+
 if [ $(echo $SLAVE_TYPE | grep '^lxplus\|^aiadm' | wc -l) -gt 0 ] ; then
   export SLAVE_UNIQUE_TARGET="YES"
   case ${SLAVE_TYPE} in 
@@ -28,7 +30,8 @@ if [ $(echo $SLAVE_TYPE | grep '^lxplus\|^aiadm' | wc -l) -gt 0 ] ; then
   esac
   for ip in $(host $SLAVE_TYPE | grep 'has address' | sed 's|^.* ||'); do
     hname=$(host $ip | grep 'domain name' | sed 's|^.* ||;s|\.$||')
-    if [ $(grep "${hname}" ${SCRIPT_DIR}/blacklist-lxplus.txt |wc -l) -gt 0 ] ; then continue ; fi
+    if [ $(grep "${hname}" ${SCRIPT_DIR}/blacklist-lxplus.txt | wc -l) -gt 0 ] ; then continue ; fi
+    if [ $(find ${BLACKLIST_DIR}/* -name ${hname} | wc -l) -gt 0 ] ; then continue ; fi
     NEW_TARGET=$(echo $TARGET | sed "s|@.*|@$hname|")
     ${SCRIPT_DIR}/start-slave.sh "${NEW_TARGET}" "$@" || [ "X$?" = "X99" ] && sleep 5 && continue
     exit 0

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -11,7 +11,7 @@ function run_check {
     node=$1
     SSH_OPTS="-q -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=60"
     scp $SSH_OPTS ${WORKSPACE}/cms-bot/jenkins/nodes-sanity-check.sh "cmsbuild@$node:/tmp" || (echo "Cannot scp script" && exit 1)
-    ssh $SSH_OPTS "cmsbuild@"$node 'sh /tmp/nodes-check.sh'; exit_code=$?
+    ssh $SSH_OPTS "cmsbuild@"$node 'sh /tmp/nodes-sanity-check.sh'; exit_code=$?
     if [[ ${exit_code} -eq 0 ]]; then
         rm -f "$blacklist_path/$node"
     else

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -4,7 +4,7 @@ WORKSPACE=$(pwd)
 nodes=("lxplus7" "lxplus8" "lxplus9" "olarm-202" "olarm-102" "ibmminsky-1" "ibmminsky-2")
 
 blacklist_path="$HOME/workspace/cache/blacklist"
-email_notification="andrea.valenzuela.ramirez@cern.ch"
+email_notification="cms-sdt-logs@cern.ch"
 job_url="${JENKINS_URL}job/test-check-nodes/${BUILD_NUMBER}"
 
 function run_check {

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -5,6 +5,7 @@ nodes_path="$HOME/nodes/"
 email_notification="cms-sdt-logs@cern.ch"
 job_url="${JENKINS_URL}job/nodes-sanity-check/${BUILD_NUMBER}"
 echo $PATHS >> $WORKSPACE/paths.param
+echo $SINGULARITY >> $WORKSPACE/paths.param
 
 function run_check {
     node=$1

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -78,11 +78,15 @@ function lxplus_disconnect {
 }
 
 function aarch_ppc_disconnect {
-    node=$1
-    node_regex="$(echo $node | cut -d "-" -f 1)*$(echo $node | cut -d "-" -f 2)*"
-    for match in $(find $nodes_path -name $node_regex); do
-        jenkins_node=$(echo $match | rev | cut -d "/" -f 1 | rev)
-        node_off $jenkins_node
+    nodes_path="/build/nodes/*"
+    host=$1
+
+    for folder in $nodes_path; do
+        node=$(grep agentCommand $folder/config.xml | tr ' <>' '\n\n\n' | grep '@' | sort | uniq | cut -d "@" -f 2)
+        if [[ $node == $host ]]; then
+            echo "Processing agent $(basename $folder) ..."
+            node_off $(basename $folder)
+        fi
     done
 }
 

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -18,7 +18,7 @@ function run_check {
         echo "... ERROR! Blacklisting ${node} ..."
 	# Check if node is already in the blacklist
 	if [ ! -e $blacklist_path/$node ]; then 
-            touch "$blacklist_path/$node"
+            touch "$blacklist_path/$node" || exit 1
             notify_failure $email_notification $node $job_url
             # If aarch or ppc, disconnect node
 	    node_regex="$(echo $node | cut -d "-" -f 1)*$(echo $node | cut -d "-" -f 2)*"

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -102,13 +102,10 @@ function notify_failure {
 function node_off {
     affected_node=$1
     node_info=$(curl -H "OIDC_CLAIM_CERN_UPN: cmssdt" "${LOCAL_JENKINS_URL}computer/$affected_node/api/json?pretty=true")
-    node_offline=$(echo $node_info | grep '"offline" : false' | wc -l)
-    if [ $node_offline -gt 0 ]; then
-        ${JENKINS_CLI_CMD} offline-node ${affected_node} -m "Node\ ${affected_node}\ has\ been\ blacklisted"
-        # Store that node has been set offline
-        echo "Storing .offline info at: $blacklist_path"
-        touch "$blacklist_path/$affected_node.offline"
-    fi
+    ${JENKINS_CLI_CMD} offline-node ${affected_node} -m "Node\ ${affected_node}\ has\ been\ blacklisted"
+    # Store that node has been set offline
+    echo "Storing .offline info at: $blacklist_path"
+    touch "$blacklist_path/$affected_node.offline"
 }
 
 function node_on {
@@ -135,10 +132,7 @@ function offline_cleanup {
         if [ $node_tempoffline -eq 0 ]; then $(rm -rf $file) && continue; fi # External action has been taken
         node_offline=$(echo $node_info | grep '"offline" : true' | wc -l)
         if [ $node_offline -gt 0 ]; then
-            node_idle=$(echo $node_info | grep '"idle" : true' | wc -l)
-            if [ $node_idle -gt 0 ]; then
-                node_on $node_name
-            fi
+            node_on $node_name
         fi
     done
 }

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -1,7 +1,4 @@
-BUILD_NUMBER=$1
 WORKSPACE=$(pwd)
-
-nodes=("lxplus7" "lxplus8" "lxplus9" "olarm-202" "olarm-102" "ibmminsky-1" "ibmminsky-2")
 
 blacklist_path="$HOME/workspace/cache/blacklist"
 email_notification="cms-sdt-logs@cern.ch"
@@ -72,7 +69,7 @@ function node_off {
 
 lxplus_hosts=()
 
-for node in ${nodes[@]}; do
+for node in ${NODES[@]}; do
     echo "Processing $node ..."
     if [[ "$node" =~ .*"lxplus".* ]]; then
         echo "Searching for lxplus hosts ..."

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -3,11 +3,12 @@ WORKSPACE=$(pwd)
 blacklist_path="$HOME/workspace/cache/blacklist"
 email_notification="cms-sdt-logs@cern.ch"
 job_url="${JENKINS_URL}job/test-check-nodes/${BUILD_NUMBER}"
+echo $PATHS >> $WORKSPACE/paths.param
 
 function run_check {
     node=$1
     SSH_OPTS="-q -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=60"
-    scp $SSH_OPTS ${WORKSPACE}/cms-bot/jenkins/nodes-sanity-check.sh "cmsbuild@$node:/tmp" || (echo "Cannot scp script" && exit 1)
+    scp $SSH_OPTS ${WORKSPACE}/cms-bot/jenkins/nodes-sanity-check.sh ${WORKSPACE}/paths.param "cmsbuild@$node:/tmp" || (echo "Cannot scp script" && exit 1)
     ssh $SSH_OPTS "cmsbuild@"$node 'sh /tmp/nodes-sanity-check.sh'; exit_code=$?
     if [[ ${exit_code} -eq 0 ]]; then
         rm -f "$blacklist_path/$node"

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -16,13 +16,18 @@ function run_check {
         rm -f "$blacklist_path/$node"
     else
         echo "... ERROR! Blacklisting ${node} ..."
-        touch "$blacklist_path/$node"
-        notify_failure $email_notification $node $job_url
-        # If aarch or ppc, disconnect node
-        if [[ $(echo $node | grep '^olarm-102' | wc -l) -gt 0 ]]; then
-            node_off "olarm-99-102a" && node_off "olarm-99-102b"
-        elif [[ $(echo $node | grep '^olarm\|^ibmminsky' | wc -l) -gt 0 ]]; then
-            node_off "${node}a" && node_off "${node}b"
+	# Check if node is already in the blacklist
+	if [ ! -e $blacklist_path/$node ]; then 
+            touch "$blacklist_path/$node"
+            notify_failure $email_notification $node $job_url
+            # If aarch or ppc, disconnect node
+            if [[ $(echo $node | grep '^olarm-102' | wc -l) -gt 0 ]]; then
+                node_off "olarm-99-102a" && node_off "olarm-99-102b"
+            elif [[ $(echo $node | grep '^olarm\|^ibmminsky' | wc -l) -gt 0 ]]; then
+                node_off "${node}a" && node_off "${node}b"
+	    fi
+	else
+            echo "Node already in blacklist. Skipping notification ..."
         fi
     fi
 }

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -1,7 +1,7 @@
 WORKSPACE=$(pwd)
 
 blacklist_path="$HOME/workspace/cache/blacklist"
-if [ -d $blacklist_path ]; then
+if [ ! -d $blacklist_path ]; then
     mkdir -p $blacklist_path
 fi
 
@@ -82,7 +82,7 @@ function aarch_ppc_disconnect {
     host=$1
 
     for folder in $nodes_path; do
-        node=$(grep agentCommand $folder/config.xml | tr ' <>' '\n\n\n' | grep '@' | sort | uniq | cut -d "@" -f 2)
+        node=$(grep agentCommand $folder/config.xml | tr ' <>' '\n\n\n' | grep '@' | sort | uniq | cut -d "@" -f 2 | cut -d "." -f 1)
         if [[ $node == $host ]]; then
             echo "Processing agent $(basename $folder) ..."
             node_off $(basename $folder)

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -22,7 +22,7 @@ function run_check {
             # If aarch or ppc, disconnect node
 	    node_regex="$(echo $node | cut -d "-" -f 1)*$(echo $node | cut -d "-" -f 2)*"
 	    for match in $(find $nodes_path -name $node_regex); do
-	        jenkins_node=$(echo $match | cut -d "/" -f 4)
+	        jenkins_node=$(echo $match | rev | cut -d "/" -f 1 | rev)
                 node_off $jenkins_node
             done
 	else

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -1,4 +1,5 @@
 BUILD_NUMBER=$1
+WORKSPACE=$(pwd)
 
 nodes=("lxplus7" "lxplus8" "lxplus9" "olarm-202" "olarm-102" "ibmminsky-1" "ibmminsky-2")
 
@@ -9,7 +10,7 @@ job_url="${JENKINS_URL}job/test-check-nodes/${BUILD_NUMBER}"
 function run_check {
     node=$1
     SSH_OPTS="-q -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=60"
-    scp $SSH_OPTS ${HOME}/workspace/cache/nodes-sanity-check.sh "cmsbuild@$node:/tmp" || (echo "Cannot scp script" && exit 1)
+    scp $SSH_OPTS ${WORKSPACE}/cms-bot/jenkins/nodes-sanity-check.sh "cmsbuild@$node:/tmp" || (echo "Cannot scp script" && exit 1)
     ssh $SSH_OPTS "cmsbuild@"$node 'sh /tmp/nodes-check.sh'; exit_code=$?
     if [[ ${exit_code} -eq 0 ]]; then
         rm -f "$blacklist_path/$node"

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -1,0 +1,85 @@
+BUILD_NUMBER=$1
+
+nodes=("lxplus7" "lxplus8" "lxplus9" "olarm-202" "olarm-102" "ibmminsky-1" "ibmminsky-2")
+
+blacklist_path="$HOME/workspace/cache/blacklist"
+email_notification="andrea.valenzuela.ramirez@cern.ch"
+job_url="${JENKINS_URL}job/test-check-nodes/${BUILD_NUMBER}"
+
+function run_check {
+    node=$1
+    SSH_OPTS="-q -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=60"
+    scp $SSH_OPTS ${HOME}/workspace/cache/nodes-sanity-check.sh "cmsbuild@$node:/tmp" || (echo "Cannot scp script" && exit 1)
+    ssh $SSH_OPTS "cmsbuild@"$node 'sh /tmp/nodes-check.sh'; exit_code=$?
+    if [[ ${exit_code} -eq 0 ]]; then
+        rm -f "$blacklist_path/$node"
+    else
+        echo "... ERROR! Blacklisting ${node} ..."
+        touch "$blacklist_path/$node"
+        notify_failure $email_notification $node $job_url
+        # If aarch or ppc, disconnect node
+        if [[ $(echo $node | grep '^olarm-102' | wc -l) -gt 0 ]]; then
+            node_off "olarm-99-102a" && node_off "olarm-99-102b"
+        elif [[ $(echo $node | grep '^olarm\|^ibmminsky' | wc -l) -gt 0 ]]; then
+            node_off "${node}a" && node_off "${node}b"
+        fi
+    fi
+}
+
+function lxplus_cleanup {
+    lxplus_hosts=$@
+    blacklist_content="$HOME/workspace/cache/blacklist/*"
+
+    for file in $blacklist_content; do
+        filename="${file##*/}"
+        if [[ "$filename" == "*" ]]; then
+            echo "Blacklist directory empty... Skipping cleanup!"
+            break
+        elif [[ $(echo $filename | grep '^olarm\|^ibmminsky' | wc -l) -gt 0 ]]; then
+            # No automatic cleanup for aarch and ppc nodes
+            continue
+        fi
+        if [[ ! " ${lxplus_hosts[@]} " =~ " ${filename} " ]]; then
+            echo "Affected lxplus node ${filename} is no longer a valid host. Removing it from blacklist ..."
+            rm -f $file
+        else
+            echo "Affected lxplus node ${filename} is still a valid host. Keeping it in blacklist ..." 
+        fi
+    done
+}
+
+function notify_failure {
+    email=$1
+    node=$2
+    job_url=$3
+    job_description="This job runs a sanity check for /afs, /cvmfs repositories and singularity."
+    error_msg="Node ${node} has been blacklisted by ${job_url}. Please, take the appropiate action.\n${job_description}"
+    echo $error_msg | mail -s "Node ${node} has been blacklisted" $email
+}
+
+function node_off {
+    affected_node=$1
+    ${JENKINS_CLI_CMD} offline-node ${affected_node} -m "Node\ ${affected_node}\ has\ been\ blacklisted"
+}
+
+# Main
+
+lxplus_hosts=()
+
+for node in ${nodes[@]}; do
+    echo "Processing $node ..."
+    if [[ "$node" =~ .*"lxplus".* ]]; then
+        echo "Searching for lxplus hosts ..."
+        for ip in $(host $node | grep 'has address' | sed 's|^.* ||'); do
+            real_nodename=$(host $ip | grep 'domain name' | sed 's|^.* ||;s|\.$||')
+            lxplus_hosts+="$real_nodename "
+            echo "[$real_nodename]"
+            run_check $real_nodename
+         done
+    else
+        run_check $node
+    fi
+done
+
+# Cleanup of lxplus hosts
+lxplus_cleanup $lxplus_hosts

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -101,7 +101,7 @@ function notify_failure {
 
 function node_off {
     affected_node=$1
-    node_info=$(curl -H "OIDC_CLAIM_CERN_UPN: cmssdt" "http://localhost:8080/jenkins/computer/$affected_node/api/json?pretty=true")
+    node_info=$(curl -H "OIDC_CLAIM_CERN_UPN: cmssdt" "${LOCAL_JENKINS_URL}computer/$affected_node/api/json?pretty=true")
     node_offline=$(echo $node_info | grep '"offline" : false' | wc -l)
     if [ $node_offline -gt 0 ]; then
         ${JENKINS_CLI_CMD} offline-node ${affected_node} -m "Node\ ${affected_node}\ has\ been\ blacklisted"
@@ -130,7 +130,7 @@ function offline_cleanup {
             break
         fi
         echo "Offline file found for $node_name ... Cleannig up, if needed."
-        node_info=$(curl -H "OIDC_CLAIM_CERN_UPN: cmssdt" "http://localhost:8080/jenkins/computer/$node_name/api/json?pretty=true")
+        node_info=$(curl -H "OIDC_CLAIM_CERN_UPN: cmssdt" "${LOCAL_JENKINS_URL}computer/$node_name/api/json?pretty=true")
         node_tempoffline=$(echo $node_info | grep '"temporarilyOffline" : true' | wc -l)
         if [ $node_tempoffline -eq 0 ]; then $(rm -rf $file) && continue; fi # External action has been taken
         node_offline=$(echo $node_info | grep '"offline" : true' | wc -l)

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -56,7 +56,7 @@ function lxplus_cleanup {
 }
 
 function lxplus_disconnect {
-    nodes_list="$HOME/logs/slaves/lxplus/*"
+    nodes_list="$HOME/logs/slaves/lxplus*"
     host=$1
     for lxplus_node in $nodes_list; do
         if [ -e $lxplus_node/slave.log ]; then

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -1,6 +1,10 @@
 WORKSPACE=$(pwd)
 
 blacklist_path="$HOME/workspace/cache/blacklist"
+if [ -d $blacklist_path ]; then
+    mkdir -p $blacklist_path
+fi
+
 nodes_path="$HOME/nodes/"
 email_notification="cms-sdt-logs@cern.ch"
 job_url="${JENKINS_URL}job/nodes-sanity-check/${BUILD_NUMBER}"

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -8,14 +8,11 @@ fi
 nodes_path="$HOME/nodes/"
 email_notification="cms-sdt-logs@cern.ch"
 job_url="${JENKINS_URL}job/nodes-sanity-check/${BUILD_NUMBER}"
-echo $PATHS >> $WORKSPACE/paths.param
-echo $SINGULARITY >> $WORKSPACE/paths.param
 
 function run_check {
     node=$1
     SSH_OPTS="-q -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=60"
-    scp $SSH_OPTS ${WORKSPACE}/cms-bot/jenkins/nodes-sanity-check.sh ${WORKSPACE}/paths.param "cmsbuild@$node:/tmp" || (echo "Cannot scp script" && exit 1)
-    ssh $SSH_OPTS "cmsbuild@"$node 'sh /tmp/nodes-sanity-check.sh'; exit_code=$?
+    ssh $SSH_OPTS "cmsbuild@"$node "sh /tmp/nodes-sanity-check.sh $SINGULARITY $PATHS"; exit_code=$?
     if [[ ${exit_code} -eq 0 ]]; then
         rm -f "$blacklist_path/$node"
     else
@@ -65,7 +62,7 @@ function lxplus_disconnect {
     for lxplus_node in $nodes_list; do
         if [ -e $lxplus_node/slave.log ]; then
             match=$(cat $lxplus_node/slave.log | grep -a "ssh -q" | grep $host)
-            lxplus_node=$(echo $lxplus_node | rev | cut -d "/" -f 1 | rev )
+            lxplus_node=$(basename $lxplus_node)
             if [ "X$match" != "X" ]; then
                 echo "Node $lxplus_node is connected to host $host ... Force reconnecting $lxplus_node ..."
                 # Reconnect node

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -54,7 +54,7 @@ function notify_failure {
     node=$2
     job_url=$3
     job_description="This job runs a sanity check for /afs, /cvmfs repositories and singularity."
-    error_msg="Node ${node} has been blacklisted by ${job_url}. Please, take the appropiate action.\n${job_description}"
+    error_msg="Node ${node} has been blacklisted by ${job_url}. Please, take the appropiate action. ${job_description}"
     echo $error_msg | mail -s "Node ${node} has been blacklisted" $email
 }
 

--- a/jenkins/nodes-sanity-check.sh
+++ b/jenkins/nodes-sanity-check.sh
@@ -1,8 +1,6 @@
 PATHS=$(head -n 1 /tmp/paths.param)
 SINGULARITY=$(tail -n 1 /tmp/paths.param)
 
-echo "List of paths: $PATHS"
-
 # Checking that paths are acessible
 for path in ${PATHS[@]}; do
     echo "Checking ${path} for host $(hostname)"

--- a/jenkins/nodes-sanity-check.sh
+++ b/jenkins/nodes-sanity-check.sh
@@ -1,0 +1,17 @@
+paths=("/afs" "/cvmfs" "/cvmfs/cms.cern.ch" "/cvmfs/cms-ci.cern.ch" "/cvmfs/cms-ib.cern.ch" "/cvmfs/grid.cern.ch" "/cvmfs/unpacked.cern.ch")
+
+# Checking that paths are acessible
+for path in ${paths[@]}; do
+    echo "Checking ${path} for host $(hostname)"
+    ls ${path} >/dev/null 2>&1 && echo -e "... OK!" || exit 1
+done
+
+arch=$(uname -r | grep -o "el[0-9]")
+
+if [[ $arch == "el7"  ]]; then
+    arch="cc7"
+fi
+
+# Checking that singularity can start
+echo "Checking that singularity can start a container on $(hostname)"
+/cvmfs/cms.cern.ch/common/cmssw-${arch} --command-to-run ls >/dev/null 2>&1 && echo -e "... OK!" || exit 1

--- a/jenkins/nodes-sanity-check.sh
+++ b/jenkins/nodes-sanity-check.sh
@@ -1,3 +1,7 @@
+PATHS=$(head -n 1 ${WORKSPACE}/paths.param)
+
+echo "List of $PATHS"
+
 # Checking that paths are acessible
 for path in ${PATHS[@]}; do
     echo "Checking ${path} for host $(hostname)"

--- a/jenkins/nodes-sanity-check.sh
+++ b/jenkins/nodes-sanity-check.sh
@@ -1,5 +1,6 @@
-PATHS=$(head -n 1 /tmp/paths.param)
-SINGULARITY=$(tail -n 1 /tmp/paths.param)
+SINGULARITY=$1
+shift
+PATHS=$@
 
 # Checking that paths are acessible
 for path in ${PATHS[@]}; do

--- a/jenkins/nodes-sanity-check.sh
+++ b/jenkins/nodes-sanity-check.sh
@@ -1,7 +1,5 @@
-paths=("/afs" "/cvmfs" "/cvmfs/cms.cern.ch" "/cvmfs/cms-ci.cern.ch" "/cvmfs/cms-ib.cern.ch" "/cvmfs/grid.cern.ch" "/cvmfs/unpacked.cern.ch")
-
 # Checking that paths are acessible
-for path in ${paths[@]}; do
+for path in ${PATHS[@]}; do
     echo "Checking ${path} for host $(hostname)"
     ls ${path} >/dev/null 2>&1 && echo -e "... OK!" || exit 1
 done

--- a/jenkins/nodes-sanity-check.sh
+++ b/jenkins/nodes-sanity-check.sh
@@ -1,5 +1,5 @@
 PATHS=$(head -n 1 /tmp/paths.param)
-SINGULARITY=$(head -n 2 /tmp/paths.param)
+SINGULARITY=$(tail -n 1 /tmp/paths.param)
 
 echo "List of paths: $PATHS"
 

--- a/jenkins/nodes-sanity-check.sh
+++ b/jenkins/nodes-sanity-check.sh
@@ -1,6 +1,6 @@
-PATHS=$(head -n 1 ${WORKSPACE}/paths.param)
+PATHS=$(head -n 1 /tmp/paths.param)
 
-echo "List of $PATHS"
+echo "List of paths: $PATHS"
 
 # Checking that paths are acessible
 for path in ${PATHS[@]}; do

--- a/jenkins/nodes-sanity-check.sh
+++ b/jenkins/nodes-sanity-check.sh
@@ -1,4 +1,5 @@
 PATHS=$(head -n 1 /tmp/paths.param)
+SINGULARITY=$(head -n 2 /tmp/paths.param)
 
 echo "List of paths: $PATHS"
 
@@ -14,6 +15,8 @@ if [[ $arch == "el7"  ]]; then
     arch="cc7"
 fi
 
-# Checking that singularity can start
-echo "Checking that singularity can start a container on $(hostname)"
-/cvmfs/cms.cern.ch/common/cmssw-${arch} --command-to-run ls >/dev/null 2>&1 && echo -e "... OK!" || exit 1
+if [ "$SINGULARITY" == "true" ]; then
+    # Checking that singularity can start
+    echo "Checking that singularity can start a container on $(hostname)"
+    /cvmfs/cms.cern.ch/common/cmssw-${arch} --command-to-run ls >/dev/null 2>&1 && echo -e "... OK!" || exit 1
+fi


### PR DESCRIPTION
This job runs a check that makes sure `/afs`, `/cvmfs`, `/cvmfs/cms.cern.ch`,  `/cvmfs/cms-ci.cern.ch`,  `/cvmfs/cms-ib.cern.ch`,  `/cvmfs/grid.cern.ch` and `/cvmfs/unpacked.cern.ch` are mounted and that `singularity` can start a container in the node. It runs on `lxplus7`, `lxplus8` and `lxplus9` considering the available hosts at the time of running and both `aarch64` and `ppc64le` machines.

If any of the checks fails, it sends an email notification and writes the node name into a blacklist. For `lxplus` nodes, this blacklist is checked before connecting any node to make sure Jenkins does not connect to a blacklisted node. For `aarch64` and `ppc64le` machines, it takes the corresponding nodes offline.

The blacklist is cleaned up for lxplus nodes if the tests run again successfully in any of the nodes or if the host is not in the list of available hosts anymore. The `aarch64` and `ppc64le` nodes must be taken online manually after receiving the email notification and fixing the issue.