### PR TITLE
Py3: More changes

### DIFF
--- a/add-externals-gh-labels.py
+++ b/add-externals-gh-labels.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env python3
 from github import Github
 from os.path import expanduser, dirname, abspath, join, exists
 from githublabels import LABEL_TYPES, COMMON_LABELS, COMPARISON_LABELS, CMSSW_BUILD_LABELS, LABEL_COLORS

--- a/create-github-hooks
+++ b/create-github-hooks
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env python3
 from github import Github
 from os.path import expanduser, exists, join, dirname, abspath
 from os import environ

--- a/es/es_git_repo_size.py
+++ b/es/es_git_repo_size.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from hashlib import sha1
 import sys, json
 from time import time

--- a/es_ibs_log.py
+++ b/es_ibs_log.py
@@ -47,7 +47,7 @@ def process_unittest_log(logFile):
     {"str_to_match": "test (.*) had ERRORS", "name": "{0} failed", 'control_type': ResultTypeEnum.ISSUE },
     {"str_to_match": '===== Test "([^\s]+)" ====', "name": "{0}", 'control_type': ResultTypeEnum.TEST }
   ]
-  with open(logFile) as f:
+  with open(logFile, encoding="ascii", errors="ignore") as f:
     utname = None
     datasets = []
     xid = None
@@ -87,7 +87,7 @@ def process_addon_log(logFile):
   payload["name"] = pathInfo[-1].split("-")[1].split("_cmsRun_")[0].split("_cmsDriver.py_")[0]
   id = sha1hexdigest(release + architecture + "addon" + payload["name"])
   config_list = []
-  with open(logFile) as f:
+  with open(logFile, encoding="ascii", errors="ignore") as f:
     for index, l in enumerate(f):
       l = l.strip()
       config_list = add_exception_to_config(l,index, config_list)
@@ -114,7 +114,7 @@ def process_hlt_log(logFile):
   payload["@timestamp"]=timestp
   payload["name"] = pathInfo[-1][:-4]
   id = sha1hexdigest(release + architecture + "hlt" + payload["name"])
-  with open(logFile) as f:
+  with open(logFile, encoding="ascii", errors="ignore") as f:
     for index, l in enumerate(f):
       l = l.strip()
       if " Initiating request to open file " in l:
@@ -145,7 +145,7 @@ def process_ib_utests(logFile):
   payload["@timestamp"] = timestp
 
   if exists(logFile):
-    with open(logFile) as f:
+    with open(logFile, encoding="ascii", errors="ignore") as f:
       try:
         it = iter(f)
         line = next(it)

--- a/es_ibs_log.py
+++ b/es_ibs_log.py
@@ -1,5 +1,6 @@
-#!/bin/env python
+#!/bin/env python3
 from __future__ import print_function
+
 from hashlib import sha1
 import os, json,  datetime, sys
 from glob import glob
@@ -9,6 +10,10 @@ from _py2with3compatibility import run_cmd
 from cmsutils import cmsswIB2Week
 from logreaderUtils import transform_and_write_config_file, add_exception_to_config, ResultTypeEnum
 import traceback
+
+
+def sha1hexdigest(data):
+  return sha1(data.encode()).hexdigest()
 
 def send_unittest_dataset(datasets, payload, id, index, doc):
   for ds in datasets:
@@ -22,8 +27,8 @@ def send_unittest_dataset(datasets, payload, id, index, doc):
     payload["protocol"]=ds_items[0].split("/store/",1)[0]+ibeos
     payload["protocol_opts"]=ds_items[1]
     payload["lfn"]="/store/"+ds_items[0].split("/store/",1)[1].strip()
-    print ("Sending",index, doc, sha1(id + ds).hexdigest(), json.dumps(payload))
-    send_payload(index, doc, sha1(id + ds).hexdigest(), json.dumps(payload))
+    print ("Sending",index, doc, sha1hexdigest(id + ds), json.dumps(payload))
+    send_payload(index, doc, sha1hexdigest(id + ds), json.dumps(payload))
 
 def process_unittest_log(logFile):
   t = getmtime(logFile)
@@ -54,7 +59,7 @@ def process_unittest_log(logFile):
         datasets = []
         utname = l.split('"')[1]
         payload["name"] = "%s/%s" % (package, utname)
-        xid = sha1(release + architecture + package + str(utname)).hexdigest()
+        xid = sha1hexdigest(release + architecture + package + str(utname))
       elif " Initiating request to open file " in l:
         try:
           rootfile = l.split(" Initiating request to open file ")[1].split(" ")[0]
@@ -80,7 +85,7 @@ def process_addon_log(logFile):
   payload["architecture"]=architecture
   payload["@timestamp"]=timestp
   payload["name"] = pathInfo[-1].split("-")[1].split("_cmsRun_")[0].split("_cmsDriver.py_")[0]
-  id = sha1(release + architecture + "addon" + payload["name"]).hexdigest()
+  id = sha1hexdigest(release + architecture + "addon" + payload["name"])
   config_list = []
   with open(logFile) as f:
     for index, l in enumerate(f):
