### PR TITLE
make `beaucero` and `SohamBhattacharya` watch the HLT Phase-2 menu

### DIFF
--- a/watchers.yaml
+++ b/watchers.yaml
@@ -1821,3 +1821,7 @@ a-kapoor:
   - EgammaAnalysis
   - DataFormats/EgammaCandidates
   - DataFormats/EgammaReco
+beaucero:
+- HLTrigger/Configuration/python/HLT_75e33
+SohamBhattacharya:
+- HLTrigger/Configuration/python/HLT_75e33


### PR DESCRIPTION
Follow-up of #1920. After #1922, entries in `watchers.yaml` can be used to watch CMSSW changes at file level.

This PR enables automatic notifications to the conveners of the HLT-Upgrade group, Stephanie (@beaucero) and Soham (@SohamBhattacharya), for PRs involving the HLT Phase-2 menu in CMSSW.

Agreed offline with @beaucero.

FYI: @cms-sw/hlt-l2 @silviodonato
