### PR TITLE
Fix one misspelled word in Jenkins parser

### DIFF
--- a/jenkins/jenkins-check-nodes.sh
+++ b/jenkins/jenkins-check-nodes.sh
@@ -118,7 +118,7 @@ function notify_failure {
     node_off_list=$@
     job_description="This job runs a sanity check for /afs, /cvmfs repositories and singularity."
     node_info="Jenkins nodes ${node_off_list[@]} have been marked offline since they where connected to host ${node}."
-    error_msg="Node ${node} has been blacklisted by ${job_url}/console. Please, take the appropiate action. ${node_info} ${job_description}"
+    error_msg="Node ${node} has been blacklisted by ${job_url}/console. Please, take the appropriate action. ${node_info} ${job_description}"
     echo $error_msg | mail -s "Node ${node} has been blacklisted" $email
 }
 
@@ -180,7 +180,7 @@ function lxplus_offline_cleanup {
             echo "No offline nodes found ... Skipping cleanup!"
             break
         fi
-        echo "Offline file found for $node_name ... Cleannig up, if needed."
+        echo "Offline file found for $node_name ... Cleaning up, if needed."
         node_info=$(curl -H "OIDC_CLAIM_CERN_UPN: cmssdt" "${LOCAL_JENKINS_URL}/computer/$node_name/api/json?pretty=true")
         node_tempoffline=$(echo $node_info | grep '"temporarilyOffline" : true' | wc -l)
         if [ $node_tempoffline -eq 0 ]; then $(rm -rf $file) && continue; fi # External action has been taken

--- a/jenkins/parser/actions.py
+++ b/jenkins/parser/actions.py
@@ -126,7 +126,7 @@ def trigger_nodeoff_action(job_to_retry, build_to_retry, job_url, node_name):
         + job_to_retry
         + " "
         + build_to_retry
-        + " 'Node\ marked\ as\ offline\ and\ job\ retried.\ Please,\ take\ the\ appropiate\ action\ and\ relaunch\ the\ node.\ Also,\ make\ sure\ that\ the\ job\ is\ running\ fine\ now.\ It\ might\ be\ queueing.'"
+        + " 'Node\ marked\ as\ offline\ and\ job\ retried.\ Please,\ take\ the\ appropriate\ action\ and\ relaunch\ the\ node.\ Also,\ make\ sure\ that\ the\ job\ is\ running\ fine\ now.\ It\ might\ be\ queueing.'"
     )
     print(update_label)
     os.system(update_label)
