### PR TITLE
override voms-cms-auth.app.cern.ch to avoid using voms-cms-auth.app.cern.ch

### DIFF
--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -64,7 +64,11 @@ if [ "X$DOCKER_IMG" != X -a "X$RUN_NATIVE" = "X" ]; then
   BUILD_BASEDIR=$(dirname $WORKSPACE)
   export KRB5CCNAME=$(klist | grep 'Ticket cache: FILE:' | sed 's|.* ||')
   MOUNT_POINTS="/cvmfs,/tmp,$(echo $WORKSPACE | cut -d/ -f1,2),/var/run/user,/run/user,/etc/pki/ca-trust,${EXTRA_MOUNTS}"
-  for xdir in /cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security /cvmfs/grid.cern.ch/etc/grid-security/vomses:/etc/vomses ; do
+  grid_dirs="/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security /cvmfs/grid.cern.ch/etc/grid-security/vomses:/etc/vomses"
+  if [ -e "/cvmfs/grid.cern.ch/etc/grid-security/vomses/voms-cms-auth.app.cern.ch" ] ; then
+    grid_dirs="${grid_dirs} /cvmfs/grid.cern.ch/etc/grid-security/vomses/voms-cms-auth.cern.ch:/etc/vomses/voms-cms-auth.app.cern.ch"
+  fi
+  for xdir in ${grid_dirs} ; do
     ldir=$(echo $xdir | sed 's|.*:||')
     if [ $(echo "${IGNORE_MOUNTS}" | tr ' ' '\n' | grep "^${ldir}$" | wc -l) -gt 0 ] ; then
       continue


### PR DESCRIPTION
See https://cms-talk.web.cern.ch/t/voms-proxy-and-token-issuer-service-change/42807/3

