### PR TITLE
Adding Geometry/HGCalMapping to geometry and upgrade

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -813,6 +813,7 @@ CMSSW_CATEGORIES = {
         "Geometry/GlobalTrackingGeometryBuilder",
         "Geometry/HGCalCommonData",
         "Geometry/HGCalGeometry",
+        "Geometry/HGCalMapping",
         "Geometry/HGCalSimData",
         "Geometry/HGCalTBCommonData",
         "Geometry/HcalAlgo",
@@ -1632,6 +1633,7 @@ CMSSW_CATEGORIES = {
     "upgrade": [
         "CalibTracker/SiPhase2TrackerESProducers",
         "CondFormats/HGCalObjects",
+        "Geometry/HGCalMapping",
         "CondTools/SiPhase2Tracker",
         "Configuration/Geometry",
         "Configuration/PyReleaseValidation",


### PR DESCRIPTION
https://github.com/cms-sw/cmssw/pull/43751 adds a new package `Geometry/HGCalMapping` which is used to fill the CondFormats which hold the information about the electronics mapping of HGCal. The package is proposed to be added under `geometry` and `upgrade` categories

@kerstinlovisa
