### PR TITLE
github_utils: fix create_team

### DIFF
--- a/github_utils.py
+++ b/github_utils.py
@@ -332,7 +332,7 @@ def get_commit_info(repo, commit):
 
 
 def create_team(org, team, description):
-    params = {"name": team, "description": description, "permission": "admin", "privacy": "closed"}
+    params = {"name": team, "description": description, "privacy": "closed"}
     return github_api("/orgs/%s/teams" % org, params=params, method="POST")
 
 


### PR DESCRIPTION
remove the deprecated `permission` parameters ( https://docs.github.com/en/rest/teams/teams?apiVersion=2022-11-28#create-a-team ) 
FYI @iarspider 