### PR TITLE
override system commands for special IBs e.g ASAN

### DIFF
--- a/pr_testing/setup-pr-test-env.sh
+++ b/pr_testing/setup-pr-test-env.sh
@@ -39,6 +39,12 @@ export SITECONFIG_PATH=/cvmfs/cms-ib.cern.ch/SITECONF/local
 mkdir -p ${RESULTS_DIR}
 [ "${ARCHITECTURE}" != "" ] && export SCRAM_ARCH=${ARCHITECTURE}
 export SCRAM_PREFIX_PATH=${CMS_BOT_DIR}/das-utils
+case $CMSSW_IB in
+  *_ASAN_* )
+   $CMS_BOT_DIR/system-overrides.sh $WORKSPACE/system-overrides
+   export SCRAM_PREFIX_PATH=$WORKSPACE/system-overrides:${SCRAM_PREFIX_PATH}
+   ;;
+esac
 if [ "${CMSSW_CVMFS_PATH}" != "" ] ; then
   WAIT_TIME=14400
   while [ $WAIT_TIME -gt 0 ] ; do

--- a/run-ib-testbase.sh
+++ b/run-ib-testbase.sh
@@ -30,6 +30,13 @@ if [ -f config/SCRAM/linkexternal.py ] ; then
   sed -i -e 's|%s build|echo %s build|'  config/SCRAM/linkexternal.py || true
 fi
 set +x
+#Check for syste commands to override e.g. ps hangs in ASAN env
+case ${RELEASE_FORMAT} in
+  *_ASAN_* )
+   $CMS_BOT_DIR/system-overrides.sh $WORKSPACE/system-overrides
+   export SCRAM_PREFIX_PATH=$WORKSPACE/system-overrides:${SCRAM_PREFIX_PATH}
+   ;;
+esac
 eval \$(scram runtime -sh)
 echo "PATH"
 echo \$PATH | tr ':' '\n'

--- a/system-overrides.sh
+++ b/system-overrides.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -x
+#This script generate system commands which hangs under ASAN/UBSAN env
+#Idea is to unset LD_PRELOAD and then call the actual system command
+OVERRIDE_DIR=$1
+[ "$1" != "" ] || OVERRIDE_DIR=$(/bin/pwd -P)
+mkdir -p ${OVERRIDE_DIR}
+for cmd in ps ; do
+  if [ ! -x ${OVERRIDE_DIR}/${cmd} ] ; then
+    sys_cmd=$(which $cmd || echo "")
+    echo '#!/bin/bash' > ${OVERRIDE_DIR}/${cmd}
+    echo "LD_PRELOAD='' exec ${sys_cmd} \"\$@\"" >> ${OVERRIDE_DIR}/${cmd}
+    chmod +x ${OVERRIDE_DIR}/${cmd}
+  fi
+done


### PR DESCRIPTION
In ASAN IBs , some unit tests fail as `LD_PRELOAD=libasan.so` and some system command do not work well. For example `ps` commands hangs when  `LD_PRELOAD=libasan.so`  is set causing few tests to hangs for 3hours. This change allow the bot to conditionally override these system commands in such a way that it unset the LD_PRELOAD and then call system command.

hanging of `ps`  under `libasan` is known issue 
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90589 
- https://sourceware.org/bugzilla/show_bug.cgi?id=27653