### PR TITLE
ignore ref wf failures if Pr tests did not run that wf

### DIFF
--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -199,7 +199,8 @@ fi
 
 #Only keep those wf in $WORKSPACE/$ERRORS_FILE which were run for PR tests
 for wf in $(cat $WORKSPACE/$ERRORS_FILE | sed -e 's|;.*||') ; do
-  [ $(echo ",$WORKFLOWS_LIST," | grep ",$wf," |wc -l) -gt 0 ] || continue
+  [ $(echo ",$WORKFLOWS_LIST," | grep ",$wf," |wc -l) -eq 0 ] || continue
+  #Failed workflow was not run for this tests. Remove it from the error file
   sed -i "/^${wf};/d" $WORKSPACE/$ERRORS_FILE
 done
 


### PR DESCRIPTION
This should fix the issue reported [here](https://github.com/cms-sw/cmssw/pull/44767#issuecomment-2087482148). There was a typo (`-gt` instead of `-eq`) and bot should have ignored the extra failed workflows ran in the baseline.