### PR TITLE
Added @mandrenguyen as new ORP manager

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -78,7 +78,7 @@ CMSSW_L2 = {
     "sunilUIET": ["pdmv"],
     "miquork": ["pdmv", "jetmet-pog"],
     "makortel": ["heterogeneous", "core", "visualization", "geometry"],
-    "mandrenguyen": ["reconstruction"],
+    "mandrenguyen": ["reconstruction", "operations"],
     "mdhildreth": ["simulation", "geometry", "fastsim"],
     "mkirsano": ["generators"],
     "menglu21": ["generators"],

--- a/categories.py
+++ b/categories.py
@@ -10,7 +10,7 @@ authors = {}
 # Any Githib user whose comments/requests should be ignored
 GITHUB_BLACKLIST_AUTHORS = []
 # CMS Offline Release Planning managers
-CMSSW_ORP = ["sextonkennedy", "rappoccio", "antoniovilela"]
+CMSSW_ORP = ["sextonkennedy", "rappoccio", "antoniovilela", "mandrenguyen"]
 # CMS-SDT members who has admin rights to various github organizations and repositories.
 # They are also reposionsible to sign for externals
 CMS_SDT = ["iarspider", "smuzaffar", "aandvalenzuela"]


### PR DESCRIPTION
@cms-sw/orp-l2 , this PR adds @mandrenguyen as ORP for CMS offline & Computing
@mandrenguyen , once merged, you will become owner of cms-sw , cms-data and cms-externals github organization. This will allow you to directly push changes to any repository under these organizations. As you are also L2 of reconstruction so simple `+1` on PR will sign that PR for both reconstruction and orp. I would suggest to use `+reconstruction` and `+orp` to separately sign PRs. 