### PR TITLE
Add D98 wf to profile runner

### DIFF
--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -162,6 +162,24 @@ workflow_configs = {
         "nThreads": 1,
         "matrix": "upgrade"
     } ,
+    #Phase2 workflow used late-2023
+    "24834.21": {
+        "num_events": 100,
+        "steps": {
+            "step3": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+            "step4": {
+                "TimeMemoryInfo": True,
+                "FastTimer": True,
+                "igprof": True,
+            },
+         },
+        "nThreads": 1,
+        "matrix": "upgrade"
+    } ,
     #8-thread T0-like promptreco workflow
     "136.889": {
         "num_events": 5000,


### PR DESCRIPTION
The phase 2 D98 workflow was added to `cmssw-pr-test-config` in #2011 
The PR adds it also to `profileRunner.py`

