### PR TITLE
allow to add changes-dataformats labels by an explicit comment by L2/ORP

### DIFF
--- a/githublabels.py
+++ b/githublabels.py
@@ -35,6 +35,7 @@ TYPE_COMMANDS = {
     "root": [LABEL_COLORS["info"], "root", "mtype"],
     "documentation": [LABEL_COLORS["doc"], "doc(umentation|)", "mtype"],
     "hlt-integration": [LABEL_COLORS["doc"], "hlt-int(egration|)", "mtype"],
+    "changes-dataformats": [LABEL_COLORS["doc"], "(change(s|)-|)dataformats", "mtype"],
     "performance-improvements": [
         LABEL_COLORS["performance"],
         "performance|improvements|performance-improvements",


### PR DESCRIPTION
This should allow to add `changes-dataformats` label by an explicit comment by L2/ORP

See https://github.com/cms-sw/cms-bot/issues/2245 for the request