### PR TITLE
avoid duplication in l2 list

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -2189,6 +2189,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
             for signature in new_assign_cats
             if signature in l2_categories
         ]
+        new_l2s = sorted(set(new_l2s), key=lambda s: s.lower())
         if not dryRun:
             issue.create_comment(
                 "New categories assigned: "

--- a/tests/PRActionData/TestProcessPr.test_assign.json
+++ b/tests/PRActionData/TestProcessPr.test_assign.json
@@ -80,7 +80,7 @@
     },
     {
         "type": "create-comment",
-        "data": "New categories assigned: dqm,db\n\nrvenditti,syuvivida,tjavaid,nothingface0,antoniovagnerini,francescobrivio,saumyaphor4252,perrotta,consuegs you have been requested to review this Pull request/Issue and eventually sign? Thanks"
+        "data": "New categories assigned: dqm,db\n\nantoniovagnerini,consuegs,francescobrivio,nothingface0,perrotta,rvenditti,saumyaphor4252,syuvivida,tjavaid you have been requested to review this Pull request/Issue and eventually sign? Thanks"
     },
     {
         "type": "add-label",


### PR DESCRIPTION
I noticed in https://github.com/cms-sw/cmssw/issues/46113 that the list of tagged L2s could contain duplicates when multiple categories are assigned.

I chose the most broadly compatible approach (works across Python 2 and 3) to remove the duplicates, preserving the order to be as consistent as possible with previous behavior. Tested in standalone Python and it works as expected.