### PR TITLE
add labeling for tracking

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1715,11 +1715,22 @@ CMSSW_CATEGORIES = {
 CMSSW_LABELS = {
   "tracking": [
     "CUDADataFormats/Track",
+    "CUDADataFormats/Vertex",
     "DataFormats/Track",
+    "DataFormats/VertexReco",
+    "DataFormats/V0Candidate",
+    "DataFormats/VZero",
+    "DQM/Tracking",
+    "FastSimulation/Tracking",
+    "Geometry/GlobalTracking",
     "RecoPixelVertexing",
     "RecoTracker",
     "RecoVertex",
     "TrackPropagation",
-    "TrackingTools"
+    "TrackingTools",
+    "Validation/RecoPixelVertexing",
+    "Validation/RecoTrack",
+    "Validation/RecoVertex",
+    "Validation/Tracking"
   ]
 }

--- a/categories_map.py
+++ b/categories_map.py
@@ -1711,9 +1711,9 @@ CMSSW_CATEGORIES = {
 #explicit `type label`. Only valid dpg/pog groups can be added as labels
 #Format: label = [cmssw_pkg1, cmssw_pkgN]
 #where cmssw_pkgX can be full or part of start of cmssw Package name
-# "jetmet" = [ "SubSystem1", "SubSystem2/Package"]
+# "jetmet": [ "SubSystem1", "SubSystem2/Package"]
 CMSSW_LABELS = {
-  "tracking" = [
+  "tracking": [
     "CUDADataFormats/Track",
     "DataFormats/Track",
     "RecoPixelVertexing",

--- a/categories_map.py
+++ b/categories_map.py
@@ -1713,4 +1713,13 @@ CMSSW_CATEGORIES = {
 #where cmssw_pkgX can be full or part of start of cmssw Package name
 # "jetmet" = [ "SubSystem1", "SubSystem2/Package"]
 CMSSW_LABELS = {
+  "tracking" = [
+    "CUDADataFormats/Track",
+    "DataFormats/Track",
+    "RecoPixelVertexing",
+    "RecoTracker",
+    "RecoVertex",
+    "TrackPropagation",
+    "TrackingTools"
+  ]
 }

--- a/categories_map.py
+++ b/categories_map.py
@@ -1714,12 +1714,17 @@ CMSSW_CATEGORIES = {
 # "jetmet": [ "SubSystem1", "SubSystem2/Package"]
 CMSSW_LABELS = {
   "tracking": [
+    "AnalysisDataFormats/TrackInfo",
+    "CondCore/BeamSpot",
+    "CondFormats/BeamSpot",
+    "CondTools/BeamSpot",
     "CUDADataFormats/Track",
     "CUDADataFormats/Vertex",
     "DataFormats/Track",
     "DataFormats/VertexReco",
     "DataFormats/V0Candidate",
     "DataFormats/VZero",
+    "DQM/BeamMonitor",
     "DQM/Tracking",
     "FastSimulation/Tracking",
     "Geometry/GlobalTracking",


### PR DESCRIPTION
add packages and subsystems to be labeled for tracking

- "CUDADataFormats/Track",
- "DataFormats/Track",
- "RecoPixelVertexing",
- "RecoTracker",
- "RecoVertex",
- "TrackPropagation",
    - will also match to TrackPropagation/SteppingHelixPropagator, which is mostly muon reco, but it's probably still OK for tracking
- "TrackingTools"
    - will also match TrackingTools/TrackAssociator, which is not tracking, but the alternative is to write a much longer list. So, we could probably unassign

@mmusich 
do you have any comments?
