### PR TITLE
Prefer python3 over python2 for running relval monitoring

### DIFF
--- a/RelValArgs.py
+++ b/RelValArgs.py
@@ -8,16 +8,16 @@ from _py2with3compatibility import run_cmd
 monitor_script = ""
 if "CMS_DISABLE_MONITORING" not in environ:
     monitor_script = dirname(abspath(__file__)) + "/monitor_workflow.py"
-    e, o = run_cmd("python2 -c 'import psutil'")
+    e, o = run_cmd("python3 -c 'import psutil'")
     if e:
-        e, o = run_cmd("python3 -c 'import psutil'")
+        e, o = run_cmd("python2 -c 'import psutil'")
         if e:
             print("Monitering of relval steps disabled: import psutils failed")
             monitor_script = ""
         else:
-            monitor_script = "python3 " + monitor_script
+            monitor_script = "python2 " + monitor_script
     else:
-        monitor_script = "python2 " + monitor_script
+        monitor_script = "python3 " + monitor_script
 
 RELVAL_KEYS = {
     "customiseWithTimeMemorySummary": [],


### PR DESCRIPTION
This should hopefully fix errors like
```
Starting python2 /data/cmsbld/jenkins/workspace/ib-run-relvals/cms-bot/monitor_workflow.py timeout --signal SIGTERM 9000  cmsRun -j JobReport2.xml  step2_L1REPACK_HLT.py
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site.py", line 62, in <module>
    import os
  File "/usr/lib64/python2.7/os.py", line 49, in <module>
    import posixpath as path
  File "/usr/lib64/python2.7/posixpath.py", line 17, in <module>
    import warnings
  File "/usr/lib64/python2.7/warnings.py", line 8, in <module>
    import types
ImportError: No module named types
```