### PR TITLE
Add DPGAnalysis/MuonTools to xpog

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1721,6 +1721,7 @@ CMSSW_CATEGORIES = {
   "xpog": [
     "DataFormats/NanoAOD",
     "DataFormats/PatCandidates",
+    "DPGAnalysis/MuonTools",
     "PhysicsTools/NanoAOD",
     "PhysicsTools/PatAlgos",
     "PhysicsTools/PatUtils",


### PR DESCRIPTION
The new package is needed by https://github.com/cms-sw/cmssw/pull/38226 (now under review).
That package uses extensively nanoAOD, and therefore it seems to me natural to assign it to xpog, rather than to the "dummy" category Analysis