### PR TITLE
Add Particle Flow DQM package to CMSSW categories

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -606,6 +606,7 @@ CMSSW_CATEGORIES = {
         "DQMOffline/PFTau",
         "DQMOffline/RecoB",
         "DQMOffline/Trigger",
+        "DQMOffline/ParticleFlow",
         "DQMServices/ClientConfig",
         "DQMServices/Components",
         "DQMServices/Core",


### PR DESCRIPTION
This PR add the new DQMOffline/ParticleFlow package in the [categories_map.py](https://github.com/cms-sw/cms-bot/blob/master/categories_map.py), introduced by the PR https://github.com/cms-sw/cmssw/pull/45667 .

@jroloff @swagata87 