### PR TITLE
Py3: Changes required for all all jenkins-* jobs run on jenkins controller

### DIFF
--- a/es_ib_build_stats.py
+++ b/es_ib_build_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import re, json, sys
 from datetime import datetime
@@ -82,7 +82,7 @@ def process_build_any_ib(logFile):
   payload["url"]=url
   week, rel_sec = cmsswIB2Week(rel)
   print(payload)
-  id = sha1(rel + arch).hexdigest()
+  id = sha1((rel + arch).encode()).hexdigest()
   send_payload("jenkins-ibs-"+week,"timings",id,json.dumps(payload))
   return finished
     

--- a/es_utils.py
+++ b/es_utils.py
@@ -73,7 +73,10 @@ def send_request(uri, payload=None, passwd_file=None, method=None, es_ser=ES_SER
   passwd=es_get_passwd(passwd_file)
   if not passwd: return False
   url = "%s/%s" % (es_ser,uri)
-  header['Authorization'] = 'Basic %s' % base64.b64encode("cmssdt:%s" % passwd)
+  if sys.version_info[0] == 2: 
+    header['Authorization'] = 'Basic %s' % base64.b64encode("cmssdt:%s" % passwd)
+  else:
+    header['Authorization'] = 'Basic %s' % base64.b64encode(("cmssdt:%s" % passwd).encode()).decode() 
   try:
     request = Request(url, payload, header)
     if method: request.get_method = lambda: method

--- a/es_utils.py
+++ b/es_utils.py
@@ -78,7 +78,10 @@ def send_request(uri, payload=None, passwd_file=None, method=None, es_ser=ES_SER
   else:
     header['Authorization'] = 'Basic %s' % base64.b64encode(("cmssdt:%s" % passwd).encode()).decode() 
   try:
-    request = Request(url, payload, header)
+    if sys.version_info[0] == 2:
+      request = Request(url, payload, header)
+    else:
+      request = Request(url, payload.encode(), header)
     if method: request.get_method = lambda: method
     content = urlopen(request, context=get_ssl_context())
   except Exception as e:

--- a/es_utils.py
+++ b/es_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 from __future__ import print_function
-import json, re, ssl, base64
+import sys, json, re, ssl, base64
 from os.path import exists
 from os import getenv
 from hashlib import sha1

--- a/jenkins/jenkins-project-report-to-markdown.py
+++ b/jenkins/jenkins-project-report-to-markdown.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 File       : jenkins-project-report-to-markdown.py
 Author     : Zygimantas Matonis

--- a/jenkins/report-jenkins-jobs.py
+++ b/jenkins/report-jenkins-jobs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 print("<html>")
 print('<head>')
@@ -39,14 +39,14 @@ for item in data:
   print("<li class="+'"'+"active"+'" '+ "id="+'"'+ name + '"'+ '><a href="https://cmssdt.cern.ch/jenkins/job/'+name+'"'+'><b>' + name.upper() +"</b></a></li>"+"<br />")
   print("<p>" , item[1]['job_desc'] , "</p><br />")
   if len(item[1]['downstream']) > 0:
-    d = [ x.encode('utf-8') for x in item[1]['downstream'] ]
+    d = [ x for x in item[1]['downstream'] ]
     for chd in d:
       parents[chd].append(name)
     print('<li>')  
     print("<b>DownStream Projects:</b> ", '  '.join([ '<a href='+'"#'+ x +'"'+ '>' + x + '</a>' for x in d ]) , "<br />")
     print('</li>')
   if len(item[1]['subprojects']) > 0:
-    sub = [ x.encode('utf-8') for x in item[1]['subprojects'] ]
+    sub = [ x for x in item[1]['subprojects'] ]
     print('<li>') 
     print("<b>Sub Projects:</b> ", ' '.join([ '<a href='+'"#'+ x +'"'+ '>' + x + '</a>' for x in sub  ]) , "<br />")
     print('</li>')
@@ -54,7 +54,7 @@ for item in data:
       parents[child].append(name)
   
   if len(item[1]['triggers_from']) > 0:
-    trg = [ x.encode('utf-8') for x in item[1]['triggers_from']]
+    trg = [ x for x in item[1]['triggers_from']]
     item[1]['upstream'].extend(trg)
   for ent in parents:
     if ent == name:
@@ -62,7 +62,7 @@ for item in data:
 
   if len(item[1]['upstream']) > 0:
     item[1]['upstream'] = set(item[1]['upstream'])
-    up = [ x.encode('utf-8') for x in item[1]['upstream']]
+    up = [ x for x in item[1]['upstream']]
     print('<li>') 
     print("<b>UpStream Projects:</b> ", ' '.join([ '<a href='+'"#'+ x +'"'+ '>' + x + '</a>' for x in up  ]) , "<br />")
     print('</li><br />')

--- a/jenkins_monitor_queue.py
+++ b/jenkins_monitor_queue.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import datetime, json
 from hashlib import sha1

--- a/parse_jenkins_builds.py
+++ b/parse_jenkins_builds.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from hashlib import sha1
 import os , re , sys , json, datetime, time, functools
 import xml.etree.ElementTree as ET
-from _py2with3compatibility import run_cmd
+import subprocess
 from es_utils import send_payload,get_payload,resend_payload,get_payload_wscroll
 
 JENKINS_PREFIX="jenkins"
@@ -113,8 +113,9 @@ if elements_inqueue:
     es_queue[entry['_id']] = entry['_source']
 
 # Get jenkins queue and construct payload to be send to elastic search
-exit_code, queue_json = run_cmd('curl -s -H "OIDC_CLAIM_CERN_UPN: cmssdt; charset=UTF-8" "' + LOCAL_JENKINS_URL + '/queue/api/json?pretty=true"')
-queue_json = json.loads(queue_json)
+que_cmd='curl -s -H "OIDC_CLAIM_CERN_UPN: cmssdt; charset=UTF-8" "' + LOCAL_JENKINS_URL + '/queue/api/json?pretty=true"'
+jque_res = subprocess.run(que_cmd,shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+queue_json = json.loads(jque_res.stdout)
 
 jenkins_queue = dict()
 current_time = get_current_time()

--- a/parse_jenkins_builds.py
+++ b/parse_jenkins_builds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from hashlib import sha1
 import os , re , sys , json, datetime, time, functools
@@ -53,12 +53,12 @@ def process_queue_reason(labels):
     if "already in progress" in labels:
         reason = "concurrent builds not allowed"
     elif "Waiting for next available executor on" in labels:
-        node = labels.split(" on ")[1].decode('utf8').encode('ascii', errors='ignore')
+        node = labels.split(" on ")[1].encode('ascii', errors='ignore')
         reason = str(node) + "-busy"
     elif "is offline;" in labels:
         reason = "multiple-offline"
     elif "is offline" in labels:
-        node = labels.split(" is ")[0].decode('utf8').encode('ascii', errors='ignore')
+        node = labels.split(" is ")[0].encode('ascii', errors='ignore')
         reason = str(node) + "-offline"
     else:
         reason = "other"
@@ -124,7 +124,7 @@ for element in queue_json["items"]:
     job_name = element["task"]["name"]
     queue_id = int(element["id"])
     queue_time = int(element["inQueueSince"])
-    labels = element["why"].encode('utf-8')
+    labels = str(element["why"].encode('utf-8'))
     reason = process_queue_reason(labels)
 
     payload['jenkins_server'] = JENKINS_PREFIX
@@ -137,7 +137,7 @@ for element in queue_json["items"]:
     payload["start_time"] = 0
 
     unique_id = JENKINS_PREFIX + ":/build/builds/" + job_name + "/" + str(queue_id) # Not a real path
-    id = sha1(unique_id).hexdigest()
+    id = sha1(unique_id.encode()).hexdigest()
     jenkins_queue[id] = payload
 
 queue_index="cmssdt-jenkins-queue-"+str(int(((current_time/86400000)+4)/7))
@@ -195,7 +195,7 @@ for root, dirs, files in os.walk(path):
       payload['job_name'] = '/'.join(job_info[3:-1])
       payload['build_number'] = job_info[-1]
       payload['url'] = "https://cmssdt.cern.ch/"+JENKINS_PREFIX+"/job/" + '/job/'.join(job_info[3:-1]) + "/" + job_info[-1] + "/"
-      id = sha1(JENKINS_PREFIX+":"+root).hexdigest()
+      id = sha1((JENKINS_PREFIX+":"+root).encode()).hexdigest()
       try:
         tree = ET.parse(logFile)
         root = tree.getroot()


### PR DESCRIPTION
@iarspider , this should fix all the `jenkins-*`  jobs which run on jenkins master/controller node. Only following jobs use python2. All other `jenkins-*` jobs either do not use `python` or already using python3 [a]
```
jenkins-elasticsearch-monitor
jenkins-monitor-queue
jenkins-projects-report
jenkins-projects-wiki-update
```

[a] jobs alread using python3
```
jenkins-backup
jenkins-test-parser
jenkins-test-parser-monitor
jenkins-test-retry
```