### PR TITLE
Avoid processing toolnames with same name but different capitalization

### DIFF
--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -584,10 +584,12 @@ if ${BUILD_EXTERNAL} ; then
         chmod +x ${RMV_CMSSW_EXTERNAL}
       fi
       DEP_NAMES=""
+      ALL_NEW_TOOLS=$(ls ${CTOOLS}/ | tr '[A-Z]' '[a-z]')
       for xml in $(ls ${BTOOLS}/*.xml) ; do
         name=$(basename $xml)
-        tool=$(echo $name | sed 's|.xml$||')
-        if [ ! -e ${CTOOLS}/$name ] ; then
+        lcname=$(echo $name | tr '[A-Z]' '[a-z]')
+        if [ $(echo " ${ALL_NEW_TOOLS} " | grep " ${lcname} " |wc -l) -eq 0 ] ; then
+          tool=$(echo $name | sed 's|.xml$||')
           echo "Removed tool $name"
           DEP_NAMES="$DEP_NAMES echo_${tool}_USED_BY"
         fi


### PR DESCRIPTION
While testing https://github.com/cms-sw/cmsdist/pull/9042 I noticed that PR tests script think that some tools were removed and tries to rebuild nealy full cmssw during PR tests. This is due is because some toolfiles have different capitalization but they point to same tool/package.  This change should avoid such cases for CMSSW releases with SCRAM V2