### PR TITLE
add `rovere` as watcher of the HLT Phase-2 menu

### DIFF
--- a/watchers.yaml
+++ b/watchers.yaml
@@ -932,6 +932,7 @@ rovere:
 - SimG4CMS
 - SimG4Core
 - SimCalorimetry
+- HLTrigger/Configuration/python/HLT_75e33
 rylanC24:
 - Validation/RecoHI
 schoef:
@@ -1799,8 +1800,6 @@ a-kapoor:
   - EgammaAnalysis
   - DataFormats/EgammaCandidates
   - DataFormats/EgammaReco
-beaucero:
-- HLTrigger/Configuration/python/HLT_75e33
 SohamBhattacharya:
 - HLTrigger/Configuration/python/HLT_75e33
 AnnikaStein:


### PR DESCRIPTION
Marco Rovere (@rovere) takes up the baton from Stephanie Beauceron (@beaucero) as co-convener of the "HLT Upgrade" subgroup of TSG for the term 01/09/2023-31/08/2025 (approved at the Collaboration Board meeting on 2023, [slide 57](https://indico.cern.ch/event/1280997/contributions/5381463/attachments/2667851/4623604/CB144%20June%202023.pdf#page=57)).

The maintaince of the HLT Phase-2 menu in CMSSW is under the responsibility of the HLT Upgrade group, and the conveners are kindly asked to "watch" the corresponding configuration files (see also https://github.com/cms-sw/cms-bot/pull/1923).
