### PR TITLE
Fix for failing CRAB jobs in IBs

### DIFF
--- a/crab/ib-monitor-crab.sh
+++ b/crab/ib-monitor-crab.sh
@@ -13,7 +13,7 @@ GRIDSITE=$2
 voms-proxy-init -voms cms
 status=""
 while true ; do
-  curl -s -L -X GET --cert "/tmp/x509up_u${ID}" --key "/tmp/x509up_u${ID}" --capath "/etc/grid-security/certificates/" "${GRIDSITE}/status_cache" > $WORKSPACE/status-${CRABCLIENT_TYPE}.log 2>&1
+  curl "${GRIDSITE}/status_cache" > $WORKSPACE/status-${CRABCLIENT_TYPE}.log 2>&1
   cat $WORKSPACE/status-${CRABCLIENT_TYPE}.log
   errval=$(grep -o "404 Not Found" $WORKSPACE/status-${CRABCLIENT_TYPE}.log || echo "")
   cat $WORKSPACE/status-${CRABCLIENT_TYPE}.log >> $WORKSPACE/testsResults/crab-logfile-${CRABCLIENT_TYPE}

--- a/crab/ib-run-crab.sh
+++ b/crab/ib-run-crab.sh
@@ -34,7 +34,6 @@ echo "INPROGRESS" > $WORKSPACE/crab/statusfile
 cat $WORKSPACE/crab/.requestcache 
 export ID=$(id -u)
 export TASK_ID=$(grep crab_${CRAB_REQUEST} $WORKSPACE/crab/.requestcache | sed 's|^V||')
-export SUBMISSION_NAME=$(echo $TASK_ID | cut -d ":" -f2 | cut -d "_" -f2-)
 
 if [ "${TASK_ID}" = "" ] ; then exit 1 ; fi
 


### PR DESCRIPTION
CRAB jobs for IBs have been failing for a while. We initially thought there was some delay in the service, but having a closer look it seems we were having some issues with the certificate:
```
+ curl -X GET --cert /tmp/x509up_u22527 --key /tmp/x509up_u22527 --capath /etc/grid-security/certificates/ 'https://cmsweb.cern.ch:8443/crabserver/prod/task?subresource=search&workflow=240222_165649:cmsbot_crab_Jenkins_CMSSW_14_1_X_2024-02-21-2300_el8_amd64_gcc12_4503'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (58) could not load PEM client certificate, OpenSSL error error:02001002:system library:fopen:No such file or directory, (no key found, wrong pass phrase, or wrong file format?)
+ report
+ exit_code=58
``` 
I propose a workaround for this by using the `crab status` monitoring command.