### PR TITLE
Vtune link has undefined for arch

### DIFF
--- a/report-summary-merged-prs.py
+++ b/report-summary-merged-prs.py
@@ -1668,7 +1668,7 @@ if __name__ == "__main__":
     MAGIC_COMMAND_FIND_VTUNE_CHECKS_FILTER = (
         "ls "
         + JENKINS_ARTIFACTS_DIR
-        + '/profiling/RELEASE_NAME/ARCHITECTURE/*/step3-vtune.log 2>/dev/null | head -1 |  sed "s|.*/RELEASE_NAME||"'
+        + '/profiling/RELEASE_NAME/ARCHITECTURE/*/step3-vtune.log 2>/dev/null | head -1 |  sed "s|.*/RELEASE_NAME||;s|step3-vtune.log$||"'
     )
     MAGIC_COMMAND_FIND_COMPARISON_BASELINE = (
         "test -f "

--- a/report-summary-merged-prs.py
+++ b/report-summary-merged-prs.py
@@ -1668,7 +1668,7 @@ if __name__ == "__main__":
     MAGIC_COMMAND_FIND_VTUNE_CHECKS_FILTER = (
         "ls "
         + JENKINS_ARTIFACTS_DIR
-        + '/profiling/RELEASE_NAME/ARCHITECTURE/*/step3-vtune.log 2>/dev/null | head -1 |  sed "s|.*/RELEASE_NAME||;s|step3-vtune.log$||"'
+        + '/profiling/RELEASE_NAME/ARCHITECTURE/WORKFLOW/step3-vtune.log 2>/dev/null | head -1 |  sed "s|.*/RELEASE_NAME||;s|step3-vtune.log$||"'
     )
     MAGIC_COMMAND_FIND_COMPARISON_BASELINE = (
         "test -f "


### PR DESCRIPTION
@smuzaffar result.arch is set to  `undefined` in the links for vtune. This should return the arch/workflow needed for the Vtune link.