### PR TITLE
Updated TauPOG L2 conveners for the tau-pog tag in categories.py

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -149,8 +149,8 @@ CMSSW_L2 = {
     "mondalspandan": ["btv-pog"],
     "michael-pitt": ["proton-pog"],
     "kshcheli": ["proton-pog"],
-    "kandrosov": ["tau-pog"],
-    "alebihan": ["tau-pog"],
+    "cardinia": ["tau-pog"],
+    "danielwinterbottom": ["tau-pog"],
     "slava77": ["tracking-pog"],
     "kskovpen": ["tracking-pog"],
     # PPD


### PR DESCRIPTION
Swapped the TauPOG L2 conveners as they have not been updated since 2021.