### PR TITLE
New tool: uniq-errors

### DIFF
--- a/jenkins-jobs/git/git-notify-ib-updates
+++ b/jenkins-jobs/git/git-notify-ib-updates
@@ -195,9 +195,16 @@ def main():
     # Save new json files
     for rel in changed_rels:
         url_ = f"https://github.com/cms-sw/cms-sw.github.io/raw/{newest_commit_id}/_data%2F{rel}.json"
-        data = libib.fetch(url_, libib.ContentType.TEXT)
-        with open(os.path.join(cache_root, "{}.json".format(rel)), "w") as f:
-            f.write(data)
+        try:
+            data = libib.fetch(url_, libib.ContentType.TEXT)
+        except urllib.error.HTTPError as e:
+            if e.code != 404:
+                raise
+            else:
+                pass
+        else:
+            with open(os.path.join(cache_root, "{}.json".format(rel)), "w") as f:
+                f.write(data)
 
 
 if __name__ == "__main__":

--- a/shift/report.py
+++ b/shift/report.py
@@ -43,7 +43,7 @@ def main():
     for ib_date in ib_dates:
         for flav, comp in libib.get_ib_comparision(ib_date, series).items():
             if comp is None:
-                print(f"No IB found for flavor {flav} and date {ib_date}")
+                # print(f"No IB found for flavor {flav} and date {ib_date}")
                 continue
             release_name, errors = libib.check_ib(comp)
             with open(f"out/{release_name}.md", "w") as f:

--- a/shift/uniq-errors.py
+++ b/shift/uniq-errors.py
@@ -1,0 +1,89 @@
+import argparse
+import libib
+import re
+import os
+
+from dataclasses import dataclass, field
+
+# noinspection PyUnresolvedReferences
+from libib import PackageInfo, ErrorInfo
+
+
+@dataclass(frozen=True)
+class CompError:
+    file: str
+    line: int
+    data: str = field(compare=False)
+    url: str = field(compare=False)
+
+
+error_rex = re.compile(
+    r"<span class=compErr> <b> (?P<path>.*):(?P<line>\d+):(?P<col>\d+): error: (?P<text>.*)"
+)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-a", "--architecture", help="Release architecture (e.g. el9_amd64_gcc13)"
+    )
+    parser.add_argument("-d", "--date", help="IB date")
+    parser.add_argument("-s", "--series", help="IB series (e.g. CMSSW_13_3_X)")
+    parser.add_argument(
+        "-f", "--filter", help="Only display errors containing given text"
+    )
+
+    args = parser.parse_args()
+
+    print(f"Getting IB data for {args.series} on {args.date}")
+    comp = libib.get_ib_comparision(args.date, args.series)[args.series]
+    if comp is None:
+        print(
+            f"No errors found for IB {args.series} on {args.date} arch {args.architecture}"
+        )
+        return
+
+    print(
+        f"Extracting build errors for {args.series} on {args.date} arch {args.architecture}"
+    )
+    _, errors = libib.check_ib(comp, True)
+    errors = errors[args.architecture]["build"]
+    seen_errors = set()
+
+    print("Collecting unique errors")
+    for error in errors:
+        if error.data[0] != "compError":
+            continue
+        pkg_name = "_".join(error.url.split("/")[-2:])
+        print(f"> Checking {pkg_name}")
+        if not os.path.exists(os.path.join("cache", pkg_name + ".html")):
+            log_html = libib.fetch(error.url, libib.ContentType.TEXT)
+            with open(os.path.join("cache", pkg_name + ".html"), "w") as f:
+                f.write(log_html)
+        else:
+            log_html = open(os.path.join("cache", pkg_name + ".html")).read()
+
+        for match in error_rex.finditer(log_html):
+            error_x = CompError(
+                file=os.path.basename(match.group("path")),
+                line=match.group("line"),
+                data=match.group("text"),
+                url=error.url,
+            )
+            seen_errors.add(error_x)
+
+    with open("errors.md", "w") as f:
+        print("| Location | Error text |", file=f)
+        print("| --- | --- |", file=f)
+        for error in sorted(tuple(seen_errors), key=lambda x: (x.url, x.file, x.line)):
+            # if 'error=array-bounds' in text:
+            if (not args.filter) or args.filter in error.data:
+                print(f"{error.url} -> {error.file}:{error.line} error {error.data}")
+                print(
+                    f"| [{error.file}:{error.line}]({error.url}) | {error.data} |",
+                    file=f,
+                )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Get unique errors in a given IB. Example usage:
```
$ python uniq-errors.py -a el9_amd64_gcc13 -s CMSSW_13_3_X -d 2023-07-28-2300
```

Can also filter out specific error:
```
$ python uniq-errors.py -a el9_amd64_gcc13 -s CMSSW_13_3_X -d 2023-07-28-2300 -f array-bounds
```