@@ -167,7 +167,7 @@ def notify_nodeoff(node_name, regex, job_to_retry, build_to_retry, job_url, node
         + job_to_retry
         + " build number "
         + build_to_retry
-        + ".\nPlease, take the appropiate action.\n\nFailed job: "
+        + ".\nPlease, take the appropriate action.\n\nFailed job: "
         + job_url
         + "\n\nDisconnected node: "
         + node_url
@@ -190,7 +190,7 @@ def notify_nodereconnect(
         + job_to_retry
         + " build number "
         + build_to_retry
-        + ".\nPlease, take the appropiate action.\n\nFailed job: "
+        + ".\nPlease, take the appropriate action.\n\nFailed job: "
         + job_url
         + "\n\nAffected node: "
         + node_url
@@ -211,7 +211,7 @@ def notify_pendingbuild(display_name, build_to_retry, job_to_retry, duration, jo
         + job_to_retry
         + " has been running for an unexpected amount of time.\nTotal running time: "
         + str(duration)
-        + ".\nPlease, take the appropiate action.\n\nPending job: "
+        + ".\nPlease, take the appropriate action.\n\nPending job: "
         + job_url
         + "\n\nParser job: "
         + parser_url
@@ -265,7 +265,7 @@ def notify_noaction(display_name, job_to_retry, build_to_retry, job_url):
         + job_to_retry
         + ","
         + display_name
-        + ".\nNo action has been taken by parser job. Please, take the appropiate action.\n\nFailed job: "
+        + ".\nNo action has been taken by parser job. Please, take the appropriate action.\n\nFailed job: "
         + job_url
     )
     email_subject = "Build failed in Jenkins: " + job_to_retry + " " + display_name

--- a/jenkins/parser/jenkins-parser-job.py
+++ b/jenkins/parser/jenkins-parser-job.py
@@ -13,7 +13,7 @@ import actions
 
 
 def process_build(build, job_dir, job_to_retry, error_list, retry_object, retry_delay):
-    """Process finished build. If failed, check for known erros. If succeed, check if it is a retried build to update its description."""
+    """Process finished build. If failed, check for known errors. If succeed, check if it is a retried build to update its description."""
     if helpers.grep(
         functools.reduce(os.path.join, [job_dir, build, "build.xml"]),
         "<result>FAILURE",
@@ -30,7 +30,7 @@ def process_build(build, job_dir, job_to_retry, error_list, retry_object, retry_
 def check_and_trigger_action(
     build_to_retry, job_dir, job_to_retry, error_list_action, retry_object, retry_delay
 ):
-    """Check build logs and trigger the appropiate action if a known error is found."""
+    """Check build logs and trigger the appropriate action if a known error is found."""
     build_dir_path = os.path.join(job_dir, build_to_retry)
     log_file_path = os.path.join(build_dir_path, "log")
     envvars_file_path = os.path.join(build_dir_path, "injectedEnvVars.txt")
@@ -158,7 +158,7 @@ def check_and_trigger_action(
             html_file_path,
             job_to_retry,
             build_to_retry,
-            "No error found. Please, take the appropiate action",
+            "No error found. Please, take the appropriate action",
             job_url,
             "[ No action taken ]",
             "NoAction",

--- a/jenkins/parser/jenkins-parser-monitor-job.py
+++ b/jenkins/parser/jenkins-parser-monitor-job.py
@@ -107,7 +107,7 @@ with open(
    <body>\n\
       <h1>Jenkins Parser Monitoring</h1>\n\
       <p>The table below displays the activity of the <a href="https://cmssdt.cern.ch/jenkins/job/jenkins-test-parser/">Jenkins Parser job</a>.</p>\n\
-      <p>Red entries correspond to failed jobs where the Jenkins Parser has not taken any action. Please, take the appropiate action in those cases. White entries correspond to jobs retried by the Parser because a known Error Message was found in the log.</p>\n\
+      <p>Red entries correspond to failed jobs where the Jenkins Parser has not taken any action. Please, take the appropriate action in those cases. White entries correspond to jobs retried by the Parser because a known Error Message was found in the log.</p>\n\
       <input type="text" id="SearchBar" onkeyup="myFunction()" placeholder="Filter by job name ..." title="Type job name">\n\
       <table id="Table" class="Table">\n\
          <tr class="header">\n\
@@ -208,7 +208,7 @@ with open(
       <p> </p>\n\
       <h1>Jenkins Blacklist</h1>\n\
       <p>The table below displays the blacklisted nodes in our Jenkins infrastructure. There is a <a href="https://cmssdt.cern.ch/jenkins/job/nodes-sanity-check/">sanity job</a> that checks if CernVM-FS repositories are accessible and if singularity can start a container on the nodes. If not, the node is blacklisted and displayed in the table below.</p>\n\
-      <p>If the table entry is red, please take the appropiate action (open a SNOW ticket, run the start_cvmfs.sh script on aarch64 machines, etc) and re-run the sanity job to take the node out of the blacklist. In any case, the sanity job automatically runs every 30 min.</p>\n\
+      <p>If the table entry is red, please take the appropriate action (open a SNOW ticket, run the start_cvmfs.sh script on aarch64 machines, etc) and re-run the sanity job to take the node out of the blacklist. In any case, the sanity job automatically runs every 30 min.</p>\n\
       <p> </p>\n\
       <table id="Offline" class="Table">\n\
          <tr class="header">\n\

--- a/jenkins/parser/jenkins-retry-job.py
+++ b/jenkins/parser/jenkins-retry-job.py
@@ -145,7 +145,7 @@ retry_label = (
 )
 
 nodeoff_label = (
-    "Node'\ 'marked'\ 'as'\ 'offline'\ 'and'\ 'job'\ 'retried.'\ 'Please,'\ 'take'\ 'the'\ 'appropiate'\ 'action'\ 'and'\ 'relaunch'\ 'the'\ 'node.'\ 'Also,'\ 'make'\ 'sure'\ 'that'\ 'the'\ 'job'\ 'is'\ 'running'\ 'fine'\ 'now.'\ 'Job'\ 'has'\ 'been'\ 'retried'\ '"
+    "Node'\ 'marked'\ 'as'\ 'offline'\ 'and'\ 'job'\ 'retried.'\ 'Please,'\ 'take'\ 'the'\ 'appropriate'\ 'action'\ 'and'\ 'relaunch'\ 'the'\ 'node.'\ 'Also,'\ 'make'\ 'sure'\ 'that'\ 'the'\ 'job'\ 'is'\ 'running'\ 'fine'\ 'now.'\ 'Job'\ 'has'\ 'been'\ 'retried'\ '"
     + str(retry_counter_update)
     + "'\ '"
     + times


### PR DESCRIPTION
I fixed all the places I saw 'appropiate' in cms-bot, and I don't think it's parsing any output for this specific misspelled word from other projects like CMSSW.