### PR TITLE
add (again) `missirol` to `configdb-owners`

### DIFF
--- a/gh-teams.py
+++ b/gh-teams.py
@@ -64,6 +64,7 @@ REPO_TEAMS["cms-sw"]["configdb-owners"] = {
         "Sam-Harper",
         "silviodonato",
         "mmusich",
+        "missirol",
     ],
     "repositories": {"hlt-confdb": "admin", "web-confdb": "admin"},
 }


### PR DESCRIPTION
In #2104, I was maybe too quick removing myself from `configdb-owners`.

Having write-access to https://github.com/cms-sw/hlt-confdb would allow me to deploy updates to the test/beta instances of the ConfDB GUI to help @cms-sw/hlt-l2 validate changes like the one discussed in https://github.com/cms-sw/hlt-confdb/pull/85.

@cms-sw/hlt-l2 , is this okay ?