### PR TITLE
Set X509_USER_KEY and X509_USER_CERT for lumi …

### DIFF
--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -108,7 +108,7 @@ if [ "X$DOCKER_IMG" != X -a "X$RUN_NATIVE" = "X" ]; then
     case $XUSER in
       cmsbld ) DOCKER_OPT="${DOCKER_OPT} -u $(id -u):$(id -g) -v /etc/passwd:/etc/passwd -v /etc/group:/etc/group" ;;
     esac
-    for e in $DOCKER_JOB_ENV GIT_CONFIG_NOSYSTEM WORKSPACE BUILD_URL BUILD_NUMBER JOB_NAME NODE_NAME NODE_LABELS DOCKER_IMG RUCIO_ACCOUNT X509_USER_PROXY; do DOCKER_OPT="${DOCKER_OPT} -e $e"; done
+    for e in $DOCKER_JOB_ENV GIT_CONFIG_NOSYSTEM WORKSPACE BUILD_URL BUILD_NUMBER JOB_NAME NODE_NAME NODE_LABELS DOCKER_IMG RUCIO_ACCOUNT X509_USER_PROXY X509_USER_KEY X509_USER_CERT; do DOCKER_OPT="${DOCKER_OPT} -e $e"; done
     if [ "${PYTHONPATH}" != "" ] ; then DOCKER_OPT="${DOCKER_OPT} -e PYTHONPATH" ; fi
     for m in $(echo $MOUNT_POINTS,/etc/localtime,${BUILD_BASEDIR},/home/$XUSER | tr ',' '\n') ; do
       x=$(echo $m | sed 's|:.*||')

--- a/lumi/get_slot.sh
+++ b/lumi/get_slot.sh
@@ -38,6 +38,8 @@ klist || true
 export X509_CERT_DIR=/cvmfs/grid.cern.ch/etc/grid-security/certificates
 export X509_VOMS_DIR=/cvmfs/grid.cern.ch/etc/grid-security/vomsdir
 export VOMS_USERCONF=/cvmfs/grid.cern.ch/etc/grid-security/vomses
+export X509_USER_KEY=$HOME/cmsbuild/.globus/userkey.pem
+export X509_USER_CERT=$HOME/cmsbuild/.globus/usercert.pem
 
 echo "#########################################"
 


### PR DESCRIPTION
…and pass these variables to container. This should fix `FallbackFileOpenError` errors in ROCM_X IBs ( like [this one](https://cmssdt.cern.ch/SDT/cgi-bin/logreader/el8_amd64_gcc12/CMSSW_15_0_ROCM_X_2025-01-19-2300/pyRelValMatrixLogs/run/141.044406_Run3-2023_JetMET2023D_RecoPixelOnlyTripletsGPU/step2_Run3-2023_JetMET2023D_RecoPixelOnlyTripletsGPU.log#/95-95) )