### PR TITLE
Add L1TriggerScouting/OnlineProcessing to DAQ and cleanup old packages

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -374,6 +374,7 @@ CMSSW_CATEGORIES = {
         "EventFilter/StorageManager",
         "EventFilter/Utilities",
         "L1TriggerScouting/Utilities",
+        "L1TriggerScouting/OnlineProcessing",
         "IORawData/CSCCommissioning",
         "IORawData/DaqSource",
     ],


### PR DESCRIPTION
Adding new package to `daq` supervision.

Package is submitted to CMSSW here:
https://github.com/cms-sw/cmssw/pull/45350

Old DAQ packages that no longer exist in the CMSSW codebase (Run1 period) are cleaned up.