### PR TITLE
Fix installation of RISC-V IBs

### DIFF
--- a/cvmfsInstall.sh
+++ b/cvmfsInstall.sh
@@ -60,6 +60,7 @@ REPOSITORIES=`tail -${NUM_WEEKS} ib-weeks | sed -e's/-\([0-9]\)$/-0\1/' | sort -
 echo $REPOSITORIES
 $CVMFS_INSTALL && cvmfs_transaction ${CVMFS_PUBLISH_PATH}
 
+mkdir -p $BASEDIR
 hostname > $BASEDIR/stratum0
 
 #Recreate the links


### PR DESCRIPTION
ib-install-cvmfs fails for riscv IBs: `cvmfsInstall.sh: line 63: /cvmfs/cms-ib.cern.ch/sw/riscv64/stratum0: No such file or directory`