### PR TITLE
Added support for cmsTritonPostBuild checks for data externals

### DIFF
--- a/create-new-data-pr.py
+++ b/create-new-data-pr.py
@@ -213,7 +213,7 @@ if __name__ == "__main__":
             content_file = None
         else:
             raise e
-    #Do not add cmsTriton checks if data/cmsTritonPostBuild.file not exists
+    # Do not add cmsTriton checks if data/cmsTritonPostBuild.file not exists
     if add_cms_triton_check:
         cms_triton_postbuild = "data/cmsTritonPostBuild"
         try:

--- a/create-new-data-pr.py
+++ b/create-new-data-pr.py
@@ -205,17 +205,9 @@ if __name__ == "__main__":
         )
 
     # PostBuild for CMS Triton Checks
-    datafile = "data/data-%s.file" % data_pkg
-    try:
-        content_file = dist_repo.get_contents(datafile, repo_tag_pr_branch)
-    except GithubException as e:
-        if e.status == 404:
-            content_file = None
-        else:
-            raise e
     # Do not add cmsTriton checks if data/cmsTritonPostBuild.file not exists
+    cms_triton_postbuild = "data/cmsTritonPostBuild"
     if add_cms_triton_check:
-        cms_triton_postbuild = "data/cmsTritonPostBuild"
         try:
             dist_repo.get_contents(cms_triton_postbuild + ".file", repo_tag_pr_branch)
         except GithubException as e:
@@ -225,6 +217,14 @@ if __name__ == "__main__":
                 raise e
     # Create/Update data/data-Repo-Name.file if add_cms_triton_check
     if add_cms_triton_check:
+        datafile = "data/data-%s.file" % data_pkg
+        try:
+            content_file = dist_repo.get_contents(datafile, repo_tag_pr_branch)
+        except GithubException as e:
+            if e.status == 404:
+                content_file = None
+            else:
+                raise e
         new_contents = "## INCLUDE %s" % cms_triton_postbuild
         if content_file is None:
             dist_repo.create_file(

--- a/github_utils.py
+++ b/github_utils.py
@@ -744,9 +744,7 @@ def get_pr_latest_commit(pr, repository):
 
 def get_issue_emojis(issue_id, repository):
     get_gh_token(repository)
-    return github_api(
-        "/repos/%s/issues/%s/reactions" % (repository, issue_id), method="GET"
-    )
+    return github_api("/repos/%s/issues/%s/reactions" % (repository, issue_id), method="GET")
 
 
 def delete_issue_emoji(emoji_id, issue_id, repository):
@@ -774,9 +772,8 @@ def set_issue_emoji(issue_id, repository, emoji="+1", reset_other=True):
         return cur_emoji
     get_gh_token(repository)
     params = {"content": emoji}
-    return github_api(
-        "/repos/%s/issues/%s/reactions" % (repository, issue_id), params=params
-    )
+    return github_api("/repos/%s/issues/%s/reactions" % (repository, issue_id), params=params)
+
 
 def set_comment_emoji(comment_id, repository, emoji="+1", reset_other=True):
     cur_emoji = None

--- a/jobs/create-relval-jobs.py
+++ b/jobs/create-relval-jobs.py
@@ -77,10 +77,10 @@ for t in thrds:
 # Get Workflow stats from ES
 print("Getting Workflow stats from ES.....")
 stats = {}
-if '_X_' in cmssw_ver:
+if "_X_" in cmssw_ver:
     release_cycle = str.lower(cmssw_ver.split("_X_")[0] + "_X")
 else:
-    release_cycle = str.lower('_'.join(cmssw_ver.split("_")[:3]) + "_X")
+    release_cycle = str.lower("_".join(cmssw_ver.split("_")[:3]) + "_X")
 days_history = 10
 # if ('_ppc64le_' in arch) or ('_aarch64_' in arch) or ('cc8_' in arch) or ('gcc10' in arch):
 #  days_history=3

--- a/pr_testing/get_source_flag_for_cmsbuild.sh
+++ b/pr_testing/get_source_flag_for_cmsbuild.sh
@@ -64,8 +64,11 @@ if [ -e cmsdist/data/cmsswdata.txt ] ; then
       if [ $(grep "Requires:  *data-${PKG_NAME} *$"  cmsdist/cmsswdata.spec | wc -l) -eq 0 ] ; then
         sed -i -e "s|^\(Source: .*\)$|\1\nRequires: data-${PKG_NAME}|" cmsdist/cmsswdata.spec
       fi
-      touch cmsdist/data/data-${PKG_NAME}.file
-      rm -rf cmsdist/data/data-${PKG_NAME}.* 
+      if [ -f cmsdist/data/cmsTritonPostBuild.file -a -e ${PKG_NAME} ] ; then
+        if [ $(find ${PKG_NAME} -name config.pbtxt -type f | wc -l) -gt 0 ] ; then
+          echo "## INCLUDE data/cmsTritonPostBuild" >> cmsdist/data/data-${PKG_NAME}.file
+        fi
+      fi
     ;;
   esac
 fi


### PR DESCRIPTION
This allows bot to create `cmsdist/data/data-Repo-Name.file` with contents like [a] for CMS data externals which contain config.pbtxt file(s). Bot will only add/create this if cmsdist branch already contains `data/cmsTritonPostBuild.file`. 

FYI @kpedro88 

[a]
```
## INCLUDE data/cmsTritonPostBuild
```