### PR TITLE
Add VourMa as watcher of the HLT Phase-2 menu

### DIFF
--- a/watchers.yaml
+++ b/watchers.yaml
@@ -1771,6 +1771,8 @@ a-kapoor:
   - DataFormats/EgammaReco
 SohamBhattacharya:
 - HLTrigger/Configuration/python/HLT_75e33
+VourMa:
+- HLTrigger/Configuration/python/HLT_75e33
 AnnikaStein:
 - Configuration/Eras
 - DataFormats/NanoAOD


### PR DESCRIPTION
I was recently appointed as co-convener of the "HLT Upgrade" subgroup of TSG from September 1st, 2024, to August 31st, 2026 (approved at the Collaboration Board meeting on 28/06/2024, [slide 23](https://indico.cern.ch/event/1421824/contributions/5978945/attachments/2886784/5059648/CB149%20June%202024%20.pdf#page=23)).

The maintenance of the HLT Phase-2 menu in CMSSW is under the responsibility of the HLT Upgrade group, and, to that purpose, I would like to be added as a watcher for the corresponding configuration files.

PR made after coordinating with @missirol.