### PR TITLE
Relax chk-invalid-headers checks to match SCRAM rules:

### DIFF
--- a/chk-invalid-headers.py
+++ b/chk-invalid-headers.py
@@ -56,7 +56,9 @@ def main():
             continue
         for src in usedby[inc].split(" "):
             sitems = src.split("/")
-            if (items[0] == sitems[0]) and (items[1] == sitems[1]) and (items[2] == sitems[2]):
+            if (items[0] == sitems[0]) and (items[1] == sitems[1]):
+                continue
+            if (items[2] == sitems[2]) and (items[2] == "test"):
                 continue
             if hasInclude(inc, src, includes):
                 if src not in errs:

--- a/chk-invalid-headers.py
+++ b/chk-invalid-headers.py
@@ -51,11 +51,11 @@ def main():
     errs = {}
     checked = {}
     for inc in usedby:
-        items = inc.split("/")
+        items = [x for x in inc.split("/") if x]
         if items[2] == "interface":
             continue
         for src in usedby[inc].split(" "):
-            sitems = src.split("/")
+            sitems = [x for x in src.split("/") if x]
             if (items[0] == sitems[0]) and (items[1] == sitems[1]):
                 continue
             if (items[2] == sitems[2]) and (items[2] == "test"):


### PR DESCRIPTION
- file in PackageA/SubpackageA can include any file from that subpackage, but only interface (public header) from other package or subpackage
- file in PackageA/SubpackageA/test can, in addition, include file from any other package's `test` directory