### PR TITLE
avoid extra commits/repos github api call

### DIFF
--- a/github_utils.py
+++ b/github_utils.py
@@ -992,14 +992,4 @@ def get_pr_commits_reversed(pr):
     :param pr:
     :return: List[Commit]
     """
-    try:
-        # This requires at least PyGithub 1.23.0. Making it optional for the moment.
-        return list(pr.get_commits().reversed)
-    except:  # noqa
-        # This seems to fail for more than 250 commits. Not sure if the
-        # problem is github itself or the bindings.
-        try:
-            return reversed(list(pr.get_commits()))
-        except IndexError:
-            print("Index error: May be PR with no commits")
-    return []
+    return list(reversed(list(pr.get_commits())))

--- a/process_pr.py
+++ b/process_pr.py
@@ -2235,9 +2235,12 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
         if "PULL_REQUESTS" in global_test_params:
             unclosed_linked_prs = []
             linked_prs = global_test_params["PULL_REQUESTS"].split()
+            extra_repos = {repository: repo}
             for linked_pr in linked_prs[1:]:
                 linked_pr_repo, linked_pr_id = linked_pr.split("#")
-                r = gh.get_repo(linked_pr_repo)
+                if not linked_pr_repo in extra_repos:
+                    extra_repos[linked_pr_repo] = gh.get_repo(linked_pr_repo)
+                r = extra_repos[linked_pr_repo]
                 linked_pr_obj = r.get_issue(int(linked_pr_id))
                 if linked_pr_obj.state != "closed":
                     unclosed_linked_prs.append(linked_pr)


### PR DESCRIPTION
FYI @iarspider , hopefully this should fix the extra github api call for commits.

Also avoid github api calls if linked PRs are from the same repostiory