### PR TITLE
Add Afiq Anuar as new EGM L2

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -138,7 +138,7 @@ CMSSW_L2 = {
     "bellan": ["pf"],
     "kdlong": ["pf"],
     "swagata87": ["pf"],
-    "a-kapoor": ["egamma-pog"],
+    "afiqaize": ["egamma-pog"],
     "RSalvatico": ["egamma-pog"],
     "kirschen": ["jetmet-pog"],
     "alkaloge": ["jetmet-pog"],


### PR DESCRIPTION
Adding Afiq Anuar (@afiqaize) as new EGM L2 and removing Anshul Kapoor, who left CMS.