### PR TITLE
Add Martina Malberti as new MTD DPG L2 convener

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -108,6 +108,7 @@ CMSSW_L2 = {
   "pfs":              ["hgcal-dpg"],
   "felicepantaleo":   ["hgcal-dpg"],
   "fabiocos":         ["mtd-dpg", "operations"],
+  "MartinaMalberti":  ["mtd-dpg"],
   "parbol":           ["mtd-dpg"],
   # pogs
   "bellan":           ["pf"],


### PR DESCRIPTION
Update of the ```categories.py``` file, adding @MartinaMalberti as new MTD DPG L2 conveners. @parbol , former DPG convener, is kept as software support for the MTD DPG.