### PR TITLE
Add Yuan and Simone as alca+db watchers

### DIFF
--- a/category-watchers.yaml
+++ b/category-watchers.yaml
@@ -9,3 +9,10 @@ silviodonato:
 - hlt
 PonIlya:
 - db
+yuanchao:
+- alca
+- db
+srossiti:
+- alca
+- db
+


### PR DESCRIPTION
Yuan Chao (@yuanchao) and Simone Rossi Tisbeni(@srossiti) are the AlCa/DB software contacts.
Add them as watchers to the alca and db related PRs and gitub issues.