### PR TITLE
Add ZDC L1T emulator to build bot categories as L1's assignment

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1003,6 +1003,7 @@ CMSSW_CATEGORIES = {
     "L1Trigger/L1TMuonOverlapPhase1",
     "L1Trigger/L1TNtuples",
     "L1Trigger/L1TTwinMux",
+    "L1Trigger/L1TZDC",
     "L1Trigger/ME0Trigger",
     "L1Trigger/Phase2L1GMT",
     "L1Trigger/Phase2L1GT",


### PR DESCRIPTION
This PR adds the upcoming ZDC L1 emulator into the categories map as an L1 assignment (no other assignments yet). The ZDC emulator PR can be found here: https://github.com/cms-sw/cmssw/pull/42634