### PR TITLE
look for relval logs with fatal system errors

### DIFF
--- a/report-pull-request-results.py
+++ b/report-pull-request-results.py
@@ -127,6 +127,9 @@ def get_wf_error_msg(out_file, filename=True):
             elif "----- Begin Fatal Exception" in line:
                 error_lines += "\n" + line
                 reading = True
+            elif 'A fatal system signal has occurred:' in line:
+                error_lines += "\n" + line
+                break
     if not error_lines and filename:
         error_lines = "/".join(out_file.split("/")[-2:]) + "\n"
     return error_lines

--- a/report-pull-request-results.py
+++ b/report-pull-request-results.py
@@ -127,7 +127,7 @@ def get_wf_error_msg(out_file, filename=True):
             elif "----- Begin Fatal Exception" in line:
                 error_lines += "\n" + line
                 reading = True
-            elif 'A fatal system signal has occurred:' in line:
+            elif "A fatal system signal has occurred:" in line:
                 error_lines += "\n" + line
                 break
     if not error_lines and filename:


### PR DESCRIPTION
Some time relvals failed with `A fatal system signal has occurred: external termination request`  after timeout. this change should look for those Relvals and properly report those in the PR result summary comment