### PR TITLE
Hotfix for handling compressed bot cache

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -135,7 +135,7 @@ REGEX_TEST_IGNORE = re.compile(
     r"^\s*(?:(?:@|)cmsbuild\s*[,]*\s+|)(?:please\s*[,]*\s+|)ignore\s+tests-rejected\s+(?:with|)([a-z -]+)$",
     re.I,
 )
-REGEX_COMMITS_CACHE = re.compile(r"<!-- (?:commits|bot) cache: (.*) -->")
+REGEX_COMMITS_CACHE = re.compile(r"<!-- (?:commits|bot) cache: (.*) -->", re.DOTALL)
 REGEX_IGNORE_COMMIT_COUNT = "\+commit-count"
 TEST_WAIT_GAP = 720
 ALL_CHECK_FUNCTIONS = None


### PR DESCRIPTION
Base64-encoded data is formatted into lines of 64 characters, lines separated by new-line character. Without `re.DOTALL`, new-line character is not matched by regular expression `.` - so bot cache was not loaded and, more important, it was not overwritten, but appended, quickly exceeding comment length limit. 