### PR TITLE
Add known failure for RV 182.1 step 1 - arch incompatibility

### DIFF
--- a/cmssw_known_errors.py
+++ b/cmssw_known_errors.py
@@ -181,6 +181,7 @@ KNOWN_ERRORS["relvals"][RelFilter] = {}
 KNOWN_ERRORS["relvals"][RelFilter][".+_(aarch64|ppc64le)_.+"] = {
     "180.1": {"step": 3, "exitcode": 16640, "reason": MSG_TRITON_INCOMPETIBILITY},
     "181.1": {"step": 3, "exitcode": 16640, "reason": MSG_TRITON_INCOMPETIBILITY},
+    "182.1": {"step": 1, "exitcode": 16640, "reason": MSG_ARCH_INCOMPETIBILITY},
     "2500.912": {"step": 1, "exitcode": 16640, "reason": MSG_ARCH_INCOMPETIBILITY},
     "2500.913": {"step": 1, "exitcode": 16640, "reason": MSG_ARCH_INCOMPETIBILITY},
 }


### PR DESCRIPTION
Example of error: https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_aarch64_gcc12/CMSSW_15_0_X_2024-12-15-0000/pyRelValMatrixLogs/run/182.1_Starlight_DoubleDiffraction_5360_UPC_2025/step1_Starlight_DoubleDiffraction_5360_UPC_2025.log#/116