### PR TITLE
Remove ex-CMS BTV accounts from some lists

### DIFF
--- a/repos/iarspider_cmssw/cmssw/groups.yaml
+++ b/repos/iarspider_cmssw/cmssw/groups.yaml
@@ -7,9 +7,7 @@ btv-pog:
   - JyothsnaKomaragiri
   - emilbols
   - andrzejnovak
-  - demuller
   - AlexDeMoor
-  - AnnikaStein
   - Ming-Yan
   - Senphy
 ecal-offline:

--- a/repos/iarspider_cmssw/cmssw/watchers.yaml
+++ b/repos/iarspider_cmssw/cmssw/watchers.yaml
@@ -1727,15 +1727,6 @@ a-kapoor:
   - DataFormats/EgammaReco
 SohamBhattacharya:
 - HLTrigger/Configuration/python/HLT_75e33
-AnnikaStein:
-- Configuration/Eras
-- DataFormats/NanoAOD
-- DPGAnalysis/Skims
-- PhysicsTools/MXNet
-- PhysicsTools/NanoAOD
-- PhysicsTools/ONNXRuntime
-- PhysicsTools/SelectorUtils
-- RecoJets/JetProducers
 jlidrych:
 - DataFormats/SiStrip
 - CUDADataFormats/SiStripCluster

--- a/watchers.yaml
+++ b/watchers.yaml
@@ -1721,15 +1721,6 @@ SohamBhattacharya:
 - HLTrigger/Configuration/python/HLT_75e33
 VourMa:
 - HLTrigger/Configuration/python/HLT_75e33
-AnnikaStein:
-- Configuration/Eras
-- DataFormats/NanoAOD
-- DPGAnalysis/Skims
-- PhysicsTools/MXNet
-- PhysicsTools/NanoAOD
-- PhysicsTools/ONNXRuntime
-- PhysicsTools/SelectorUtils
-- RecoJets/JetProducers
 jlidrych:
 - DataFormats/SiStrip
 - CUDADataFormats/SiStripCluster


### PR DESCRIPTION
Small cleanup, removing previous BTV conveners and contacts that have left CMS and still receive notifications.