### PR TITLE
Mention linked PRs in "fully signed" comment

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -2033,6 +2033,23 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
                 managers=releaseManagersList,
             )
 
+        if not is_hold and ("PULL_REQUESTS" in global_test_params):
+            autoMergeMsg += "\n**Notice** This PR was tested with additional Pull Request(s), please also merge them if necessary: "
+            linked_prs = global_test_params["PULL_REQUEST"].split()
+            autoMergeMsg += ", ".join(linked_prs[1:])
+            if not dryRun:
+                for pr in linked_prs[1:]:
+                    repo, pr_id = pr.split("#")
+                    r = gh.get_repository(repo)
+                    pr = r.get_issue(pr_id)
+                    pr.create_comment(
+                        "**REMINDER** "
+                        + releaseManagersList
+                        + ": This PR was used to test "
+                        + linked_prs[0]
+                        + ", and should probably be merged together with it"
+                    )
+
     devReleaseRelVal = ""
     if (pr.base.ref in RELEASE_BRANCH_PRODUCTION) and (pr.base.ref != "master"):
         devReleaseRelVal = (


### PR DESCRIPTION
@smuzaffar 
1. Not sure if testing `is_hold` is necessary - always mention linked PRs?
2. Maybe check if PR requires either cmsdist or cmsdata PR, not just any external one?
