### PR TITLE
make a copy of /etc/tnsnames.ora before starting the container

### DIFF
--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -78,11 +78,8 @@ if [ "X$DOCKER_IMG" != X -a "X$RUN_NATIVE" = "X" ]; then
   if [ -d /afs/cern.ch ] ; then MOUNT_POINTS="${MOUNT_POINTS},/afs"; fi
   for tnsnames in /etc/tnsnames.ora ${HOME}/tnsnames.ora ; do
     if [ -e "${tnsnames}" ] ; then
-      if [ $(echo ${tnsnames} | grep '^/afs/' | wc -l) -gt 0 ] ; then
-        cp ${tnsnames} ${WORKSPACE}/
-        tnsnames="${WORKSPACE}/tnsnames.ora"
-      fi
-      MOUNT_POINTS="${MOUNT_POINTS},${tnsnames}:/etc/tnsnames.ora"
+      cp -f ${tnsnames} ${WORKSPACE}/tnsnames.ora.$$
+      MOUNT_POINTS="${MOUNT_POINTS},${WORKSPACE}/tnsnames.ora.$$:/etc/tnsnames.ora"
       break
     fi
   done


### PR DESCRIPTION
As discussed in https://github.com/apptainer/apptainer/issues/2328 , we think issue with failures like 
```
FATAL:   container creation failed: mount hook function failure: mount /etc/tnsnames.ora->/etc/tnsnames.ora error: while mounting /etc/tnsnames.ora: destination /etc/tnsnames.ora doesn't exist in container
```
are due to the update of `/etc/tnsnames.ora` on host by puppet.

This PR proposes to make a copy of /etc/tnsnames.ora and then mount that copy in side container. This why any update of /etc/tnsnames.ora by puppet will not change the mounted copy. 

This might be a fix/workaround for the https://github.com/cms-sw/cmssw/issues/45501 issue