@@ -108,7 +113,7 @@ def process_hlt_log(logFile):
   payload["architecture"]=architecture
   payload["@timestamp"]=timestp
   payload["name"] = pathInfo[-1][:-4]
-  id = sha1(release + architecture + "hlt" + payload["name"]).hexdigest()
+  id = sha1hexdigest(release + architecture + "hlt" + payload["name"])
   with open(logFile) as f:
     for index, l in enumerate(f):
       l = l.strip()
@@ -147,11 +152,11 @@ def process_ib_utests(logFile):
         while '--------' not in line:
           line = next(it)
         while True:
-          line=it.next().strip()
+          line=next(it).strip()
           if ":" in line:
             pkg = line.split(':')[0].strip()
             payload["url"] = 'https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/'+ architecture +'/'+ release +'/unitTestLogs/' + pkg
-            line = it.next().strip()
+            line = next(it).strip()
             while ':' not in line:
               if "had ERRORS" in line:
                 payload["status"] = 1
@@ -160,10 +165,10 @@ def process_ib_utests(logFile):
               utest= line.split(' ')[0]
               payload["package"] = pkg
               payload["name"] = utest
-              id = sha1(release + architecture + utest).hexdigest()
+              id = sha1hexdigest(release + architecture + utest)
               print("==> ", json.dumps(payload) + '\n')
               send_payload(index,document,id,json.dumps(payload))
-              line = it.next().strip()
+              line = next(it).strip()
       except Exception as e:
         print("ERROR: File processed: %s" % e)
   else:

--- a/fix-backport-labels.py
+++ b/fix-backport-labels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import re
 from github import Github
@@ -32,13 +32,13 @@ for issue in issues:
   if not issue.pull_request: continue
   api_rate_limits(gh)
   backport_pr=None
-  issue_body = issue.body.encode("ascii", "ignore") if issue.body else ""
+  issue_body = issue.body.encode("ascii", "ignore").decode() if issue.body else ""
   if (issue.user.login == CMSBUILD_GH_USER) and re.match(ISSUE_SEEN_MSG,issue_body.split("\n",1)[0].strip()):
      backport_pr=get_backported_pr(issue_body)
   else:
     for comment in issue.get_comments():
       commenter = comment.user.login
-      comment_msg = comment.body.encode("ascii", "ignore")
+      comment_msg = comment.body.encode("ascii", "ignore").decode()
       # The first line is an invariant.
       comment_lines = [ l.strip() for l in comment_msg.split("\n") if l.strip() ]
       first_line = comment_lines[0:1]

--- a/gh-teams.py
+++ b/gh-teams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from copy import deepcopy
 from github import Github
@@ -114,7 +114,7 @@ for org_name in CMS_ORGANIZATIONS:
         api_rate_limits(gh,msg=False)
   pending_members = []
   for user in get_pending_members(org_name):
-    user = user['login'].encode("ascii", "ignore")
+    user = user['login'].encode("ascii", "ignore").decode()
     pending_members.append(user)
   print("Pending Invitations: %s" % ",".join(["@%s" % u for u in pending_members]))
   api_rate_limits(gh)
@@ -123,7 +123,7 @@ for org_name in CMS_ORGANIZATIONS:
   print("  Looking for owners:",REPO_OWNERS[org_name])
   chg_flag=0
   for mem in org.get_members(role="admin"):
-    login = mem.login.encode("ascii", "ignore")
+    login = mem.login.encode("ascii", "ignore").decode()
     if not login in cache["users"]: cache["users"][login] = mem
     if not login in REPO_OWNERS[org_name]:
       print("    =>Removing owner:",login)
@@ -158,7 +158,7 @@ for org_name in CMS_ORGANIZATIONS:
       create_team(org_name, team, "cmssw team for "+team)
       chg_flag+=1
   total_changes+=chg_flag
-  org_members = [ mem.login.encode("ascii", "ignore") for mem in org.get_members() ]
+  org_members = [ mem.login.encode("ascii", "ignore").decode() for mem in org.get_members() ]
   print("  All members: ",org_members)
   if chg_flag: teams = org.get_teams()
   for team in teams:
@@ -174,7 +174,7 @@ for org_name in CMS_ORGANIZATIONS:
       continue
     members = team_info["members"]
     tm_members = [ mem for mem in team.get_members()]
-    tm_members_login = [ mem.login.encode("ascii", "ignore") for mem in tm_members ]
+    tm_members_login = [ mem.login.encode("ascii", "ignore").decode() for mem in tm_members ]
     print("      Valid Members:",members)
     print("      Existing Members:",tm_members_login)
     ok_mems = ["*"]
@@ -182,7 +182,7 @@ for org_name in CMS_ORGANIZATIONS:
     if not "*" in members:
       for mem in tm_members:
         api_rate_limits(gh,msg=False)
-        login = mem.login.encode("ascii", "ignore")
+        login = mem.login.encode("ascii", "ignore").decode()
         if not login in cache["users"]: cache["users"][login] = mem
         if (login in members):
           ok_mems.append(login)
