### PR TITLE
Allow relval comparsion to have long and short names

### DIFF
--- a/logRootQA.py
+++ b/logRootQA.py
@@ -323,7 +323,7 @@ sameEvts=True
 nRoot=0
 for r in commonRoots:
 #    print 'I could have tested',r
-    if ('PU' in r or 'RECODR' in r or 'REMINIAOD' in r) and 'inDQM.root' not in r:
+    if 'inDQM.root' not in r:
         checkResult=checkEventContent(baseDir+r,testDir+r)
         sameEvts=sameEvts and checkResult
         nRoot=nRoot+1

--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -107,22 +107,38 @@ ${NANO_TEST} && process_nano nano $WORKSPACE/data/PR-${PR_NUM}
 cat $WORKSPACE/data/$COMPARISON_RELEASE/wf_mapping.*txt | sort | uniq > $WORKSPACE/$MAPPING_FILE
 cat $WORKSPACE/data/$COMPARISON_RELEASE/wf_errors.*txt  | sort | uniq > $WORKSPACE/$ERRORS_FILE
 
-#Create long to short symlinks
-mv $WORKSPACE/data/$COMPARISON_RELEASE $WORKSPACE/data/${COMPARISON_RELEASE}-long
-cp $WORKSPACE/$MAPPING_FILE $WORKSPACE/$MAPPING_FILE.orig
-mkdir $WORKSPACE/data/${COMPARISON_RELEASE}
-for wf_dir in $(ls $WORKSPACE/data/${COMPARISON_RELEASE}-long) ; do
-  if [ ! -e $WORKSPACE/data/${COMPARISON_RELEASE}-long/${wf_dir}/cmdLog ] ; then
-    ln -sf ../${COMPARISON_RELEASE}-long/${wf_dir} $WORKSPACE/data/${COMPARISON_RELEASE}/${wf_dir}
-    continue
+#Temp fix for RelVal long vs short names: Remove it once we have PRs using IBs with short relval names
+MATRIX_READER="src/Configuration/PyReleaseValidation/python/MatrixReader.py"
+if ! grep 'stepList=stepList' $CMSSW_RELEASE_BASE/${MATRIX_READER} >/dev/null 2>&1 ; then
+  #Release is still using long relval names
+  if [ -f $CMSSW_BASE/${MATRIX_READER} ] ; then
+    #PR tests might have latest short name changes
+    if grep 'stepList=stepList' $CMSSW_BASE/${MATRIX_READER} >/dev/null 2>&1 ; then
+      #PR tests generated short relval names change
+      #Create long to short symlinks for root & logs files and update mapping file
+      mv $WORKSPACE/data/$COMPARISON_RELEASE $WORKSPACE/data/${COMPARISON_RELEASE}-long
+      cp $WORKSPACE/$MAPPING_FILE $WORKSPACE/$MAPPING_FILE.orig
+      mkdir $WORKSPACE/data/${COMPARISON_RELEASE}
+      for wf_dir in $(ls $WORKSPACE/data/${COMPARISON_RELEASE}-long) ; do
+        if [ ! -e $WORKSPACE/data/${COMPARISON_RELEASE}-long/${wf_dir}/cmdLog ] ; then
+          ln -sf ../${COMPARISON_RELEASE}-long/${wf_dir} $WORKSPACE/data/${COMPARISON_RELEASE}/${wf_dir}
+          continue
+        fi
+        wf=$(echo $wf_dir | cut -d_ -f1)
+        long_name=$(echo $wf_dir | cut -d_ -f2-)
+        short_name=$(ls -d $WORKSPACE/data/PR-${PR_NUM}/${wf}_*/cmdLog | sed "s|.*/${wf}_||;s|/cmdLog||")
+        [ "${short_name}" = "" ] && exit 1
+        nwf_dir="${wf}_${short_name}"
+        ln -sf ../${COMPARISON_RELEASE}-long/${wf_dir} $WORKSPACE/data/${COMPARISON_RELEASE}/${nwf_dir}
+        sed -i -e "s|${wf_dir}/|${nwf_dir}/|" $WORKSPACE/$MAPPING_FILE
+        #create symlinks for log files
+        for log in $(ls $WORKSPACE/data/PR-${PR_NUM}/${nwf_dir}/step*_${short_name}.log) ; do
+          mv $log $WORKSPACE/data/PR-${PR_NUM}/${nwf_dir}/$(basename $log | cut -d_ -f1)_${long_name}.log
+        done
+      done
+    fi
   fi
