### PR TITLE
process_pr: bug fix use milestone number instead of id

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -360,7 +360,7 @@ def updateMilestone(repo, issue, pr, dryRun):
     if pr.state != "open":
         print("PR not open, not setting/checking milestone")
         return
-    if issue.milestone and issue.milestone.id == milestoneId:
+    if issue.milestone and issue.milestone.number == milestoneId:
         return
     milestone = repo.get_milestone(milestoneId)
     print("Setting milestone to %s" % milestone.title)


### PR DESCRIPTION
This avoids an extra api call if milestone is already set to correct number.

FYI @iarspider 