@@ -220,20 +220,20 @@ for org_name in CMS_ORGANIZATIONS:
       ref.close()
       continue
     team_repos      = [ repo for repo in team.get_repos() ]
-    team_repos_name = [ repo.name.encode("ascii", "ignore") for repo in team_repos ]
+    team_repos_name = [ repo.name.encode("ascii", "ignore").decode() for repo in team_repos ]
     print("      Checking team repositories")
     print("        Valid Repos:",list(team_info["repositories"].keys()))
     print("        Existing Repos:",team_repos_name)
     repo_to_check = team_repos_name[:]
     for repo in team_info["repositories"]:
-      if repo=="*":              repo_to_check += [ r.name.encode("ascii", "ignore") for r in org_repos ]
+      if repo=="*":              repo_to_check += [ r.name.encode("ascii", "ignore").decode() for r in org_repos ]
       elif repo.startswith("!"): repo_to_check += [repo[1:]]
       else:                      repo_to_check += [repo]
     chg_flag=0
     for repo_name in set(repo_to_check):
       api_rate_limits(gh, msg=False)
       inv_repo = "!"+repo_name
-      repo = [ r for r in team_repos if r.name.encode("ascii", "ignore") == repo_name ]
+      repo = [ r for r in team_repos if r.name.encode("ascii", "ignore").decode() == repo_name ]
       if (repo_name in team_info["repositories"]) or \
          ("*" in team_info["repositories"] and (not inv_repo in team_info["repositories"])):
          prem = "pull"

--- a/jenkins-jobs/git/git-mirror-repository
+++ b/jenkins-jobs/git/git-mirror-repository
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 from os.path import abspath, dirname
 from sys import argv, exit, path
@@ -21,4 +21,3 @@ request = Request(url, headers=headers)
 request.get_method = lambda: "POST"
 response = urlopen(request)
 print(response.read())
-

--- a/jenkins/jenkins-kill-placeholder-job.py
+++ b/jenkins/jenkins-kill-placeholder-job.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This job will check if there are queued jobs for jenkins slaves with 'condor' label and how many.
 Then it will kill needed amount of placeholder jobs.
@@ -101,7 +101,7 @@ def main():
         found = False
         m = RX_Queue_why.match(j['why'])
         if m:
-          label = m.group(1).encode('utf-8')
+          label = m.group(1)
           print("Waiting for",label)
           for node in get_nodes(label):
             if re.match('^grid[1-9][0-9]*$', node['nodeName']):

--- a/jenkins_callback.py
+++ b/jenkins_callback.py
@@ -26,7 +26,7 @@ def build_jobs(jenkins_url, jobs_data, headers = {}, user="cmssdt"):
              "Submit": "Build"
            }
     try:
-      data = urlencode(data)
+      data = urlencode(data).encode()
       req = Request(url=url,data=data,headers=headers)
       content = urlopen(req).read()
       print ("ALL_OK")

--- a/process_pr.py
+++ b/process_pr.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from categories import CMSSW_L2, CMSSW_L1, TRIGGER_PR_TESTS, CMSSW_ISSUES_TRACKERS, PR_HOLD_MANAGERS, EXTERNAL_REPOS,CMSDIST_REPOS
 from categories import CMSSW_CATEGORIES
 from releases import RELEASE_BRANCH_MILESTONE, RELEASE_BRANCH_PRODUCTION, CMSSW_DEVEL_BRANCH
@@ -156,7 +155,8 @@ def read_repo_file(repo_config, repo_file, default=None):
   file_path = join(repo_config.CONFIG_DIR, repo_file)
   contents = default
   if exists(file_path):
-    contents = (yaml.load(file(file_path),Loader=Loader))
+    with open(file_path, "r") as f:
+      contents = (yaml.load(f,Loader=Loader))
     if not contents: contents = default
   return contents
 

--- a/trigger_jenkins_job.py
+++ b/trigger_jenkins_job.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from __future__ import print_function
+#!/usr/bin/env python3
 from optparse import OptionParser
 from jenkins_callback import build_jobs
 import json

--- a/update-github-hooks-ip
+++ b/update-github-hooks-ip
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from _py2with3compatibility import urlopen
 from json import loads
 from os import system
@@ -6,7 +6,7 @@ from sys import exit
 ip_file="/data/sdt/github-hook-meta.txt"
 cnt = 0
 with open("%s.tmp" % ip_file, "w") as ref:
-  for m in [i.encode() for i in loads(urlopen("https://api.github.com/meta").readlines()[0])['hooks']]:
+  for m in [i.encode().decode() for i in loads(urlopen("https://api.github.com/meta").readlines()[0])['hooks']]:
     ref.write("%s\n" % m)
     cnt+=1
 if cnt:


### PR DESCRIPTION
`process_pr` fix is just to remove error (one should always use `open` to open a file). There are more changes required to make `process_pr` fully py3-compatible: I see many calls to `.encode("ascii", "ignore")` and comparision of result with string. This will no longer work, since `encode` returns `bytes` object, which can't be compared to `str` (directly or with a regex). Do you remember why these calls were added? 