### PR TITLE
Add upgrade to L1Trigger/L1TMuonOverlapPhase2

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -1692,6 +1692,7 @@ CMSSW_CATEGORIES = {
         "L1Trigger/L1TTrackMatch",
         "L1Trigger/ME0Trigger",
         "L1Trigger/L1TMuonEndCapPhase2",
+        "L1Trigger/L1TMuonOverlapPhase2",
         "L1Trigger/Phase2L1GT",
         "L1Trigger/Phase2L1ParticleFlow",
         "L1Trigger/TrackTrigger",


### PR DESCRIPTION
This PR adds upgrade to the `L1Trigger/L1TMuonOverlapPhase2` (phase 2 OMTF) package for https://github.com/cms-sw/cmssw/pull/44557