### PR TITLE
remove `beaucero` and `trtomei` from `upgrade` watchers

### DIFF
--- a/category-watchers.yaml
+++ b/category-watchers.yaml
@@ -7,7 +7,3 @@ mmusich:
 - db
 silviodonato:
 - hlt
-beaucero:
-- upgrade
-trtomei:
-- upgrade


### PR DESCRIPTION
This PR removes @trtomei (former HLT-Upgrade convener) and @beaucero from the watchers of `upgrade` packages.

The HLT-Upgrade conveners, Stephanie (@beaucero) and Soham (@SohamBhattacharya), only intend to monitor PRs touching the HLT Phase-2 menu (i.e. `HLTrigger/Configuration/python/HLT_75e33*`), and I will notify them manually in the relevant PRs until there is a better solution.

~~This PR makes the conveners of the HLT-Upgrade group, Stephanie (@beaucero) and Soham (@SohamBhattacharya), watchers of the HLT Phase-2 menu in CMSSW.~~

~~It also removes @trtomei (former HLT-Upgrade convener) and @beaucero from the watchers of the "upgrade" packages.~~

Agreed offline with @beaucero. 

FYI: @cms-sw/hlt-l2 @silviodonato
