### PR TITLE
Add Raffaella Tramontano as EGM convener

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -133,7 +133,7 @@ CMSSW_L2 = {
     "bellan": ["pf"],
     "kdlong": ["pf"],
     "swagata87": ["pf"],
-    "afiqaize": ["egamma-pog"],
+    "Raffaella07": ["egamma-pog"],
     "RSalvatico": ["egamma-pog"],
     "kirschen": ["jetmet-pog"],
     "alkaloge": ["jetmet-pog"],


### PR DESCRIPTION
### PR description

Add Raffaella Tramontano as new EGM convener. Remove Afiq Anuar, since he left CMS.