### PR TITLE
Remove temporary symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ To have it working you'll need a `~/.github-token` which can access the
 
 # Release integration
 
-- [process-pull-request](https://github.com/cms-sw/cms-bot/blob/master/process-pull-request):
+- [process-pull-request.py](https://github.com/cms-sw/cms-bot/blob/master/process-pull-request.py):
 this is the script which updates the status of a CMSSW PR. It parses all the
 messages associated to the specified PR and if it spots a transition (e.g. a L2
 signature) it posts a message acknowledging what happended, updates the tags
 etc. The state of the PR is fully obtained by parsing all the comments, so that
 we do not have to maintain our own state tracking DB.
 - [watchers.yaml](https://github.com/cms-sw/cms-bot/blob/master/watchers.yaml):
-contains all the information required by `process-pull-requests` to notify
+contains all the information required by `process-pull-requests.py` to notify
 developers when a PR touches the packages they watch.
 
 # Release building
 
-- [process-build-release-request](https://github.com/cms-sw/cms-bot/blob/master/process-build-release-request)
+- [process-build-release-request.py](https://github.com/cms-sw/cms-bot/blob/master/process-build-release-request.py)
 - [release-build](): script used to build a release which has been requested
 through a Github issue.
 - [upload-release](): script used to upload a release to the repository. When
@@ -39,7 +39,7 @@ Elasticsearch for "live" data from which we dump precomputed views on a
 basis.
 
 - [es-templates](https://github.com/cms-sw/cms-bot/tree/master/es-templates): contains the templates for the logged dataes-templates.
-- [es-cleanup-indexes](https://github.com/cms-sw/cms-bot/blob/master/es-cleanup-indexes): cleanups old indexes in elasticsearch.
+- [es-cleanup-indexes.py](https://github.com/cms-sw/cms-bot/blob/master/es-cleanup-indexes.py): cleanups old indexes in elasticsearch.
 
 # Code style
 

--- a/cms-jenkins-api
+++ b/cms-jenkins-api
@@ -1,1 +1,0 @@
-cms-jenkins-api.py

--- a/comment-gh-pr
+++ b/comment-gh-pr
@@ -1,1 +1,0 @@
-comment-gh-pr.py

--- a/compareTriggerResults
+++ b/compareTriggerResults
@@ -1,1 +1,0 @@
-compareTriggerResults.py

--- a/compareTriggerResultsSummary
+++ b/compareTriggerResultsSummary
@@ -1,1 +1,0 @@
-compareTriggerResultsSummary.py

--- a/create-github-hooks
+++ b/create-github-hooks
@@ -1,1 +1,0 @@
-create-github-hooks.py

--- a/deprecate-releases
+++ b/deprecate-releases
@@ -1,1 +1,0 @@
-deprecate-releases.py

--- a/es-cleanup-indexes
+++ b/es-cleanup-indexes
@@ -1,1 +1,0 @@
-es-cleanup-indexes.py

--- a/es-reindex
+++ b/es-reindex
@@ -1,1 +1,0 @@
-es-reindex.py

--- a/forward-pull-requests
+++ b/forward-pull-requests
@@ -1,1 +1,0 @@
-forward-pull-requests.py

--- a/generate-categories-json
+++ b/generate-categories-json
@@ -1,1 +1,0 @@
-generate-categories-json.py

--- a/generate-json-performance-charts
+++ b/generate-json-performance-charts
@@ -1,1 +1,0 @@
-generate-json-performance-charts.py

--- a/generate-performance-summary
+++ b/generate-performance-summary
@@ -1,1 +1,0 @@
-generate-performance-summary.py

--- a/get-git-tags
+++ b/get-git-tags
@@ -1,1 +1,0 @@
-get-git-tags.py

--- a/get-pr-branch
+++ b/get-pr-branch
@@ -1,1 +1,0 @@
-get-pr-branch.py

--- a/github-rate-limits
+++ b/github-rate-limits
@@ -1,1 +1,0 @@
-github-rate-limits.py

--- a/jenkins-jobs/git/git-mirror-repository
+++ b/jenkins-jobs/git/git-mirror-repository
@@ -1,1 +1,0 @@
-git-mirror-repository.py

--- a/jenkins-jobs/git/git-notify-ib-updates
+++ b/jenkins-jobs/git/git-notify-ib-updates
@@ -1,1 +1,0 @@
-git-notify-ib-updates.py

--- a/merge-pull-request
+++ b/merge-pull-request
@@ -1,1 +1,0 @@
-merge-pull-request.py

--- a/new-release-cycle
+++ b/new-release-cycle
@@ -1,1 +1,0 @@
-new-release-cycle.py

--- a/pr-checks/check-pr-files
+++ b/pr-checks/check-pr-files
@@ -1,1 +1,0 @@
-check-pr-files.py

--- a/pr-checks/check-pr-files.py
+++ b/pr-checks/check-pr-files.py
@@ -24,7 +24,7 @@ def check_commits_files(repo, pr, detail=False):
     invalid_status = [("A", "D"), ("C", "D"), ("R", "D"), ("X", "X"), ("U", "U")]
 
     all_ok = False
-    e, o = run_cmd("%s/process-pull-request -a -c -r %s %s" % (CMS_BOT_DIR, repo, pr))
+    e, o = run_cmd("%s/process-pull-request.py -a -c -r %s %s" % (CMS_BOT_DIR, repo, pr))
     if e:
         print(o)
         return all_ok

--- a/pr-schedule-tests
+++ b/pr-schedule-tests
@@ -8,7 +8,7 @@ cd $WORKSPACE
 # The pull request number is $1
 PULL_REQUESTS=$(echo $1 | sed 's/^ *//;s/ *$//')
 PULL_REQUEST="$(echo ${PULL_REQUESTS} | sed 's| .*||')"
-COMMIT=$(${CMS_BOT_DIR}/process-pull-request -c -r $(echo ${PULL_REQUEST} | sed 's/#.*//') $(echo ${PULL_REQUEST} | sed 's/.*#//'))
+COMMIT=$(${CMS_BOT_DIR}/process-pull-request.py -c -r $(echo ${PULL_REQUEST} | sed 's/#.*//') $(echo ${PULL_REQUEST} | sed 's/.*#//'))
 echo "${PULL_REQUEST}=${COMMIT}" > ${WORKSPACE}/prs_commits
 source $CMS_BOT_DIR/pr_testing/_helper_functions.sh
 source $CMS_BOT_DIR/common/github_reports.sh

--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -319,7 +319,7 @@ if [ "X$RUN_TR_COMP" = Xtrue ]; then
     wait_dqm_comp 0.5
     WF_DIR=`echo ${WF} | cut -d "/" -f1`
     echo "Running: edm::TriggerResults ${WF_DIR}"
-    (${CMS_BOT_DIR}/compareTriggerResults -r ${WORKSPACE}/data/${COMPARISON_RELEASE} -t ${WORKSPACE}/data/PR-${PR_NUM} \
+    (${CMS_BOT_DIR}/compareTriggerResults.py -r ${WORKSPACE}/data/${COMPARISON_RELEASE} -t ${WORKSPACE}/data/PR-${PR_NUM} \
       -f "*/${WF_DIR}/step*.root" -o ${WORKSPACE}/upload/triggerResults > ${WORKSPACE}/upload/triggerResults/${WF_DIR}.log 2>&1 || true) &
   done
 fi
@@ -503,7 +503,7 @@ wait || true
 
 if [ "X$RUN_TR_COMP" = Xtrue ]; then
   echo "[`date`] Done comparisons of edm::TriggerResults"
-  ${CMS_BOT_DIR}/compareTriggerResultsSummary -i ${WORKSPACE}/upload/triggerResults -f "*/*.json" -o ${WORKSPACE}/upload/triggerResults/index.html -F html > ${WORKSPACE}/upload/triggerResults.log 2>&1 || true
+  ${CMS_BOT_DIR}/compareTriggerResultsSummary.py -i ${WORKSPACE}/upload/triggerResults -f "*/*.json" -o ${WORKSPACE}/upload/triggerResults/index.html -F html > ${WORKSPACE}/upload/triggerResults.log 2>&1 || true
   echo "[`date`] Summary of TriggerResults comparisons saved in ${WORKSPACE}/upload/triggerResults.log"
   echo "HLT_TRIGGER_COMPARISON${TEST_FLAVOR_STR};OK,HLT Trigger ${UC_TEST_FLAVOR} comparison,See results,/SDT/jenkins-artifacts/${COMP_UPLOAD_DIR}/triggerResults/" >> ${RESULTS_FILE}
   if [ -f ${JR_COMP_DIR}/qaResultsSummary.log ]; then

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -158,7 +158,7 @@ ls /cvmfs/cms-ib.cern.ch || true
 which scram 2>/dev/null || source /cvmfs/cms.cern.ch/cmsset_default.sh
 
 # Put hashcodes of last commits to a file. Mostly used for commenting back
-COMMIT=$(${CMSBOT_PYTHON_CMD} ${CMS_BOT_DIR}/process-pull-request -c -r ${PR_REPO} ${PR_NUMBER})
+COMMIT=$(${CMSBOT_PYTHON_CMD} ${CMS_BOT_DIR}/process-pull-request.py -c -r ${PR_REPO} ${PR_NUMBER})
 echo "${PULL_REQUEST}=${COMMIT}" > ${WORKSPACE}/prs_commits
 cp ${WORKSPACE}/prs_commits ${WORKSPACE}/prs_commits.txt
 

--- a/process-build-release-request
+++ b/process-build-release-request
@@ -1,1 +1,0 @@
-process-build-release-request.py

--- a/process-create-data-repo-request
+++ b/process-create-data-repo-request
@@ -1,1 +1,0 @@
-process-create-data-repo-request.py

--- a/process-error-reports
+++ b/process-error-reports
@@ -1,1 +1,0 @@
-process-error-reports.py

--- a/process-pull-request
+++ b/process-pull-request
@@ -1,1 +1,0 @@
-process-pull-request.py

--- a/query-and-process-prs
+++ b/query-and-process-prs
@@ -1,1 +1,0 @@
-query-and-process-prs.py

--- a/query-new-pull-requests
+++ b/query-new-pull-requests
@@ -1,1 +1,0 @@
-query-new-pull-requests.py

--- a/release-notes
+++ b/release-notes
@@ -1,1 +1,0 @@
-release-notes.py

--- a/report-cmsdist-pull-request-results
+++ b/report-cmsdist-pull-request-results
@@ -1,1 +1,0 @@
-report-cmsdist-pull-request-results.py

--- a/report-summary-merged-prs
+++ b/report-summary-merged-prs
@@ -1,1 +1,0 @@
-report-summary-merged-prs.py

--- a/run-pr-code-checks
+++ b/run-pr-code-checks
@@ -69,7 +69,7 @@ pushd $CMSSW_BASE/src
     echo -e "\nSee log ${UP_URL}/cms-checkout-topic.log" >> ${UP_DIR}/code-checks.md
     if ! $DRY_RUN ; then
       send_jenkins_artifacts ${UP_DIR}/ pr-code-checks/${REPO_USER}-PR-${PULL_REQUEST}/${BUILD_NUMBER}
-      ${CMS_BOT_DIR}/comment-gh-pr -r ${REPOSITORY} -p $PULL_REQUEST -R ${UP_DIR}/code-checks.md
+      ${CMS_BOT_DIR}/comment-gh-pr.py -r ${REPOSITORY} -p $PULL_REQUEST -R ${UP_DIR}/code-checks.md
     fi
     exit 0
   fi
@@ -94,7 +94,7 @@ pushd $CMSSW_BASE/src
     echo '```' >> ${UP_DIR}/code-checks.md
     if ! $DRY_RUN ; then
       send_jenkins_artifacts ${UP_DIR}/ pr-code-checks/${REPO_USER}-PR-${PULL_REQUEST}/${BUILD_NUMBER}
-      ${CMS_BOT_DIR}/comment-gh-pr -r ${REPOSITORY} -p $PULL_REQUEST -R ${UP_DIR}/code-checks.md
+      ${CMS_BOT_DIR}/comment-gh-pr.py -r ${REPOSITORY} -p $PULL_REQUEST -R ${UP_DIR}/code-checks.md
     fi
     exit 0
   fi
@@ -102,7 +102,7 @@ pushd $CMSSW_BASE/src
   NSIZE=$(du -sk .git/objects/pack | sed 's|\s.*||')
   let DSIZE=${NSIZE}-${OSIZE} || DSIZE=0
   if [ $DSIZE -lt 0 ] ; then DSIZE=0 ; fi
-  $CMS_BOT_DIR/pr-checks/check-pr-files -d -r ${REPO_USER}/cmssw ${PULL_REQUEST} > ${UP_DIR}/invalid_files.txt || true
+  $CMS_BOT_DIR/pr-checks/check-pr-files.py -d -r ${REPO_USER}/cmssw ${PULL_REQUEST} > ${UP_DIR}/invalid_files.txt || true
   touch ${UP_DIR}/duplicate-data.txt
   if [ -d ${CMSSW_RELEASE_BASE}/external/${SCRAM_ARCH}/data ] ; then
     for f in $(cat ${UP_DIR}/all-changed-files.txt) ; do
@@ -129,7 +129,7 @@ if $CODE_CHECKS ; then
       echo '```' >> ${UP_DIR}/code-checks.md
       if ! $DRY_RUN ; then
         send_jenkins_artifacts ${UP_DIR}/ pr-code-checks/${REPO_USER}-PR-${PULL_REQUEST}/${BUILD_NUMBER}
-        ${CMS_BOT_DIR}/comment-gh-pr -r ${REPOSITORY} -p $PULL_REQUEST -R ${UP_DIR}/code-checks.md
+        ${CMS_BOT_DIR}/comment-gh-pr.py -r ${REPOSITORY} -p $PULL_REQUEST -R ${UP_DIR}/code-checks.md
       fi
       exit 0
     fi
@@ -227,5 +227,5 @@ echo -e "${MSG}${HOW_TO_RUN}" > ${UP_DIR}/code-checks.md
 if ! $DRY_RUN ; then
   send_jenkins_artifacts ${UP_DIR}/ pr-code-checks/${REPO_USER}-PR-${PULL_REQUEST}/${BUILD_NUMBER}
   eval `scram unset -sh`
-  ${CMS_BOT_DIR}/comment-gh-pr -r ${REPOSITORY} -p $PULL_REQUEST -R ${UP_DIR}/code-checks.md
+  ${CMS_BOT_DIR}/comment-gh-pr.py -r ${REPOSITORY} -p $PULL_REQUEST -R ${UP_DIR}/code-checks.md
 fi

--- a/run-user-pr-test
+++ b/run-user-pr-test
@@ -23,7 +23,7 @@ if [ "X${PULL_REQUEST}" != "X" ] ; then
   cd userrepo
   git fetch origin pull/${PULL_REQUEST}/head:CHANGES_${PULL_REQUEST}
   git merge CHANGES_${PULL_REQUEST}
-  COMMIT=$($CMS_BOT_DIR/process-pull-request -c -r ${REPOSITORY} ${PULL_REQUEST})
+  COMMIT=$($CMS_BOT_DIR/process-pull-request.py -c -r ${REPOSITORY} ${PULL_REQUEST})
   $CMS_BOT_DIR/modify_comment.py -r $REPOSITORY \
     -t JENKINS_TEST_URL \
     -m "${JENKINS_URL}/job/${JOB_NAME}/${BUILD_NUMBER}/console  Started: $(date '+%Y/%m/%d %H:%M')" $PULL_REQUEST || true
@@ -81,7 +81,7 @@ if [ -f ${JOB_SUMMARY_LOG} ] ; then
   cat ${JOB_SUMMARY_LOG} >> ${RESULT_LOG}
 fi
 if [ "X${PULL_REQUEST}" != "X" ] ; then
-  $WORKSPACE/cms-bot/comment-gh-pr -r $REPOSITORY -p ${PULL_REQUEST} -R ${RESULT_LOG}
+  $WORKSPACE/cms-bot/comment-gh-pr.py -r $REPOSITORY -p ${PULL_REQUEST} -R ${RESULT_LOG}
 else
   OPEN_ISSUE=$(grep '^ *OPEN_ISSUE_FOR_PUSH_TESTS *=' $REPO_DIR/repo_config.py | sed 's|^.*OPEN_ISSUE_FOR_PUSH_TESTS *=||;s| ||g' || true)
   if [ "X${OPEN_ISSUE}" = "XTrue" ] ; then

--- a/scram-package-monitor-sender
+++ b/scram-package-monitor-sender
@@ -1,1 +1,0 @@
-scram-package-monitor-sender.py

--- a/scram-package-monitor-timestamps
+++ b/scram-package-monitor-timestamps
@@ -1,1 +1,0 @@
-scram-package-monitor-timestamps.py

--- a/tag-ib
+++ b/tag-ib
@@ -1,1 +1,0 @@
-tag-ib.py

--- a/update-github-hooks-ip
+++ b/update-github-hooks-ip
@@ -1,1 +1,0 @@
-update-github-hooks-ip.py

--- a/updateVOTags
+++ b/updateVOTags
@@ -1,1 +1,0 @@
-updateVOTags.py


### PR DESCRIPTION
The following scripts doesn't appear to be used:

* cms-jenkins-api
* es-cleanup-indexes
* es-reindex
* forward-pull-requests
* generate-json-performance-charts
* generate-performance-summary
* get-git-tags
* merge-pull-request
* new-release-cycle
* process-error-reports
* report-cmsdist-pull-request-results
* scram-package-monitor-sender
* scram-package-monitor-timestamps
* tag-ib
* updateVOTags