### PR TITLE
Push GitHub API Rate Limits to ES

### DIFF
--- a/github-rate-limits.py
+++ b/github-rate-limits.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import json, os
 from datetime import datetime

--- a/github-rate-limits.py
+++ b/github-rate-limits.py
@@ -18,31 +18,18 @@ if __name__ == "__main__":
     print("Max calls: ", limit)
     reset_time = datetime.fromtimestamp(gh.rate_limiting_resettime)
     print("Reset time (GMT): ", reset_time)
-
-    JENKINS_PREFIX = "jenkins"
-    try:
-        JENKINS_PREFIX = os.environ["JENKINS_URL"].strip("/").split("/")[-1]
-    except:
-        JENKINS_PREFIX = "jenkins"
+    gh_user = gh.get_user("cms-sw")
 
     current_time = datetime.utcnow() - datetime(1970, 1, 1)
     current_time = round(current_time.total_seconds() * 1000)
 
     gh_api_index = "cmssdt-github-api-" + str(int(((current_time / 86400000) + 4) / 7))
     gh_api_document = "github-api-data"
-    unique_id = (
-        JENKINS_PREFIX
-        + "/"
-        + str(reset_time).split(" ")[0].replace("-", "")
-        + "/"
-        + str(reset_time).split(" ")[1].replace(":", "")
-        + "/"
-        + str(remaining)
-    )
+    unique_id = str(gh_user) + str(current_time)
     unique_id = sha1(unique_id.encode()).hexdigest()
 
     payload = dict()
-    payload["jenkins_server"] = JENKINS_PREFIX
+    payload["jenkins_server"] = gh_user
     payload["api_limit"] = limit
     payload["api_remaining"] = remaining
     payload["reset_time"] = str(reset_time)

--- a/github-rate-limits.py
+++ b/github-rate-limits.py
@@ -18,18 +18,18 @@ if __name__ == "__main__":
     print("Max calls: ", limit)
     reset_time = datetime.fromtimestamp(gh.rate_limiting_resettime)
     print("Reset time (GMT): ", reset_time)
-    gh_user = gh.get_user("cms-sw")
+    user = os.getlogin()
 
     current_time = datetime.utcnow() - datetime(1970, 1, 1)
     current_time = round(current_time.total_seconds() * 1000)
 
     gh_api_index = "cmssdt-github-api-" + str(int(((current_time / 86400000) + 4) / 7))
     gh_api_document = "github-api-data"
-    unique_id = str(gh_user) + str(current_time)
+    unique_id = user + str(current_time)
     unique_id = sha1(unique_id.encode()).hexdigest()
 
     payload = dict()
-    payload["gh_user"] = str(gh_user)
+    payload["user"] = user
     payload["api_limit"] = limit
     payload["api_remaining"] = remaining
     payload["reset_time"] = str(reset_time)

--- a/github-rate-limits.py
+++ b/github-rate-limits.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     unique_id = sha1(unique_id.encode()).hexdigest()
 
     payload = dict()
-    payload["jenkins_server"] = str(gh_user)
+    payload["gh_user"] = str(gh_user)
     payload["api_limit"] = limit
     payload["api_remaining"] = remaining
     payload["reset_time"] = str(reset_time)

--- a/github-rate-limits.py
+++ b/github-rate-limits.py
@@ -1,14 +1,53 @@
 #!/usr/bin/env python
 from __future__ import print_function
-from github import Github
-from os.path import expanduser
+import json, os
 from datetime import datetime
+from hashlib import sha1
+from os.path import expanduser
 from socket import setdefaulttimeout
+from github import Github
+from es_utils import send_payload
 
 setdefaulttimeout(120)
 
 if __name__ == "__main__":
     gh = Github(login_or_token=open(expanduser("~/.github-token")).read().strip())
-    print("API Rate Limit")
-    print("Limit, Remaining: ", gh.rate_limiting)
-    print("Reset time (GMT): ", datetime.fromtimestamp(gh.rate_limiting_resettime))
+    print("Checking GitHub API Rate Limit")
+    remaining, limit = gh.rate_limiting
+    print("Remaining calls: ", remaining)
+    print("Max calls: ", limit)
+    reset_time = datetime.fromtimestamp(gh.rate_limiting_resettime)
+    print("Reset time (GMT): ", reset_time)
+
+    JENKINS_PREFIX = "jenkins"
+    try:
+        JENKINS_PREFIX = os.environ["JENKINS_URL"].strip("/").split("/")[-1]
+    except:
+        JENKINS_PREFIX = "jenkins"
+
+    current_time = datetime.utcnow() - datetime(1970, 1, 1)
+    current_time = round(current_time.total_seconds() * 1000)
+
+    gh_api_index = "cmssdt-github-api-" + str(int(((current_time / 86400000) + 4) / 7))
+    gh_api_document = "github-api-data"
+    unique_id = (
+        JENKINS_PREFIX
+        + "/"
+        + str(reset_time).split(" ")[0].replace("-", "")
+        + "/"
+        + str(reset_time).split(" ")[1].replace(":", "")
+        + "/"
+        + str(remaining)
+    )
+    unique_id = sha1(unique_id.encode()).hexdigest()
+
+    payload = dict()
+    payload["jenkins_server"] = JENKINS_PREFIX
+    payload["api_limit"] = limit
+    payload["api_remaining"] = remaining
+    payload["reset_time"] = str(reset_time)
+    payload["@timestamp"] = current_time
+
+    print(payload)
+
+    send_payload(gh_api_index, gh_api_document, unique_id, json.dumps(payload))

--- a/github-rate-limits.py
+++ b/github-rate-limits.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     unique_id = sha1(unique_id.encode()).hexdigest()
 
     payload = dict()
-    payload["jenkins_server"] = gh_user
+    payload["jenkins_server"] = str(gh_user)
     payload["api_limit"] = limit
     payload["api_remaining"] = remaining
     payload["reset_time"] = str(reset_time)


### PR DESCRIPTION
API remaining calls, limit, and reset time are pushed to the new index `cmssdt-github-api-*` on OpenSearch
Running on Jenkins under https://cmssdt.cern.ch/jenkins/view/All/job/github-monitor-api
