### PR TITLE
Fixes and improvements in nodes-sanity-check job

### DIFF
--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -14,7 +14,7 @@ if [[ "$TEST_SINGLE_LXPLUS_HOST" == "true" ]]; then
 fi
 
 nodes_path="$HOME/nodes/"
-email_notification="andrea.valenzuela.ramirez@cern.ch"
+email_notification="cms-sdt-logs@cern.ch"
 job_url="${JENKINS_URL}job/nodes-sanity-check/${BUILD_NUMBER}"
 
 function run_check {
@@ -56,7 +56,6 @@ function get_jenkins_nodenames {
             jenkins_nodes_list+="$(basename $folder) "
         fi
     done
-    echo "Get Jenkins nodenames: $jenkins_nodes_list"
 }
 
 function lxplus_disconnect {
@@ -90,7 +89,7 @@ function aarch_ppc_disconnect {
         node=$(grep agentCommand $folder/config.xml | tr ' <>' '\n\n\n' | grep '@' | sort | uniq | cut -d "@" -f 2 | cut -d "." -f 1)
         if [[ $node == $host ]]; then
             agent=$(basename $folder)
-            echo "Processing agent $agent ..."
+            echo "Marking node $agent as offline ..."
             node_off_list+="$agent "
             node_off $agent
         fi
@@ -176,8 +175,8 @@ function lxplus_offline_cleanup {
         node_idle=$(echo $node_info | grep '"idle" : true' | wc -l)
         if [ $node_idle -gt 0 ]; then
             echo "Bringing node $node_name online again ..."
-            node_on $node_name
-            connect_node $node_name
+            node_on $node_name  # Brings node online, but it stays connected to the buggy host
+            connect_node $node_name  # We need to send the connect command so that the jenkins node is re-connected
         fi
     done
 }
@@ -223,7 +222,7 @@ for node in ${NODES[@]}; do
 done
 
 
-# Cleanup of lxplus hosts
+# Cleanup of lxplus hosts, if needed
 if [ $(echo "${NODES[@]}" | grep "lxplus" | wc -l) -gt 0 ]; then
     if [[ "$TEST_SINGLE_LXPLUS_HOST" == "false" ]]; then 
         lxplus_blacklist_cleanup $lxplus_hosts

--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -5,8 +5,16 @@ if [ ! -d $blacklist_path ]; then
     mkdir -p $blacklist_path
 fi
 
+if [[ "$TEST_SINGLE_LXPLUS_HOST" == "true" ]]; then
+    # Check that is actually a lxplusWXYZ node
+    for node in ${NODES[@]}; do
+        echo $node | grep -E "lxplus[0-9]{2}"; exit_code=$?
+        if [ $exit_code -gt 0 ]; then echo "Host ${node} is not a valid lxplusXYZ host. Please, set TEST_SINGLE_LXPLUS_HOST to false or indicate a valid host." && exit 1; fi
+    done
+fi
+
 nodes_path="$HOME/nodes/"
-email_notification="cms-sdt-logs@cern.ch"
+email_notification="andrea.valenzuela.ramirez@cern.ch"
 job_url="${JENKINS_URL}job/nodes-sanity-check/${BUILD_NUMBER}"
 
 function run_check {
@@ -16,12 +24,15 @@ function run_check {
     ssh $SSH_OPTS "cmsbuild@"$node "sh /tmp/nodes-sanity-check.sh $SINGULARITY $PATHS"; exit_code=$?
     if [[ ${exit_code} -eq 0 ]]; then
         rm -f "$blacklist_path/$node"
+        # Special .offline cleanup for aarch and ppc nodes
+        if [[ $(echo $node | grep -e 'olarm\|ibmminsky' | wc -l) -gt 0 ]]; then
+            aarch_ppc_cleanup $node
+        fi
     else
         echo "... ERROR! Blacklisting ${node} ..."
 	# Check if node is already in the blacklist
 	if [ ! -e $blacklist_path/$node ]; then 
             touch "$blacklist_path/$node" || exit 1
-            notify_failure $email_notification $node $job_url
 	    if [[ $(echo $node | grep '^olarm\|^ibmminsky' | wc -l) -gt 0 ]]; then
                 # If aarch or ppc, bring node off
                 aarch_ppc_disconnect $node
@@ -35,12 +46,101 @@ function run_check {
     fi
 }
 
-function lxplus_cleanup {
+function get_jenkins_nodenames {
+    node=$1
+    nodes_content_path="$HOME/nodes/*"
+    jenkins_nodes_list=()
+    for folder in $nodes_content_path; do
+        jenkins_node=$(grep agentCommand $folder/config.xml | tr ' <>' '\n\n\n' | grep '@' | sort | uniq | cut -d "@" -f 2 | cut -d "." -f 1)
+        if [[ $jenkins_node == $node ]]; then
+            jenkins_nodes_list+="$(basename $folder) "
+        fi
+    done
+    echo "Get Jenkins nodenames: $jenkins_nodes_list"
+}
+
+function lxplus_disconnect {
+    nodes_list="$HOME/logs/slaves/lxplus*"
+    host=$1
+    node_off_list=()
+    for lxplus_node in $nodes_list; do
+        if [ -e $lxplus_node/slave.log ]; then
+            match=$(cat $lxplus_node/slave.log | grep -a "ssh -q" | grep $host)
+            lxplus_node=$(basename $lxplus_node)
+            if [ "X$match" != "X" ]; then
+                echo "Node $lxplus_node is connected to host $host ... Marking $lxplus_node as offline, if needed ..."
+                node_off_list+="$lxplus_node "
+                node_off $lxplus_node
+            else
+                echo "Node $lxplus_node not connected to $host. Skipping ..."
+            fi
+        fi
+    done
+    if [[ "X$node_off_list" != "X" ]]; then
+        notify_failure $email_notification $host $job_url $node_off_list
+    fi
+
+}
+
+function aarch_ppc_disconnect {
+    nodes_path="$HOME/nodes/*"
+    host=$1
+    node_off_list=()   
+    for folder in $nodes_path; do
+        node=$(grep agentCommand $folder/config.xml | tr ' <>' '\n\n\n' | grep '@' | sort | uniq | cut -d "@" -f 2 | cut -d "." -f 1)
+        if [[ $node == $host ]]; then
+            agent=$(basename $folder)
+            echo "Processing agent $agent ..."
+            node_off_list+="$agent "
+            node_off $agent
+        fi
+    done
+    if [[ "X$node_off_list" != "X" ]]; then
+        notify_failure $email_notification $host $job_url $node_off_list
+    fi
+}
+
+function notify_failure {
+    email=$1; shift
+    node=$1; shift
+    job_url=$1; shift
+    node_off_list=$@
+    job_description="This job runs a sanity check for /afs, /cvmfs repositories and singularity."
+    node_info="Jenkins nodes ${node_off_list[@]} have been marked offline since they where connected to host ${node}."
+    error_msg="Node ${node} has been blacklisted by ${job_url}. Please, take the appropiate action. ${node_info} ${job_description}"
+    echo $error_msg | mail -s "Node ${node} has been blacklisted" $email
+}
+
+function node_off {
+    affected_node=$1
+    ${JENKINS_CLI_CMD} offline-node ${affected_node} -m "Node\ ${affected_node}\ has\ been\ blacklisted"
+    # Store that node has been set offline
+    echo "Storing .offline info at: $blacklist_path"
+    touch "$blacklist_path/$affected_node.offline"
+}
+
+function node_on {
+    affected_node=$1
+    ${JENKINS_CLI_CMD} online-node ${affected_node}
+    # Remove offline flag
+    echo "Removing .offline info at: $blacklist_path"
+    rm -rf "$blacklist_path/$affected_node.offline"
+}
+
+function connect_node {
+    affected_node=$1
+    ${JENKINS_CLI_CMD} connect-node ${affected_node}
+    # Remove offline flag
+    echo "Removing .offline info at: $blacklist_path"
+    rm -rf "$blacklist_path/$affected_node.offline"
+}
+
+function lxplus_blacklist_cleanup {
     lxplus_hosts=$@
     blacklist_content="$HOME/workspace/cache/blacklist/*"
 
     for file in $blacklist_content; do
-	filename=$(basename $file)
+        filename=$(basename $file)
         offline_file=$(echo $filename | grep ".offline" | wc -l)
         if [ $offline_file -gt 0 ]; then continue; fi
         if [[ "$filename" == "*" ]]; then
@@ -59,65 +159,8 @@ function lxplus_cleanup {
     done
 }
 
-function lxplus_disconnect {
-    nodes_list="$HOME/logs/slaves/lxplus*"
-    host=$1
-    for lxplus_node in $nodes_list; do
-        if [ -e $lxplus_node/slave.log ]; then
-            match=$(cat $lxplus_node/slave.log | grep -a "ssh -q" | grep $host)
-            lxplus_node=$(basename $lxplus_node)
-            if [ "X$match" != "X" ]; then
-                echo "Node $lxplus_node is connected to host $host ... Marking $lxplus_node as offline, if needed ..."
-                node_off $lxplus_node
-            else
-                echo "Node $lxplus_node not connected to $host. Skipping ..."
-            fi
-        fi
-    done
-
-}
-
-function aarch_ppc_disconnect {
-    nodes_path="$HOME/nodes/*"
-    host=$1
-
-    for folder in $nodes_path; do
-        node=$(grep agentCommand $folder/config.xml | tr ' <>' '\n\n\n' | grep '@' | sort | uniq | cut -d "@" -f 2 | cut -d "." -f 1)
-        if [[ $node == $host ]]; then
-            echo "Processing agent $(basename $folder) ..."
-            node_off $(basename $folder)
-        fi
-    done
-}
-
-function notify_failure {
-    email=$1
-    node=$2
-    job_url=$3
-    job_description="This job runs a sanity check for /afs, /cvmfs repositories and singularity."
-    error_msg="Node ${node} has been blacklisted by ${job_url}. Please, take the appropiate action. ${job_description}"
-    echo $error_msg | mail -s "Node ${node} has been blacklisted" $email
-}
-
-function node_off {
-    affected_node=$1
-    node_info=$(curl -H "OIDC_CLAIM_CERN_UPN: cmssdt" "${LOCAL_JENKINS_URL}computer/$affected_node/api/json?pretty=true")
-    ${JENKINS_CLI_CMD} offline-node ${affected_node} -m "Node\ ${affected_node}\ has\ been\ blacklisted"
-    # Store that node has been set offline
-    echo "Storing .offline info at: $blacklist_path"
-    touch "$blacklist_path/$affected_node.offline"
-}
-
-function node_on {
-    affected_node=$1
-    ${JENKINS_CLI_CMD} online-node ${affected_node}
-    # Remove offline flag
-    echo "Removing .offline info at: $blacklist_path"
-    rm -rf "$blacklist_path/$affected_node.offline"
-}
-
-function offline_cleanup {
-    offline_content="$HOME/workspace/cache/blacklist/*.offline"
+function lxplus_offline_cleanup {
+    offline_content="$HOME/workspace/cache/blacklist/lxplus*.offline"
 
     for file in $offline_content; do
         filename=$(basename $file)
@@ -127,24 +170,40 @@ function offline_cleanup {
             break
         fi
         echo "Offline file found for $node_name ... Cleannig up, if needed."
-        node_info=$(curl -H "OIDC_CLAIM_CERN_UPN: cmssdt" "${LOCAL_JENKINS_URL}computer/$node_name/api/json?pretty=true")
+        node_info=$(curl -H "OIDC_CLAIM_CERN_UPN: cmssdt" "${LOCAL_JENKINS_URL}/computer/$node_name/api/json?pretty=true")
         node_tempoffline=$(echo $node_info | grep '"temporarilyOffline" : true' | wc -l)
         if [ $node_tempoffline -eq 0 ]; then $(rm -rf $file) && continue; fi # External action has been taken
-        node_offline=$(echo $node_info | grep '"offline" : true' | wc -l)
-        if [ $node_offline -gt 0 ]; then
+        node_idle=$(echo $node_info | grep '"idle" : true' | wc -l)
+        if [ $node_idle -gt 0 ]; then
+            echo "Bringing node $node_name online again ..."
             node_on $node_name
+            connect_node $node_name
         fi
     done
 }
 
+function aarch_ppc_cleanup {
+    node=$1
+    get_jenkins_nodenames $node
+
+    echo ${jenkins_nodes_list[@]}
+    for node_name in ${jenkins_nodes_list[@]}; do
+        if [ -e "$blacklist_path/$node_name.offline" ]; then
+            offline_reason=$(grep -e "string" -m 2 "$nodes_path/$node_name/config.xml" | awk '{split($0,a,"<string>|</string>"); print a[2]}' | tail -n 1)
+            if [ $(echo $offline_reason | grep "has been blacklisted" | wc -l) -gt 0 ]; then
+                echo "Bringing node $node_name online again ..."
+                node_on $node_name
+            fi
+        fi
+    done
+}
 
 # Main
-
 lxplus_hosts=()
 
 for node in ${NODES[@]}; do
     echo "Processing $node ..."
-    if [[ "$node" =~ .*"lxplus".* ]]; then
+    if ([[ "$node" =~ .*"lxplus".* ]] && [[ "$TEST_SINGLE_LXPLUS_HOST" == "false" ]]); then
         echo "Searching for lxplus hosts ..."
         for ip in $(host $node | grep 'has address' | sed 's|^.* ||'); do
             real_nodename=$(host $ip | grep 'domain name' | sed 's|^.* ||;s|\.$||')
@@ -153,10 +212,21 @@ for node in ${NODES[@]}; do
             run_check $real_nodename
         done
     else
+        if [[ "$TEST_SINGLE_LXPLUS_HOST" == "true" ]]; then
+            if [ $(echo $node | grep ".cern.ch" | wc -l) -eq 0 ]; then
+                node="${node}.cern.ch"
+            fi
+            lxplus_hosts+=$node
+        fi
         run_check $node
     fi
 done
 
+
 # Cleanup of lxplus hosts
-lxplus_cleanup $lxplus_hosts
-offline_cleanup
+if [ $(echo "${NODES[@]}" | grep "lxplus" | wc -l) -gt 0 ]; then
+    if [[ "$TEST_SINGLE_LXPLUS_HOST" == "false" ]]; then 
+        lxplus_blacklist_cleanup $lxplus_hosts
+    fi
+    lxplus_offline_cleanup
+fi


### PR DESCRIPTION
This PR adds the option of testing one single lxplus node setting the boolean parameter `TEST_SINGLE_LXPLUS_HOST` to true. It also includes a special cleanup for non x86_64 (now it will only bring nodes online again if the offline reason is known, so in case one of the nodes is offline because of a different reason, e.g., building Spack, it won't bring the node online). Finally, `node-online` action on lxplus nodes brings the node online, but it stays connected to the buggy host. That is why we now send a `connect-node` action also so that jenkins runs the `connect.sh` script again avoiding the blacklisted host.