### PR TITLE
Automatically kill stuck PR tests and report back

### DIFF
--- a/kill-stuck-pr-test.sh
+++ b/kill-stuck-pr-test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -ex
+source ${CMS_BOT_DIR}/jenkins-artifacts
+source ${CMS_BOT_DIR}/pr_testing/_helper_functions.sh
+rm -f *.prop
+
+if [ "X${UPLOAD_UNIQUE_ID}" = "X" ] ; then exit 0 ; fi
+if [ "X${PULL_REQUEST}" = "X" ] ; then exit 0 ; fi
+
+REPOSITORY=$(echo ${PULL_REQUEST} | cut -d '#' -f 1)
+PR_ID=$(echo ${PULL_REQUEST} | cut -d '#' -f 2)
+
+COMMIT_ID=$(grep ${ARTIFACT_BASE_DIR_MAIN}/pull-request-integration/${UPLOAD_UNIQUE_ID}/prs_commits.txt -e "^${PULL_REQUEST}=")
+if [ "X${COMMIT_ID}" = "X" ] ; then exit 0 ; fi
+
+${CMS_BOT_DIR}/update-commit-statuses-matching.py -r ${REPOSITORY} -c ${COMMIT_ID} -p ${CONTEXT} ${TEST_FLAVOR}
+
+touch abort-jenkins-job.prop
+echo "JENKINS_PROJECT_TO_KILL=${JENKINS_PROJECT_TO_KILL}" >> abort-jenkins-job.prop
+echo "JENKINS_PROJECT_PARAMS=${JENKINS_PROJECT_PARAMS}" >> abort-jenkins-job.prop
+echo "EXTRA_PARAMS=${EXTRA_PARAMS}" >> abort-jenkins-job.prop
+
+###########################################################
+UC_TEST_FLAVOR=$(echo "${TEST_FLAVOR}" | tr 'a-z' 'A-Z')
+
+echo "MATRIX${UC_TEST_FLAVOR}_TESTS;ERROR,Matrix ${UC_TEST_FLAVOR} Tests Outputs,Timed out waiting for node,none" > ${ARTIFACT_BASE_DIR_MAIN}/pull-request-integration/${UPLOAD_UNIQUE_ID}/testsResults/$(get_status_file_name relval "${TEST_FLAVOR}")
+echo "RelVals-${UC_TEST_FLAVOR}" > ${ARTIFACT_BASE_DIR_MAIN}/pull-request-integration/${UPLOAD_UNIQUE_ID}/testsResults/$(get_result_file_name relval "${TEST_FLAVOR}" failed)
+echo "${TEST_FLAVOR}_UNIT_TEST_RESULTS;ERROR,${UC_TEST_FLAVOR} GPU Unit Tests,Timed out waiting for node,none" > ${ARTIFACT_BASE_DIR_MAIN}/pull-request-integration/${UPLOAD_UNIQUE_ID}/testsResults/$(get_status_file_name utest "${TEST_FLAVOR}")
+echo "${TEST_FLAVOR}UnitTests" > ${ARTIFACT_BASE_DIR_MAIN}/pull-request-integration/${UPLOAD_UNIQUE_ID}/testsResults/$(get_result_file_name utest "${TEST_FLAVOR}" failed)

--- a/parse_jenkins_builds.json
+++ b/parse_jenkins_builds.json
@@ -1,0 +1,5 @@
+{
+"whitelist": ["ib-run-pr-unittests", "ib-run-pr-relvals", "ib-run-baseline"],
+"timeout": 3600,
+"custom": {}
+}

--- a/pr_testing/_helper_functions.sh
+++ b/pr_testing/_helper_functions.sh
@@ -134,6 +134,63 @@ function is_in_array() {
     return 1  # No match
 }
 
