### PR TITLE
Remove dpiparo from the CMSSW L1/ORP list

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -10,7 +10,7 @@ authors = {}
 #Any Githib user whose comments/requests should be ignored
 GITHUB_BLACKLIST_AUTHORS = []
 #CMS Offline Release Planning managers
-CMSSW_L1 = ["dpiparo", "rappoccio", "antoniovilela"]
+CMSSW_L1 = ["rappoccio", "antoniovilela"]
 #CMS-SDT members who has admin rights to various github organizations and repositories.
 #They are also reposionsible to sign for externals
 CMS_SDT    = [ "iarspider", "smuzaffar", "aandvalenzuela" ]


### PR DESCRIPTION
This PR removes @dpiparo from CMSSW ORP list.

Thanks a lot for all the work and support @dpiparo 