-  wf=$(echo $wf_dir | sed 's|_.*||')
-  sname=$(ls -d $WORKSPACE/data/PR-${PR_NUM}/${wf}_*/cmdLog | sed "s|.*/${wf}_||;s|/cmdLog||")
-  [ "${sname}" = "" ] && exit 1
-  nwf_dir="${wf}_${sname}"
-  ln -sf ../${COMPARISON_RELEASE}-long/${wf_dir} $WORKSPACE/data/${COMPARISON_RELEASE}/${nwf_dir}
-  sed -i -e "s|${wf_dir}/|${nwf_dir}/|" $WORKSPACE/$MAPPING_FILE
-done
+fi
 
 cat $WORKSPACE/$MAPPING_FILE
 cat $WORKSPACE/$ERRORS_FILE

--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -109,6 +109,7 @@ cat $WORKSPACE/data/$COMPARISON_RELEASE/wf_errors.*txt  | sort | uniq > $WORKSPA
 
 #Create long to short symlinks
 mv $WORKSPACE/data/$COMPARISON_RELEASE $WORKSPACE/data/${COMPARISON_RELEASE}-long
+cp $WORKSPACE/$MAPPING_FILE $WORKSPACE/$MAPPING_FILE.orig
 mkdir $WORKSPACE/data/${COMPARISON_RELEASE}
 for wf_dir in $(ls $WORKSPACE/data/${COMPARISON_RELEASE}-long) ; do
   if [ ! -e $WORKSPACE/data/${COMPARISON_RELEASE}-long/${wf_dir}/cmdLog ] ; then
@@ -119,8 +120,8 @@ for wf_dir in $(ls $WORKSPACE/data/${COMPARISON_RELEASE}-long) ; do
   sname=$(ls -d $WORKSPACE/data/PR-${PR_NUM}/${wf}_*/cmdLog | sed "s|.*/${wf}_||;s|/cmdLog||")
   [ "${sname}" = "" ] && exit 1
   nwf_dir="${wf}_${sname}"
-  ln -sf ../${COMPARISON_RELEASE}-long/${wf_dir} $WORKSPACE/data/${COMPARISON_RELEASE}/${wf_dir}
-  sed -i -e "s|${wf_dir}/|${nwf_dir}/|" wf_mapping.txt
+  ln -sf ../${COMPARISON_RELEASE}-long/${wf_dir} $WORKSPACE/data/${COMPARISON_RELEASE}/${nwf_dir}
+  sed -i -e "s|${wf_dir}/|${nwf_dir}/|" $WORKSPACE/$MAPPING_FILE
 done
 
 cat $WORKSPACE/$MAPPING_FILE

--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -106,6 +106,23 @@ ${NANO_TEST} && process_nano nano $WORKSPACE/data/PR-${PR_NUM}
 
 cat $WORKSPACE/data/$COMPARISON_RELEASE/wf_mapping.*txt | sort | uniq > $WORKSPACE/$MAPPING_FILE
 cat $WORKSPACE/data/$COMPARISON_RELEASE/wf_errors.*txt  | sort | uniq > $WORKSPACE/$ERRORS_FILE
+
+#Create long to short symlinks
+mv $WORKSPACE/data/$COMPARISON_RELEASE $WORKSPACE/data/${COMPARISON_RELEASE}-long
+mkdir $WORKSPACE/data/${COMPARISON_RELEASE}
+for wf_dir in $(ls $WORKSPACE/data/${COMPARISON_RELEASE}-long) ; do
+  if [ ! -e $WORKSPACE/data/${COMPARISON_RELEASE}-long/${wf_dir}/cmdLog ] ; then
+    ln -sf ../${COMPARISON_RELEASE}-long/${wf_dir} $WORKSPACE/data/${COMPARISON_RELEASE}/${wf_dir}
+    continue
+  fi
+  wf=$(echo $wf_dir | sed 's|_.*||')
+  sname=$(ls -d $WORKSPACE/data/PR-${PR_NUM}/${wf}_*/cmdLog | sed "s|.*/${wf}_||;s|/cmdLog||")
+  [ "${sname}" = "" ] && exit 1
+  nwf_dir="${wf}_${sname}"
+  ln -sf ../${COMPARISON_RELEASE}-long/${wf_dir} $WORKSPACE/data/${COMPARISON_RELEASE}/${wf_dir}
+  sed -i -e "s|${wf_dir}/|${nwf_dir}/|" wf_mapping.txt
+done
+
 cat $WORKSPACE/$MAPPING_FILE
 cat $WORKSPACE/$ERRORS_FILE
 WFS_WITH_ERRORS=''