+function get_status_file_name () {
+  # get_status_file_name TEST_TYPE TEST_FLAVOR
+  [ $# -eq 2 ] || return 1
+
+  TEST_TYPE=$1; shift;
+  TEST_FLAVOR=$1; shift;
+
+  UC_TEST_FLAVOR=$(echo "${TEST_FLAVOR}" | tr 'a-z' 'A-Z')
+
+  case $TEST_TYPE in
+    relval)
+      echo "relval${UC_TEST_FLAVOR}.txt"
+      return 0
+      ;;
+    utest)
+      echo "unittest${TEST_FLAVOR}.txt"
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+function get_result_file_name () {
+  # get_result_file_name TEST_TYPE TEST_FLAVOR SUFFIX
+  [ $# -eq 3 ] || return 1
+
+  TEST_TYPE=$1; shift;
+  TEST_FLAVOR=$1; shift;
+  SUFFIX=$1
+
+  UC_TEST_FLAVOR=$(echo "${TEST_FLAVOR}" | tr 'a-z' 'A-Z')
+
+  case $TEST_TYPE in
+    relval)
+      echo "12${UC_TEST_FLAVOR}-relvals-${SUFFIX}.res"
+      return 0
+      ;;
+    utest)
+      echo "14-${TEST_FLAVOR}-${SUFFIX}.res"
+      return 0
+      ;;
+    comp)
+      if [ "$TEST_FLAVOR" != "" ]; then
+        echo "20-${TEST_FLAVOR}-comparison-report.res"
+      else
+        echo "20-comparison-report.res"
+      fi
+      return 0
+      ;;
+    compnano)
+      echo "21-${TEST_FLAVOR}-comparison-report.res"
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 function get_gpu_matrix_args() {
   GPU_FLAG=""
   if runTheMatrix.py --help | grep -q '\-\-gpu' ; then

--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -592,18 +592,19 @@ sed -i "s/^COMPARISON${TEST_FLAVOR_STR};RUNNING,/COMPARISON${TEST_FLAVOR_STR};$B
 mv ${RESULTS_FILE} $WORKSPACE/testsResults/
 
 [ -e comparisonDetails.txt ] && mv comparisonDetails.txt upload/
+REPORT_FILE=$WORKSPACE/testsResults/$(get_result_file_name "comp" "${TEST_FLAVOR}" "")
+NANO_REPORT_FILE=$WORKSPACE/testsResults/$(get_result_file_name "compnano" "${TEST_FLAVOR}" "")
 ${CMS_BOT_DIR}/report-pull-request-results "COMPARISON_READY" --report-url ${PR_RESULT_URL} \
   -f $WORKSPACE/${ERRORS_FILE} --f2 $WORKSPACE/wf_non_consistent_das.txt \
-  --missing_map $WORKSPACE/results/JR-comparison/missing_map.txt  --report-file $WORKSPACE/testsResults/20-comparison-report.res
+  --missing_map $WORKSPACE/results/JR-comparison/missing_map.txt  --report-file $REPORT_FILE
 
 if [ "${TEST_FLAVOR}" != "" ] ; then
-  sed -i -e "s|## Comparison Summary|## ${UC_TEST_FLAVOR} Comparison Summary|" $WORKSPACE/testsResults/20-comparison-report.res
-  mv $WORKSPACE/testsResults/20-comparison-report.res $WORKSPACE/testsResults/20-${TEST_FLAVOR}-comparison-report.res
+  sed -i -e "s|## Comparison Summary|## ${UC_TEST_FLAVOR} Comparison Summary|" $REPORT_FILE
   if [ -e $WORKSPACE/upload/nano/NANO_report.md ] ; then
-    echo "**Nano size comparison Summary**:" >> $WORKSPACE/testsResults/21-${TEST_FLAVOR}-comparison-report.res
-    echo "" >> $WORKSPACE/testsResults/21-${TEST_FLAVOR}-comparison-report.res
-    cat $WORKSPACE/upload/nano/NANO_report.md >> $WORKSPACE/testsResults/21-${TEST_FLAVOR}-comparison-report.res
-    echo "" >> $WORKSPACE/testsResults/21-${TEST_FLAVOR}-comparison-report.res
+    echo "**Nano size comparison Summary**:" >> $NANO_REPORT_FILE
+    echo "" >> $NANO_REPORT_FILE
+    cat $WORKSPACE/upload/nano/NANO_report.md >> $NANO_REPORT_FILE
+    echo "" >> $NANO_REPORT_FILE
   fi
 fi
 

--- a/pr_testing/run-pr-relvals.sh
+++ b/pr_testing/run-pr-relvals.sh
@@ -79,27 +79,30 @@ popd
 TEST_ERRORS=$(grep -ai -E "ERROR .*" ${LOG} | grep -v 'DAS QL ERROR' | grep -v 'ERROR failed to parse X509 proxy') || true
 GENERAL_ERRORS=`grep -a "ALL_OK" ${LOG}` || true
 
+RESULT_FILE_NAME=$(get_result_file_name relval "${TEST_FLAVOR}" results)
+FAILED_FILE_NAME=$(get_result_file_name relval "${TEST_FLAVOR}" failed)
+
 if [ "X$TEST_ERRORS" != "X" -o "X$GENERAL_ERRORS" = "X" ]; then
   echo "Errors in the RelVals"
-  echo "MATRIX${UC_TEST_FLAVOR}_TESTS;ERROR,Matrix ${UC_TEST_FLAVOR} Tests Outputs,See Logs,runTheMatrix${UC_TEST_FLAVOR}-results" >> ${RESULTS_DIR}/relval${UC_TEST_FLAVOR}.txt
+  echo "MATRIX${UC_TEST_FLAVOR}_TESTS;ERROR,Matrix ${UC_TEST_FLAVOR} Tests Outputs,See Logs,runTheMatrix${UC_TEST_FLAVOR}-results" >> ${RESULTS_DIR}/$(get_status_file_name relval "$TEST_FLAVOR")
   ALL_OK=false
   RELVALS_OK=false
-  $CMS_BOT_DIR/report-pull-request-results PARSE_MATRIX_FAIL -f ${LOG} --report-file ${RESULTS_DIR}/12${UC_TEST_FLAVOR}-relvals-report.res --report-url ${PR_RESULT_URL} $NO_POST
-  if [ $(grep -v '## RelVals' ${RESULTS_DIR}/12${UC_TEST_FLAVOR}-relvals-report.res | grep -v '^ *$' | wc -l) -eq 0 ] ; then
-    echo -e "## RelVals\n\n\`\`\`\n${TEST_ERRORS}\n\`\`\`\n" > ${RESULTS_DIR}/12${UC_TEST_FLAVOR}-relvals-report.res
+  $CMS_BOT_DIR/report-pull-request-results PARSE_MATRIX_FAIL -f ${LOG} --report-file ${RESULTS_DIR}/${RESULT_FILE_NAME} --report-url ${PR_RESULT_URL} $NO_POST
+  if [ $(grep -v '## RelVals' ${RESULTS_DIR}/${RESULT_FILE_NAME} | grep -v '^ *$' | wc -l) -eq 0 ] ; then
+    echo -e "## RelVals\n\n\`\`\`\n${TEST_ERRORS}\n\`\`\`\n" > ${RESULTS_DIR}/${RESULT_FILE_NAME}
   fi
   if [ "${TEST_FLAVOR}" != "" ] ; then
-    sed -i -e "s|## RelVals|## RelVals-${UC_TEST_FLAVOR}|;s|/runTheMatrix-results|/runTheMatrix${UC_TEST_FLAVOR}-results|g" ${RESULTS_DIR}/12${UC_TEST_FLAVOR}-relvals-report.res
-    echo "RelVals-${UC_TEST_FLAVOR}" > ${RESULTS_DIR}/12${UC_TEST_FLAVOR}-relvals-failed.res
+    sed -i -e "s|## RelVals|## RelVals-${UC_TEST_FLAVOR}|;s|/runTheMatrix-results|/runTheMatrix${UC_TEST_FLAVOR}-results|g" ${RESULTS_DIR}/${RESULT_FILE_NAME}
+    echo "RelVals-${UC_TEST_FLAVOR}" > ${RESULTS_DIR}/${FAILED_FILE_NAME}
   else
-    echo "RelVals" > ${RESULTS_DIR}/12${UC_TEST_FLAVOR}-relvals-failed.res
+    echo "RelVals" > ${RESULTS_DIR}/${FAILED_FILE_NAME}
   fi
   mark_commit_status_all_prs "${GH_COMP_CONTEXT}" 'success' -d "Not run due to failure in relvals" ${MARK_OPTS}
 else
-  touch ${RESULTS_DIR}/12${UC_TEST_FLAVOR}-relvals-failed.res
-  touch ${RESULTS_DIR}/12${UC_TEST_FLAVOR}-relvals-report.res
+  touch ${RESULTS_DIR}/${FAILED_FILE_NAME}
+  touch ${RESULTS_DIR}/${RESULT_FILE_NAME}
   echo "no errors in the RelVals!!"
-  echo "MATRIX${UC_TEST_FLAVOR}_TESTS;OK,Matrix ${UC_TEST_FLAVOR} Tests Outputs,See Logs,runTheMatrix${UC_TEST_FLAVOR}-results" >> ${RESULTS_DIR}/relval${UC_TEST_FLAVOR}.txt
+  echo "MATRIX${UC_TEST_FLAVOR}_TESTS;OK,Matrix ${UC_TEST_FLAVOR} Tests Outputs,See Logs,runTheMatrix${UC_TEST_FLAVOR}-results" >> ${RESULTS_DIR}/$(get_status_file_name relval "$TEST_FLAVOR")
 
   if $DO_COMPARISON ; then
     echo "COMPARISON${UC_TEST_FLAVOR};QUEUED,Comparison ${UC_TEST_FLAVOR} with the baseline,See results,See results" >> ${RESULTS_DIR}/comparison${UC_TEST_FLAVOR}.txt

--- a/update-commit-statues-matching.py
+++ b/update-commit-statues-matching.py
@@ -1,0 +1,36 @@
+import github_utils
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", "-r")
+    parser.add_argument("--commit", "-c")
+    parser.add_argument("--prefix", "-p")
+    parser.add_argument("suffix")
+    args = parser.parse_args()
+
+    status_prefix = f"{args.prefix}/"
+
+    all_statuses = github_utils.get_combined_statuses(args.commit, args.repository).get(
+        "statuses", []
+    )
+
+    for status in all_statuses:
+        if (
+            status["context"].startswith(status_prefix)
+            and status["context"].endswith(f"/{args.suffix}")
+            and status["state"] == "pending"
+        ):
+            github_utils.mark_commit_status(
+                args.commit,
+                args.repository,
+                status["context"],
+                "success",
+                "",
+                "Timed out waiting for node",
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Split from #2418. For now, job list and criteria for killing builds are hardcoded. We can discuss how configurable do we want this job to be - for example, a dict mapping job name and filters on params to timeout.