### PR TITLE
Update categories_map.py to assign category for GeometryAligner

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -816,6 +816,7 @@ CMSSW_CATEGORIES = {
         "Geometry/ForwardSimData",
         "Geometry/GEMGeometry",
         "Geometry/GEMGeometryBuilder",
+        "Geometry/GeometryAligner",
         "Geometry/GlobalTrackingGeometryBuilder",
         "Geometry/HGCalCommonData",
         "Geometry/HGCalGeometry",


### PR DESCRIPTION
The GeometryAligner.h has to be moved from Geometry/CommonTopologies to avoid unusual dependencies