### PR TITLE
Drop user name (user login is enough) from bot messages to avoid one api call

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -2091,20 +2091,15 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
             backport_msg = ""
             if backport_pr_num:
                 backport_msg = "%s%s\n" % (BACKPORT_STR, backport_pr_num)
-            uname = ""
-            if issue.user.name:
-                uname = issue.user.name.encode("ascii", "ignore").decode()
             l2s = ", ".join([gh_user_char + name for name in CMSSW_ISSUES_TRACKERS])
             issueMessage = format(
-                "%(msgPrefix)s %(gh_user_char)s%(user)s"
-                " %(name)s.\n\n"
+                "%(msgPrefix)s %(gh_user_char)s%(user)s.\n\n"
                 "%(l2s)s can you please review it and eventually sign/assign?"
                 " Thanks.\n\n"
                 'cms-bot commands are listed <a href="http://cms-sw.github.io/cms-bot-cmssw-issues.html">here</a>\n%(backport_msg)s',
                 msgPrefix=NEW_ISSUE_PREFIX,
                 user=requestor,
                 gh_user_char=gh_user_char,
-                name=uname,
                 backport_msg=backport_msg,
                 l2s=l2s,
             )
@@ -2321,7 +2316,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
                 pkg_msg.append("- %s (**new**)" % pkg)
         messageNewPR = format(
             "%(msgPrefix)s %(gh_user_char)s%(user)s"
-            " %(name)s for %(branch)s.\n\n"
+            " for %(branch)s.\n\n"
             "It involves the following packages:\n\n"
             "%(packages)s\n\n"
             "%(new_package_message)s\n"
@@ -2334,7 +2329,6 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
             msgPrefix=NEW_PR_PREFIX,
             user=pr.user.login,
             gh_user_char=gh_user_char,
-            name=pr.user.name and "(%s)" % pr.user.name or "",
             branch=pr.base.ref,
             l2s=", ".join(missing_notifications),
             packages="\n".join(pkg_msg),
@@ -2353,7 +2347,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
     else:
         messageNewPR = format(
             "%(msgPrefix)s %(gh_user_char)s%(user)s"
-            " %(name)s for branch %(branch)s.\n\n"
+            " for branch %(branch)s.\n\n"
             "%(l2s)s can you please review it and eventually sign?"
             " Thanks.\n"
             "%(watchers)s"
@@ -2362,7 +2356,6 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
             msgPrefix=NEW_PR_PREFIX,
             user=pr.user.login,
             gh_user_char=gh_user_char,
-            name=pr.user.name and "(%s)" % pr.user.name or "",
             branch=pr.base.ref,
             l2s=", ".join(missing_notifications),
             releaseManagers=releaseManagersMsg,


### PR DESCRIPTION
Every time bot runs (even if there are no changes for PR or issue) bot make an api call to get gihtub user name. This change proposes to use only github user login instead of user login + user name. So after this change bot will post message like 
```
A new Pull Request was created by @smuzaffar for branch master.
```
 instead of
```
A new Pull Request was created by @smuzaffar (Malik Shahzad Muzaffar) for branch master.
```

If we want to keep the user name then we can update bot to only generate the comment messages when needed e.g. if bot has already seen the issue/PR then no need to execute https://github.com/cms-sw/cms-bot/blob/master/process_pr.py#L2322-L2345 code.


