### PR TITLE
Nano Comparison: Keep WF full name and forward it to .json files

### DIFF
--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -32,7 +32,7 @@ function process_nano(){
       WF_DIR=$(dirname $r)
       [ -e ${WF_DIR}/JobReport2.xml ] || continue
       while [ $(jobs -p | wc -l) -ge ${NUM_PROC} ] ; do sleep 0.1 ; done
-      WF=$(basename ${WF_DIR} | cut -d_ -f1)
+      WF=$(basename ${WF_DIR})
       CMD=inspectNanoFile.py
       [ -e ${NANO_TEST_DIR}/inspectNanoFile.py ] && CMD=${NANO_TEST_DIR}/inspectNanoFile.py
       ${CMD} $r -j ${WF}-size.json &


### PR DESCRIPTION
Currently the nano comparison report will shows only the WF number. The goal is to have the the full WF name available.

The table:

| Sample | kb/ev | ref kb/ev | diff kb/ev | ev/s/thd | ref ev/s/thd | diff rate | mem/thd | ref mem/thd |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 2500.238 | 2.595 | 2.501 | 0.094 ( +3.8% ) | 13.76 | 13.71 | +0.4% | 2.751 | 2.745 |

Will become:

| Sample | kb/ev | ref kb/ev | diff kb/ev | ev/s/thd | ref ev/s/thd | diff rate | mem/thd | ref mem/thd |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 2500.238_ScoutingNANOwithPromptdata140Xrun3 | 2.595 | 2.501 | 0.094 ( +3.8% ) | 13.76 | 13.71 | +0.4% | 2.751 | 2.745 |

Since I don´t know how to test this proposal in this repo, I'm placing this PR and hoping to test during review.