--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -115,22 +115,14 @@ if ! grep 'stepList=stepList' $CMSSW_RELEASE_BASE/${MATRIX_READER} >/dev/null 2>
     #PR tests might have latest short name changes
     if grep 'stepList=stepList' $CMSSW_BASE/${MATRIX_READER} >/dev/null 2>&1 ; then
       #PR tests generated short relval names change
-      #Create long to short symlinks for root & logs files and update mapping file
-      mv $WORKSPACE/data/$COMPARISON_RELEASE $WORKSPACE/data/${COMPARISON_RELEASE}-long
-      cp $WORKSPACE/$MAPPING_FILE $WORKSPACE/$MAPPING_FILE.orig
-      mkdir $WORKSPACE/data/${COMPARISON_RELEASE}
-      for wf_dir in $(ls $WORKSPACE/data/${COMPARISON_RELEASE}-long) ; do
-        if [ ! -e $WORKSPACE/data/${COMPARISON_RELEASE}-long/${wf_dir}/cmdLog ] ; then
-          ln -sf ../${COMPARISON_RELEASE}-long/${wf_dir} $WORKSPACE/data/${COMPARISON_RELEASE}/${wf_dir}
-          continue
-        fi
+      #Move PR short names to long names and rename log fils
+      for wf_dir in $(ls $WORKSPACE/data/PR-${PR_NUM}) ; do
+        [ ! -e $WORKSPACE/data/PR-${PR_NUM}/${wf_dir}/cmdLog ] || continue
         wf=$(echo $wf_dir | cut -d_ -f1)
-        long_name=$(echo $wf_dir | cut -d_ -f2-)
-        short_name=$(ls -d $WORKSPACE/data/PR-${PR_NUM}/${wf}_*/cmdLog | sed "s|.*/${wf}_||;s|/cmdLog||")
-        [ "${short_name}" = "" ] && exit 1
-        nwf_dir="${wf}_${short_name}"
-        ln -sf ../${COMPARISON_RELEASE}-long/${wf_dir} $WORKSPACE/data/${COMPARISON_RELEASE}/${nwf_dir}
-        sed -i -e "s|${wf_dir}/|${nwf_dir}/|" $WORKSPACE/$MAPPING_FILE
+        short_name=$(echo $wf_dir | cut -d_ -f2-)
+        long_name=$(ls -d $WORKSPACE/data/$COMPARISON_RELEASE/${wf}_*/cmdLog | sed "s|.*/${wf}_||;s|/cmdLog||")
+        nwf_dir="${wf}_${long_name}"
+        mv $WORKSPACE/data/PR-${PR_NUM}/${wf_dir} $WORKSPACE/data/PR-${PR_NUM}/${nwf_dir}
         #create symlinks for log files
         for log in $(ls $WORKSPACE/data/PR-${PR_NUM}/${nwf_dir}/step*_${short_name}.log) ; do
           mv $log $WORKSPACE/data/PR-${PR_NUM}/${nwf_dir}/$(basename $log | cut -d_ -f1)_${long_name}.log

--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -117,7 +117,7 @@ if ! grep 'stepList=stepList' $CMSSW_RELEASE_BASE/${MATRIX_READER} >/dev/null 2>
       #PR tests generated short relval names change
       #Move PR short names to long names and rename log fils
       for wf_dir in $(ls $WORKSPACE/data/PR-${PR_NUM}) ; do
-        [ ! -e $WORKSPACE/data/PR-${PR_NUM}/${wf_dir}/cmdLog ] || continue
+        [ -e $WORKSPACE/data/PR-${PR_NUM}/${wf_dir}/cmdLog ] || continue
         wf=$(echo $wf_dir | cut -d_ -f1)
         short_name=$(echo $wf_dir | cut -d_ -f2-)
         long_name=$(ls -d $WORKSPACE/data/$COMPARISON_RELEASE/${wf}_*/cmdLog | sed "s|.*/${wf}_||;s|/cmdLog||")


### PR DESCRIPTION
Change in `run-pr-comparisons` is a temporary to allow cms-sw/cmssw#40106 to get integrated. Once cms-sw/cmssw#40106 is 
 integrated and PRs start using IBs with cms-sw/cmssw#40106 then we can remove this change.

Also it enable checking edmEventSize for all root files ( except inDQM.root).