### PR TITLE
automatically approve operations on tests passed

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -157,6 +157,9 @@ CMSSW_L2 = {
     "y19y19": ["ml"],
 }
 
+# Automatically sign these categories if tests are passed
+CATS_TO_APPROVE_ON_TEST = ["operations"]
+
 # All CMS_SDT members can sign externals ( e.g Pull Requests in cms-sw/cmsdist , cms-data and cms-externals
 for user in CMS_SDT:
     if user not in CMSSW_L2:

--- a/process_pr.py
+++ b/process_pr.py
@@ -49,7 +49,10 @@ try:
     from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
     from yaml import Loader, Dumper
-
+try:
+    from categories import CATS_TO_APPROVE_ON_TEST
+except:
+    CATS_TO_APPROVE_ON_TEST = []
 try:
     from categories import CMSSW_LABELS
 except:
@@ -2080,6 +2083,16 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
     if override_tests_failure and signatures["tests"] == "rejected":
         signatures["tests"] = "approved"
         labels.append("tests-" + override_tests_failure)
+
+    # automatically approve CATS_TO_APPROVE_ON_TEST on test-approved
+    if ("tests" in signatures) and (signatures["tests"] == "approved"):
+        for cat in [
+            c
+            for c in CATS_TO_APPROVE_ON_TEST
+            if ((c in signatures) and (signatures[c] == "pending"))
+        ]:
+            signatures[cat] = "approved"
+            print("Overriding/Approving singatures for %s due to tests-approved" % cat)
 
     for cat in signing_categories:
         l = cat + "-pending"

--- a/process_pr.py
+++ b/process_pr.py
@@ -2086,11 +2086,7 @@ def process_pr(repo_config, gh, repo, issue, dryRun, cmsbuild_user=None, force=F
 
     # automatically approve CATS_TO_APPROVE_ON_TEST on test-approved
     if ("tests" in signatures) and (signatures["tests"] == "approved"):
-        for cat in [
-            c
-            for c in CATS_TO_APPROVE_ON_TEST
-            if ((c in signatures) and (signatures[c] == "pending"))
-        ]:
+        for cat in [c for c in CATS_TO_APPROVE_ON_TEST if (signatures.get(c) == "pending")]:
             signatures[cat] = "approved"
             print("Overriding/Approving singatures for %s due to tests-approved" % cat)
 


### PR DESCRIPTION
@cms-sw/orp-l2 , as discussed, this PR should allow to automatically sign `operations` when tests are passed. 