### PR TITLE
remove `missirol` from HLT `cmssw`-L2s and `hlt-confdb` owners

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -80,7 +80,6 @@ CMSSW_L2 = {
     "makortel": ["heterogeneous", "core", "visualization", "geometry"],
     "mandrenguyen": ["reconstruction"],
     "mdhildreth": ["simulation", "geometry", "fastsim"],
-    "missirol": ["hlt"],
     "mkirsano": ["generators"],
     "menglu21": ["generators"],
     "rappoccio": ["operations"],

--- a/gh-teams.py
+++ b/gh-teams.py
@@ -63,7 +63,6 @@ REPO_TEAMS["cms-sw"]["configdb-owners"] = {
         "Martin-Grunewald",
         "Sam-Harper",
         "silviodonato",
-        "missirol",
         "mmusich",
     ],
     "repositories": {"hlt-confdb": "admin", "web-confdb": "admin"},


### PR DESCRIPTION
My term as HLT "L2" ended in September (see also https://github.com/cms-sw/cms-bot/pull/2051). After a transition period of a few weeks, I can now be removed from the corresponding lists.

FYI: @cms-sw/hlt-l2 