### PR TITLE
override cpu count via JENKINS_AGENT_CORES

### DIFF
--- a/cmsutils.py
+++ b/cmsutils.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from _py2with3compatibility import run_cmd
-from os import getcwd
+from os import getcwd, environ
 from time import asctime, time, strftime, gmtime
 import sys, re
 from sys import platform
@@ -36,6 +36,8 @@ def getHostName():
 
 
 def _getCPUCount():
+    if "JENKINS_AGENT_CORES" in os.environ:
+        return int(os.environ["JENKINS_AGENT_CORES"])
     cmd = "nproc"
     if platform == "darwin":
         cmd = "sysctl -n hw.ncpu"

--- a/cmsutils.py
+++ b/cmsutils.py
@@ -36,8 +36,8 @@ def getHostName():
 
 
 def _getCPUCount():
-    if "JENKINS_AGENT_CORES" in os.environ:
-        return int(os.environ["JENKINS_AGENT_CORES"])
+    if "JENKINS_AGENT_CORES" in environ:
+        return int(environ["JENKINS_AGENT_CORES"])
     cmd = "nproc"
     if platform == "darwin":
         cmd = "sysctl -n hw.ncpu"

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -1493,7 +1493,7 @@ if [ "X$DO_SHORT_MATRIX" = Xtrue ]; then
       ex_type_lc=$(echo ${ex_type} | tr '[A-Z]' '[a-z]')
       grep -v '^MATRIX_ARGS=' $WORKSPACE/run-relvals.prop > $WORKSPACE/run-relvals-${ex_type_lc}.prop
       echo "MATRIX_ARGS=$(get_pr_relval_args $DO_COMPARISON _${ex_type})" >> $WORKSPACE/run-relvals-${ex_type_lc}.prop
-      if [ "${ENABLE_MEMORY_PROFILE}" = "ture" -a "${ex_type}" = "ROCM" ] ; then
+      if [ "${ENABLE_MEMORY_PROFILE}" = "true" -a "${ex_type}" = "ROCM" ] ; then
         sed -i -e 's|RUN_THE_MATRIX_CMD_OPTS=\-\-maxmem_profile\s*|RUN_THE_MATRIX_CMD_OPTS=|' $WORKSPACE/run-relvals-${ex_type_lc}.prop
       fi
     done

--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -1462,8 +1462,16 @@ if [ "X$DO_SHORT_MATRIX" = Xtrue ]; then
   WF_COMMON="-s $(get_pr_relval_args $DO_COMPARISON '')"
   [ "${WORKFLOWS_PR_LABELS}" != "" ] && WF_COMMON="${WF_COMMON};-l ${WORKFLOWS_PR_LABELS}"
   echo "MATRIX_ARGS=${WF_COMMON}" >> $WORKSPACE/run-relvals.prop
-  if $ENABLE_MEMORY_PROFILE && cmsDriver.py --help | grep -q '\-\-maxmem_profile'  ; then
-    echo "RUN_THE_MATRIX_CMD_OPTS=--maxmem_profile ${EXTRA_MATRIX_COMMAND_ARGS}" >> $WORKSPACE/run-relvals.prop
+  FULL_MATRIX_ARGS="${EXTRA_MATRIX_COMMAND_ARGS}"
+  if  $ENABLE_MEMORY_PROFILE ; then
+    if cmsDriver.py --help | grep -q '\-\-maxmem_profile' ; then
+      FULL_MATRIX_ARGS="--maxmem_profile ${FULL_MATRIX_ARGS}"
+    else
+      ENABLE_MEMORY_PROFILE=false
+    fi
+  fi
+  if [ "${FULL_MATRIX_ARGS}" != "" ] ; then
+    echo "RUN_THE_MATRIX_CMD_OPTS=${FULL_MATRIX_ARGS}" >> $WORKSPACE/run-relvals.prop
   fi
 
   if [ $(echo ${ENABLE_BOT_TESTS} | tr ',' ' ' | tr ' ' '\n' | grep '^THREADING$' | wc -l) -gt 0 ] ; then
@@ -1485,6 +1493,9 @@ if [ "X$DO_SHORT_MATRIX" = Xtrue ]; then
       ex_type_lc=$(echo ${ex_type} | tr '[A-Z]' '[a-z]')
       grep -v '^MATRIX_ARGS=' $WORKSPACE/run-relvals.prop > $WORKSPACE/run-relvals-${ex_type_lc}.prop
       echo "MATRIX_ARGS=$(get_pr_relval_args $DO_COMPARISON _${ex_type})" >> $WORKSPACE/run-relvals-${ex_type_lc}.prop
+      if [ "${ENABLE_MEMORY_PROFILE}" = "ture" -a "${ex_type}" = "ROCM" ] ; then
+        sed -i -e 's|RUN_THE_MATRIX_CMD_OPTS=\-\-maxmem_profile\s*|RUN_THE_MATRIX_CMD_OPTS=|' $WORKSPACE/run-relvals-${ex_type_lc}.prop
+      fi
     done
     if [ $(runTheMatrix.py --help | grep '^ *--maxSteps' | wc -l) -eq 0 ] ; then
       mark_commit_status_all_prs "relvals/input" 'success' -u "${BUILD_URL}" -d "Not ran, runTheMatrix does not support --maxSteps flag" -e


### PR DESCRIPTION
- override cpu count via JENKINS_AGENT_CORES
- disable using `maxmem-profile` for rocm tests . Just like we do it for IB relvals https://github.com/cms-sw/cms-bot/blob/master/run-ib-pr-matrix.sh#L67-L69 