### PR TITLE
Add "ngt" label

### DIFF
--- a/githublabels.py
+++ b/githublabels.py
@@ -41,6 +41,7 @@ TYPE_COMMANDS = {
         "performance|improvements|performance-improvements",
         "mtype",
     ],
+    "ngt": [LABEL_COLORS["performance"], "ngt", "mtype"],
 }
 
 for lab in get_dpg_pog():


### PR DESCRIPTION
Add the `ngt` label, to support the `type ngt` bot command.