### PR TITLE
Drop dependency on PyGithub external package for release build process

### DIFF
--- a/report-build-release-status
+++ b/report-build-release-status
@@ -1,6 +1,8 @@
 #!/bin/bash
+PYTHON_CMD="python"
+if which python3 >/dev/null 2>&1 ; then PYTHON_CMD="python3" ; fi
 for x in 0 1 2 ; do
-  $(dirname $0)/report-build-release-status.py "$@" && exit 0
+  ${PYTHON_CMD} $(dirname $0)/report-build-release-status.py "$@" && exit 0
   sleep 30
 done
 exit 1

--- a/report-build-release-status.py
+++ b/report-build-release-status.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
   action = args[ 5 ]
 
   repo = GH_CMSSW_ORGANIZATION + '/' + GH_CMSSW_REPO
-  ALL_LABELS = [ l.name for l in get_issue_labels(repo, issue) ]
+  ALL_LABELS = [ l["name"] for l in get_issue_labels(repo, issue) ]
   test_logfile = "build/"+release_name+"-tests/matrixTests/runall-report-step123-.log"
   
   if action == POST_BUILDING:


### PR DESCRIPTION
https://github.com/PyGithub/PyGithub versions are either available for python2 or python3. The one we have deploy for bot is based on python2. So during the release build process if `python` ( i.e. python2) is missing either on the host or in the container then release build jobs fails. e.g. `python` missing in
- machines with centos stream8/almalinux8/rhel8 OS
- cmssw/el9 containers

This change drops the usage of `PyGithub` and make use of our `github_utility` api calls.

This is being tested by el9_amd64_gcc11 build of CMSSW_13_0_2 ( https://cmssdt.cern.ch/jenkins/job/build-release/3834/console ). If that `el9` builds goes fine then we should merge it