### PR TITLE
Adding new L2s for EGM and PF in `categories.py`

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -110,8 +110,10 @@ CMSSW_L2 = {
   # pogs
   "juska":            ["pf"],
   "kdlong":           ["pf"],
+  "swagata87":        ["pf"],
   "a-kapoor":         ["egamma-pog"],
   "swagata87":        ["egamma-pog"],
+  "RSalvatico":       ["egamma-pog"],
   "kirschen":         ["jetmet-pog"],
   "miquork":          ["jetmet-pog"],
   "alkaloge":         ["jetmet-pog"],

--- a/categories.py
+++ b/categories.py
@@ -108,7 +108,7 @@ CMSSW_L2 = {
   "fabiocos":         ["mtd-dpg", "operations"],
   "parbol":           ["mtd-dpg"],
   # pogs
-  "juska":            ["pf"],
+  "bellan":           ["pf"],
   "kdlong":           ["pf"],
   "swagata87":        ["pf"],
   "a-kapoor":         ["egamma-pog"],


### PR DESCRIPTION
Adding new L2 convenors for EGM POG and PF group. 
The old L2s are not removed as we are in overlap period until end of August.
FYI @cms-sw/egamma-pog-l2 and @cms-sw/pf-l2, @RSalvatico
