### PR TITLE
add `mmusich` as HLT L2

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -131,7 +131,7 @@ CMSSW_L2 = {
   "kandrosov":        ["tau-pog"],
   "alebihan":         ["tau-pog"],
   "slava77":          ["tracking-pog"],
-  "mmusich":          ["tracking-pog"],
+  "mmusich":          ["tracking-pog", "hlt"],
   "kskovpen":         ["tracking-pog"],
   # PPD
   "malbouis":         ["ppd"],

--- a/gh-teams.py
+++ b/gh-teams.py
@@ -58,7 +58,7 @@ REPO_TEAMS["cms-sw"]["Dqm-Integration-developers"] = {
   "repositories" : { "DQM-Integration": "push"}
 }
 REPO_TEAMS["cms-sw"]["configdb-owners"] = {
-  "members" : ["fwyzard", "Martin-Grunewald", "Sam-Harper", "silviodonato", "missirol"],
+  "members" : ["fwyzard", "Martin-Grunewald", "Sam-Harper", "silviodonato", "missirol", "mmusich"],
   "repositories" : { "hlt-confdb":"admin", "web-confdb":"admin"}
 }
 REPO_TEAMS["cms-sw"]["cmsdist-writers"] = {


### PR DESCRIPTION
Marco Musich (@mmusich) takes on the duty of HLT-software L2 for the term 01/09/2023-31/08/2025 (approved at the Collaboration Board meeting on 16/06/2023, [slide 53](https://indico.cern.ch/event/1280997/contributions/5381463/attachments/2667851/4623604/CB144%20June%202023.pdf#page=53)). @martin-grunewald continues in this role for the same term ([slide 52](https://indico.cern.ch/event/1280997/contributions/5381463/attachments/2667851/4623604/CB144%20June%202023.pdf#page=52)).

(As agreed internally, I will remove myself from @cms-sw/hlt-l2 after a period of overlap.)
