### PR TITLE
Modify exit codes for cms-docker building issues

### DIFF
--- a/cms-docker-gh-issues.py
+++ b/cms-docker-gh-issues.py
@@ -69,7 +69,7 @@ if args.comment == False:
         if issue.state == "open":
             print("Issue already opened... Nothing to do!")
             # Delete property files
-            sys.exit(0)
+            sys.exit(1)
         # We can have multiple issues closed, we take the one that was opened first
         print("Issue already closed... Ready for building!")
         issue_number = issue.number
@@ -106,10 +106,10 @@ if args.comment == False:
                 with open("gh-info.tmp", "a") as f:
                     f.write(str(label_obj["name"]) + "\n")
         # Don't delete property files
-        sys.exit(1)
+        sys.exit(0)
 
     # Delete property files
-    sys.exit(0)
+    sys.exit(1)
 else:
     for issue in gh_repo.get_issues(labels=[str(label) for label in args.labels], state="all"):
         issue_number = issue.number


### PR DESCRIPTION
This PR modifies the exit codes that are then handled in the Jenkins job. With the new values, if there is any error when running the script, the Jenkins job will nicely clean up the corresponding property files.