### PR TITLE
Added PhysicsTools/NanoAODTools under xpog and update watchers

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1736,6 +1736,7 @@ CMSSW_CATEGORIES = {
     "DPGAnalysis/HcalNanoAOD",
     "DPGAnalysis/MuonTools",
     "PhysicsTools/NanoAOD",
+    "PhysicsTools/NanoAODTools",
     "PhysicsTools/PatAlgos",
     "PhysicsTools/PatUtils",
     "PhysicsTools/Scouting",

--- a/watchers.yaml
+++ b/watchers.yaml
@@ -1146,6 +1146,7 @@ rchatter:
 clelange:
 - JetMETCorrections
 - RecoJets
+- PhysicsTools/NanoAODTools
 gkasieczka:
 - CondFormats/JetMETObjects
 - DQMOffline/JetMET
@@ -1819,3 +1820,5 @@ jlidrych:
 - RecoLocalTracker/Records
 - RecoLocalTracker/SiStrip
 - RecoLocalTracker/SubCollectionProducers
+lenzip:
+- PhysicsTools/NanoAODTools


### PR DESCRIPTION
FYI @clelange @lenzip @vlimant 
- Added PhysicsTools/NanoAODTools under @cms-sw/xpog-l2 
- Added @clelange @lenzip as watcher for PhysicsTools/NanoAODTools

See https://github.com/cms-sw/cms-bot/issues/2043 and https://github.com/cms-sw/cmssw/pull/42323

Fixes https://github.com/cms-sw/cms-bot/issues/2043