### PR TITLE
Add DPGAnalysis/MuonTools and assign it to xpog

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1722,6 +1722,7 @@ CMSSW_CATEGORIES = {
     "DataFormats/NanoAOD",
     "DataFormats/PatCandidates",
     "DPGAnalysis/HcalNanoAOD",
+    "DPGAnalysis/MuonTools",
     "PhysicsTools/NanoAOD",
     "PhysicsTools/PatAlgos",
     "PhysicsTools/PatUtils",

--- a/watchers.yaml
+++ b/watchers.yaml
@@ -260,9 +260,9 @@ battibass:
 - DataFormats/L1DTTrackFinder
 - DataFormats/MuonDetId
 - DataFormats/MuonReco
+- DPGAnalysis/MuonTools
 - DQM/DTMonitorClient
 - DQM/DTMonitorModule
-- DQM/Integration
 - DQMOffline/CalibMuon
 - EventFilter/DTRawToDigi
 - EventFilter/L1TXRawToDigi


### PR DESCRIPTION
As discussed during the approval of [PR 38226](https://github.com/cms-sw/cmssw/pull/38226) a new package is created and assigned to @cms-sw/xpog-l2 