### PR TITLE
Add wf `10804.31` and `10805.31` to known errors for release CMSSW_13_* also

### DIFF
--- a/cmssw_known_errors.py
+++ b/cmssw_known_errors.py
@@ -124,7 +124,7 @@ KNOWN_ERRORS["relvals"][RelFilter][".+"] = {
   "536.0": { "step": 1, "exitcode": 256,   "reason" : MSG_ASAN_INCOMPETIBILITY},
 }
 
-RelFilter="CMSSW_12_.+"
+RelFilter="CMSSW_(12|13)_.+"
 KNOWN_ERRORS["relvals"][RelFilter] = {}
 KNOWN_ERRORS["relvals"][RelFilter][".+_(aarch64|ppc64le)_.+"] = {
   "10804.31": { "step": 3, "exitcode": 16640, "reason" : MSG_TRITON_INCOMPETIBILITY},

--- a/cmssw_known_errors.py
+++ b/cmssw_known_errors.py
@@ -124,7 +124,7 @@ KNOWN_ERRORS["relvals"][RelFilter][".+"] = {
   "536.0": { "step": 1, "exitcode": 256,   "reason" : MSG_ASAN_INCOMPETIBILITY},
 }
 
-RelFilter="CMSSW_(12|13)_.+"
+RelFilter="CMSSW_(12|1[2-9]|[2-9][0-9]|[1-9][0-9][0-9]+)_.+"
 KNOWN_ERRORS["relvals"][RelFilter] = {}
 KNOWN_ERRORS["relvals"][RelFilter][".+_(aarch64|ppc64le)_.+"] = {
   "10804.31": { "step": 3, "exitcode": 16640, "reason" : MSG_TRITON_INCOMPETIBILITY},


### PR DESCRIPTION
We want to keep relvals wf  `10804.31` and `10805.31` as known errors in non-amd64 archs for the new  CMSSW_13_* release cycle. This will avoid showing TritonService server fallback errors in relvals as reported in https://github.com/cms-sw/cmssw/issues/37767.