### PR TITLE
PR test: Run sourcing of cmsset_default.sh for el6-el9

### DIFF
--- a/pr_testing/_helper_functions.sh
+++ b/pr_testing/_helper_functions.sh
@@ -79,7 +79,7 @@ function prepare_upload_results (){
     else
       mkdir -p upload
     fi
-    for f in external_checks git-recent-commits.json cmssw.tar.gz unitTests gpuUnitTests dasqueries testsResults build-logs clang-logs runTheMatrix*-results llvm-analysis *.log *.html *.txt *.js DQMTestsResults valgrindResults-* cfg-viewerResults igprof-results-data git-merge-result git-log-recent-commits addOnTests codeRules dupDict material-budget ; do
+    for f in external_checks git-recent-commits.json cmssw.tar.gz unitTests gpuUnitTests dasqueries testsResults build-logs clang-logs runTheMatrix*-results llvm-analysis *.log *.html *.txt *.js DQMTestsResults valgrindResults-* cfg-viewerResults igprof-results-data git-merge-result git-log-recent-commits addOnTests codeRules dupDict material-budget cmsset_default; do
       [ -e $f ] && mv $f upload/$f
     done
     if [ -e upload/renderPRTests.js ] ; then mkdir -p upload/js && mv upload/renderPRTests.js upload/js/ ; fi

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -527,6 +527,32 @@ if ${BUILD_EXTERNAL} ; then
       echo 'CMSSWTOOLCONF_RESULTS;OK,Externals compilation,See Log,cmsswtoolconf.log' >> ${RESULTS_DIR}/toolconf.txt
     fi
 
+    #Testing sourcing of cmsset_default
+    CMSSET_DEFAULT_OK=true
+    mkdir $WORKSPACE/cmsset_default
+    EL_OS=$(ls $WORKSPACE/$BUILD_DIR/common/cmssw-el* | sed 's|.*/common/cmssw-el|el|' | grep -v 'el5')
+    for sh in bash sh zsh ; do
+      for os in $EL_OS ; do
+        echo "Checking cmsset_default.sh for $sh under $os" >>  $WORKSPACE/cmsset_default/run.log
+        if ! $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -e $WORKSPACE/$BUILD_DIR/cmsset_default.sh >>$WORKSPACE/cmsset_default/run.log 2>&1 ; then
+          CMSSET_DEFAULT_OK=false
+          echo " => Failed $sh:$os" >> $WORKSPACE/cmsset_default/run.log
+          $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -ex $WORKSPACE/$BUILD_DIR/cmsset_default.sh > $WORKSPACE/cmsset_default/${sh}-${os}.log 2>&1
+        else
+          echo "OK $sh:$os" >> $WORKSPACE/cmsset_default/run.log
+        fi
+      done
+    done
+    if ! ${CMSSET_DEFAULT_OK} ; then
+      echo 'CMSSET_DEFAULT_RESULTS;ERROR,Environment setup,See Log,cmsset_default' >> ${RESULTS_DIR}/cmsset_default.txt
+      echo -e "\n## Setting up env\n\nUnable to run cmsset_default.sh" >> 10-report.res
+      prepare_upload_results
+      mark_commit_status_all_prs '' 'error' -u "${PR_RESULT_URL}" -d "Environment setup error"
+      exit 0
+    else
+      echo 'CMSSET_DEFAULT_RESULTS;OK,Environment setup,See Log,cmsset_default/run.log' >> ${RESULTS_DIR}/cmsset_default.txt
+    fi
+
     OLD_DASGOCLIENT=$(dasgoclient --version  | tr ' ' '\n' | grep '^git=' | sed 's|^git=||')
     # Create an appropriate CMSSW area
     source $WORKSPACE/$BUILD_DIR/cmsset_default.sh

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -537,7 +537,7 @@ if ${BUILD_EXTERNAL} ; then
         if ! $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -e $WORKSPACE/$BUILD_DIR/cmsset_default.sh >>$WORKSPACE/cmsset_default/run.log 2>&1 ; then
           CMSSET_DEFAULT_ERR="${CMSSET_DEFAULT_ERR} $sh:$os"
           echo "Failed: $sh:$os" >> $WORKSPACE/cmsset_default/run.log
-          $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -ex $WORKSPACE/$BUILD_DIR/cmsset_default.sh > $WORKSPACE/cmsset_default/${sh}-${os}.log 2>&1
+          $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -ex $WORKSPACE/$BUILD_DIR/cmsset_default.sh > $WORKSPACE/cmsset_default/${sh}-${os}.log 2>&1 || true
         else
           echo "OK: $sh:$os" >> $WORKSPACE/cmsset_default/run.log
         fi

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -528,24 +528,24 @@ if ${BUILD_EXTERNAL} ; then
     fi
 
     #Testing sourcing of cmsset_default
-    CMSSET_DEFAULT_OK=true
+    CMSSET_DEFAULT_ERR=""
     mkdir $WORKSPACE/cmsset_default
     EL_OS=$(ls $WORKSPACE/$BUILD_DIR/common/cmssw-el* | sed 's|.*/common/cmssw-el|el|' | grep -v 'el5')
     for sh in bash sh zsh ; do
       for os in $EL_OS ; do
         echo "Checking cmsset_default.sh for $sh under $os" >>  $WORKSPACE/cmsset_default/run.log
         if ! $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -e $WORKSPACE/$BUILD_DIR/cmsset_default.sh >>$WORKSPACE/cmsset_default/run.log 2>&1 ; then
-          CMSSET_DEFAULT_OK=false
-          echo " => Failed $sh:$os" >> $WORKSPACE/cmsset_default/run.log
+          CMSSET_DEFAULT_ERR="${CMSSET_DEFAULT_ERR} $sh:$os"
+          echo "Failed: $sh:$os" >> $WORKSPACE/cmsset_default/run.log
           $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -ex $WORKSPACE/$BUILD_DIR/cmsset_default.sh > $WORKSPACE/cmsset_default/${sh}-${os}.log 2>&1
         else
-          echo "OK $sh:$os" >> $WORKSPACE/cmsset_default/run.log
+          echo "OK: $sh:$os" >> $WORKSPACE/cmsset_default/run.log
         fi
       done
     done
-    if ! ${CMSSET_DEFAULT_OK} ; then
+    if [ "${CMSSET_DEFAULT_ERR}" != "" ]  ; then
       echo 'CMSSET_DEFAULT_RESULTS;ERROR,Environment setup,See Log,cmsset_default' >> ${RESULTS_DIR}/cmsset_default.txt
-      echo -e "\n## Setting up env\n\nUnable to run cmsset_default.sh" >> 10-report.res
+      echo -e "\n## Setting up env\n\nUnable to run cmsset_default.sh for ${CMSSET_DEFAULT_ERR}" >> 10-report.res
       prepare_upload_results
       mark_commit_status_all_prs '' 'error' -u "${PR_RESULT_URL}" -d "Environment setup error"
       exit 0

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -527,31 +527,33 @@ if ${BUILD_EXTERNAL} ; then
       echo 'CMSSWTOOLCONF_RESULTS;OK,Externals compilation,See Log,cmsswtoolconf.log' >> ${RESULTS_DIR}/toolconf.txt
     fi
 
-    #Testing sourcing of cmsset_default
-    CMSSET_DEFAULT_ERR=""
-    mkdir $WORKSPACE/cmsset_default
-    EL_OS=$(ls $WORKSPACE/$BUILD_DIR/common/cmssw-el* | sed 's|.*/common/cmssw-el|el|' | grep -v 'el5')
-    for sh in bash sh zsh ; do
-      for os in $EL_OS ; do
-        echo "Checking cmsset_default.sh for $sh under $os" >>  $WORKSPACE/cmsset_default/run.log
-        if ! $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -e $WORKSPACE/$BUILD_DIR/cmsset_default.sh >>$WORKSPACE/cmsset_default/run.log 2>&1 ; then
-          CMSSET_DEFAULT_ERR="${CMSSET_DEFAULT_ERR} $sh:$os"
-          echo "Failed" >> $WORKSPACE/cmsset_default/run.log
-          $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -ex $WORKSPACE/$BUILD_DIR/cmsset_default.sh > $WORKSPACE/cmsset_default/${sh}-${os}.log 2>&1 || true
-        else
-          echo "OK" >> $WORKSPACE/cmsset_default/run.log
-        fi
+    #Testing sourcing of cmsset_default: run only for CMSSW master IB/Proudcuton arch
+    if $CMSSW_DEVEL_PROD_ARCH ; then
+      CMSSET_DEFAULT_ERR=""
+      mkdir $WORKSPACE/cmsset_default
+      EL_OS=$(ls $WORKSPACE/$BUILD_DIR/common/cmssw-el* | sed 's|.*/common/cmssw-el|el|' | grep -v 'el5')
+      for sh in bash sh zsh ; do
+        for os in $EL_OS ; do
+          echo "Checking cmsset_default.sh for $sh under $os" >>  $WORKSPACE/cmsset_default/run.log
+          if ! $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -e $WORKSPACE/$BUILD_DIR/cmsset_default.sh >>$WORKSPACE/cmsset_default/run.log 2>&1 ; then
+            CMSSET_DEFAULT_ERR="${CMSSET_DEFAULT_ERR} $sh:$os"
+            echo "Failed" >> $WORKSPACE/cmsset_default/run.log
+            $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -ex $WORKSPACE/$BUILD_DIR/cmsset_default.sh > $WORKSPACE/cmsset_default/${sh}-${os}.log 2>&1 || true
+          else
+            echo "OK" >> $WORKSPACE/cmsset_default/run.log
+          fi
+        done
       done
-    done
-    if [ "${CMSSET_DEFAULT_ERR}" != "" ]  ; then
-      echo "CMSSet_Default" >> ${RESULTS_DIR}/09-failed.res
-      echo 'CMSSET_DEFAULT_RESULTS;ERROR,Environment setup,See Log,cmsset_default' >> ${RESULTS_DIR}/toolconf.txt
-      echo "**Failed environment setup**: \`${CMSSET_DEFAULT_ERR}\`" >> ${RESULTS_DIR}/09-report.res
-      prepare_upload_results
-      mark_commit_status_all_prs '' 'error' -u "${PR_RESULT_URL}" -d "Environment setup error"
-      exit 0
-    else
-      echo 'CMSSET_DEFAULT_RESULTS;OK,Environment setup,See Log,cmsset_default/run.log' >> ${RESULTS_DIR}/toolconf.txt
+      if [ "${CMSSET_DEFAULT_ERR}" != "" ]  ; then
+        echo "CMSSet_Default" >> ${RESULTS_DIR}/09-failed.res
+        echo 'CMSSET_DEFAULT_RESULTS;ERROR,Environment setup,See Log,cmsset_default' >> ${RESULTS_DIR}/toolconf.txt
+        echo "**Failed environment setup**: \`${CMSSET_DEFAULT_ERR}\`" >> ${RESULTS_DIR}/09-report.res
+        prepare_upload_results
+        mark_commit_status_all_prs '' 'error' -u "${PR_RESULT_URL}" -d "Environment setup error"
+        exit 0
+      else
+        echo 'CMSSET_DEFAULT_RESULTS;OK,Environment setup,See Log,cmsset_default/run.log' >> ${RESULTS_DIR}/toolconf.txt
+      fi
     fi
 
     OLD_DASGOCLIENT=$(dasgoclient --version  | tr ' ' '\n' | grep '^git=' | sed 's|^git=||')

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -536,21 +536,22 @@ if ${BUILD_EXTERNAL} ; then
         echo "Checking cmsset_default.sh for $sh under $os" >>  $WORKSPACE/cmsset_default/run.log
         if ! $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -e $WORKSPACE/$BUILD_DIR/cmsset_default.sh >>$WORKSPACE/cmsset_default/run.log 2>&1 ; then
           CMSSET_DEFAULT_ERR="${CMSSET_DEFAULT_ERR} $sh:$os"
-          echo "Failed: $sh:$os" >> $WORKSPACE/cmsset_default/run.log
+          echo "Failed" >> $WORKSPACE/cmsset_default/run.log
           $WORKSPACE/$BUILD_DIR/common/cmssw-$os -- $sh -ex $WORKSPACE/$BUILD_DIR/cmsset_default.sh > $WORKSPACE/cmsset_default/${sh}-${os}.log 2>&1 || true
         else
-          echo "OK: $sh:$os" >> $WORKSPACE/cmsset_default/run.log
+          echo "OK" >> $WORKSPACE/cmsset_default/run.log
         fi
       done
     done
     if [ "${CMSSET_DEFAULT_ERR}" != "" ]  ; then
-      echo 'CMSSET_DEFAULT_RESULTS;ERROR,Environment setup,See Log,cmsset_default' >> ${RESULTS_DIR}/cmsset_default.txt
-      echo -e "\n## Setting up env\n\nUnable to run cmsset_default.sh for ${CMSSET_DEFAULT_ERR}" >> 10-report.res
+      echo "CMSSet_Default" >> ${RESULTS_DIR}/09-failed.res
+      echo 'CMSSET_DEFAULT_RESULTS;ERROR,Environment setup,See Log,cmsset_default' >> ${RESULTS_DIR}/toolconf.txt
+      echo "**Failed environment setup**: \`${CMSSET_DEFAULT_ERR}\`" >> ${RESULTS_DIR}/09-report.res
       prepare_upload_results
       mark_commit_status_all_prs '' 'error' -u "${PR_RESULT_URL}" -d "Environment setup error"
       exit 0
     else
-      echo 'CMSSET_DEFAULT_RESULTS;OK,Environment setup,See Log,cmsset_default/run.log' >> ${RESULTS_DIR}/cmsset_default.txt
+      echo 'CMSSET_DEFAULT_RESULTS;OK,Environment setup,See Log,cmsset_default/run.log' >> ${RESULTS_DIR}/toolconf.txt
     fi
 
     OLD_DASGOCLIENT=$(dasgoclient --version  | tr ' ' '\n' | grep '^git=' | sed 's|^git=||')


### PR DESCRIPTION
Run `cmsset_default.sh` under `bash -ex` or `zsh -ex` for all supported containers to make sure it runs without errors.