### PR TITLE
[NODES SANITY CHECK] Add offline reason to monitor page

### DIFF
--- a/jenkins/nodes-sanity-check.sh
+++ b/jenkins/nodes-sanity-check.sh
@@ -5,7 +5,7 @@ PATHS=$@
 # Checking that paths are acessible
 for path in ${PATHS[@]}; do
     echo "Checking ${path} for host $(hostname)"
-    ls ${path} >/dev/null 2>&1 && echo -e "... OK!" || exit 1
+    ls ${path} >/dev/null 2>&1 && echo -e "... OK!" || echo "ERROR accessing ${path}"
 done
 
 arch=$(uname -r | grep -o "el[0-9]")
@@ -17,5 +17,5 @@ fi
 if [ "$SINGULARITY" == "true" ]; then
     # Checking that singularity can start
     echo "Checking that singularity can start a container on $(hostname)"
-    /cvmfs/cms.cern.ch/common/cmssw-${arch} --command-to-run ls >/dev/null 2>&1 && echo -e "... OK!" || exit 1
+    /cvmfs/cms.cern.ch/common/cmssw-${arch} --command-to-run ls >/dev/null 2>&1 && echo -e "... OK!" || echo "ERROR starting singularity"
 fi

--- a/jenkins/parser/jenkins-parser-monitor-job.py
+++ b/jenkins/parser/jenkins-parser-monitor-job.py
@@ -214,12 +214,16 @@ with open(
          <tr class="header">\n\
             <th>Blacklisted Node</th>\n\
             <th>Node Url</th>\n\
+            <th>Reason</th>\n\
          </tr>\n\
          </thead>\n\
       <tbody>\n'
     html_file.write(tail)
 
     for node in os.listdir("/var/lib/jenkins/workspace/cache/blacklist/"):
+        file_path = "/var/lib/jenkins/workspace/cache/blacklist/" + node
+        with open(file_path, 'r') as file:
+            reason = file.read()
         if ".offline" in node:
             node = node.split(".offline")[0]
             print("Node " + node + " is blacklisted")
@@ -230,6 +234,9 @@ with open(
                 + node
                 + '">https://cmssdt.cern.ch/jenkins/computer/'
                 + node
+                + "</td><td>"
+                + str(reason)
+                + "</td></tr>"
             )
         elif ".cern.ch" in node:
             node = node.split(".cern.ch")[0]
@@ -237,7 +244,9 @@ with open(
             html_file.writelines(
                 '      <tr class="Retry">\n        <td>'
                 + node
-                + "</td>\n        <td>Lxplus host is blacklisted, no Jenkins node will connect to it </td>\n      </tr>\n"
+                + "</td>\n        <td>Lxplus host is blacklisted, no Jenkins node will connect to it </td>\n<td>"
+                + reason
+                + "</td>      </tr>\n"
             )
 
     tail = "      </table>\n\

--- a/jenkins/parser/jenkins-parser-monitor-job.py
+++ b/jenkins/parser/jenkins-parser-monitor-job.py
@@ -222,7 +222,7 @@ with open(
 
     for node in os.listdir("/var/lib/jenkins/workspace/cache/blacklist/"):
         file_path = "/var/lib/jenkins/workspace/cache/blacklist/" + node
-        with open(file_path, 'r') as file:
+        with open(file_path, "r") as file:
             reason = file.read()
         if ".offline" in node:
             node = node.split(".offline")[0]

--- a/jenkins/parser/jenkins-parser-monitor-job.py
+++ b/jenkins/parser/jenkins-parser-monitor-job.py
@@ -222,8 +222,11 @@ with open(
 
     for node in os.listdir("/var/lib/jenkins/workspace/cache/blacklist/"):
         file_path = "/var/lib/jenkins/workspace/cache/blacklist/" + node
-        with open(file_path, "r") as file:
-            reason = file.read()
+        try:
+            with open(file_path, "r") as file:
+                reason = file.read()
+        except:
+            reason = "Unknown"
         if ".offline" in node:
             node = node.split(".offline")[0]
             print("Node " + node + " is blacklisted")


### PR DESCRIPTION
These changes allow to display the offline reason in the monitor table as follows:

<img width="1152" alt="Captura de pantalla 2024-03-27 a la(s) 1 23 38 p m" src="https://github.com/cms-sw/cms-bot/assets/70633699/e0fefd16-d7b5-4025-a2d1-10e98fdb3a62">