### PR TITLE
[RFC] Ignore draft pull requests when building a list of modified files

### DIFF
--- a/github_modified_files.py
+++ b/github_modified_files.py
@@ -62,7 +62,7 @@ def main():
     print("GitHub API rate limit before: {}".format(gh.get_rate_limit()))
     for pr in pr_list:
         nr = str(pr.number)
-        if pr.state == "closed":
+        if pr.state == "closed" or pr.draft:
             if nr in rez:
                 del rez[nr]
             continue


### PR DESCRIPTION
@smuzaffar Maybe we should also skip notifying L2s for them (as if no-notify "flag" is set in PR message)? We can listed for `ready_for_review` action in `pull_requests` hooks and run a trimmed down version of `process_pr` (just check whom to notify and post a notification comment) when a draft PR is marked "ready for review"?