### PR TITLE
update github create hook: include name and data in to url

### DIFF
--- a/create-github-hooks.py
+++ b/create-github-hooks.py
@@ -31,8 +31,10 @@ def get_url(repo_name, hook, secret, hk_conf):
     ss = "%s:%s:%s" % (repo_name, hook, secret)
     data = hashlib.sha256(ss.encode()).hexdigest()
     xparam = "name=%s&data=%s" % (hook, data)
-    if "?" in url: return "%s&%s" % (url, xparam)
+    if "?" in url:
+        return "%s&%s" % (url, xparam)
     return "%s?%s" % (url, xparam)
+
 
 # match hook config
 def match_config(new, old):
@@ -187,9 +189,14 @@ if __name__ == "__main__":
         repo_hooks_all = {}
         for hook in repo.get_hooks():
             url = hook.config["url"]
-            if not url.startswith(CMSSDT_BASE_URL): continue
-            if 'name=Jenkins_Github_' in url:
-                name = [x.split("=")[-1] for x in url.split("?")[-1].split("&") if x.startswith('name=Jenkins_Github_')][0]
+            if not url.startswith(CMSSDT_BASE_URL):
+                continue
+            if "name=Jenkins_Github_" in url:
+                name = [
+                    x.split("=")[-1]
+                    for x in url.split("?")[-1].split("&")
+                    if x.startswith("name=Jenkins_Github_")
+                ][0]
                 repo_hooks_all[name] = hook
         api_rate_limits(gh)
         for hook in hooks:

--- a/create-github-hooks.py
+++ b/create-github-hooks.py
@@ -3,9 +3,9 @@ from github import Github
 from os.path import expanduser, exists, join, dirname, abspath
 from os import environ
 from optparse import OptionParser
-from github_hooks_config import get_repository_hooks, get_event_hooks
+from github_hooks_config import get_repository_hooks, get_event_hooks, CMSSDT_BASE_URL
 from github_utils import api_rate_limits
-import hashlib
+import hashlib, copy
 from categories import EXTERNAL_REPOS, CMSSW_REPOS, CMSDIST_REPOS
 from sys import argv
 from socket import setdefaulttimeout
@@ -24,6 +24,15 @@ def get_secret(hook_name):
             secret_file = "/data/secrets/github_hook_secret_cmsbot"
     return open(secret_file, "r").read().split("\n")[0].strip()
 
+
+# Get hook url
+def get_url(repo_name, hook, secret, hk_conf):
+    url = hk_conf[hook]["config"]["url"]
+    ss = "%s:%s:%s" % (repo_name, hook, secret)
+    data = hashlib.sha256(ss.encode()).hexdigest()
+    xparam = "name=%s&data=%s" % (hook, data)
+    if "?" in url: return "%s&%s" % (url, xparam)
+    return "%s?%s" % (url, xparam)
 
 # match hook config
 def match_config(new, old):
@@ -146,6 +155,7 @@ if __name__ == "__main__":
             repos[r] = None
 
     # process repos
+    print("Dryrun:", opts.dryRun)
     for repo_name in repos:
         gh = ghx
         isUserRepo = False
@@ -176,20 +186,20 @@ if __name__ == "__main__":
             repo = gh.get_repo(repo_name)
         repo_hooks_all = {}
         for hook in repo.get_hooks():
-            if "name" in hook.config:
-                repo_hooks_all[hook.config["name"]] = hook
+            url = hook.config["url"]
+            if not url.startswith(CMSSDT_BASE_URL): continue
+            if 'name=Jenkins_Github_' in url:
+                name = [x.split("=")[-1] for x in url.split("?")[-1].split("&") if x.startswith('name=Jenkins_Github_')][0]
+                repo_hooks_all[name] = hook
         api_rate_limits(gh)
-        print("Dryrun:", opts.dryRun)
         for hook in hooks:
             print("checking for web hook", hook)
-            hook_conf = hk_conf[hook]
+            secret = get_secret(hook)
+            hook_conf = copy.deepcopy(hk_conf[hook])
             hook_conf["name"] = "web"
             hook_conf["config"]["insecure_ssl"] = "1"
-            hook_conf["config"]["secret"] = get_secret(hook)
-            hook_conf["config"]["name"] = hook
-            hook_conf["config"]["data"] = hashlib.sha256(
-                hook_conf["config"]["secret"].encode()
-            ).hexdigest()
+            hook_conf["config"]["secret"] = secret
+            hook_conf["config"]["url"] = get_url(repo_name, hook, secret, hk_conf)
             if hook in repo_hooks_all:
                 old_hook = repo_hooks_all[hook]
                 if opts.force or not match_config(hook_conf, old_hook):

--- a/github_hooks_config.py
+++ b/github_hooks_config.py
@@ -1,17 +1,18 @@
 from cms_static import VALID_CMS_SW_REPOS_FOR_TESTS
 
+CMSSDT_BASE_URL = "https://cmssdt.cern.ch/SDT/cgi-bin/github_webhook"
 GITHUB_HOOKS = {}
 GITHUB_HOOKS["Jenkins_Github_Hook"] = {
     "active": True,
     "events": ["issues", "pull_request", "issue_comment", "status"],
-    "config": {"url": "https://cmssdt.cern.ch/SDT/cgi-bin/github_webhook", "content_type": "json"},
+    "config": {"url": CMSSDT_BASE_URL, "content_type": "json"},
 }
 
 GITHUB_HOOKS["Jenkins_Github_Hook_Push"] = {
     "active": True,
     "events": ["push"],
     "config": {
-        "url": "https://cmssdt.cern.ch/SDT/cgi-bin/github_webhook?push",
+        "url": "%s?push" % CMSSDT_BASE_URL,
         "content_type": "json",
     },
 }


### PR DESCRIPTION
Github has updated the API for creating/updating webhooks and now it does not allow to add any arbitrary data to be added in hook.config. We previously we were adding hook name and hook extra data in to it to check if a hook needs to be updated ( e.g. due to url change or secret update). Now use add `name and  data` in to hook URL