### PR TITLE
Rpm db size issue

### DIFF
--- a/cvmfsInstall.sh
+++ b/cvmfsInstall.sh
@@ -9,7 +9,7 @@ function install_package() {
       echo "  Trying local DB"
       rm -rf ${WORKSPACE}/rpm
       mv $WORKDIR/${SCRAM_ARCH}/var/lib/rpm  ${WORKSPACE}/rpm
-      ln -d ${WORKSPACE}/rpm $WORKDIR/${SCRAM_ARCH}/var/lib/rpm
+      ln -s ${WORKSPACE}/rpm $WORKDIR/${SCRAM_ARCH}/var/lib/rpm
       rm -f ${WORKSPACE}/inst.log
       ${CMSPKG} install -y $@ 2>&1 | tee -a ${WORKSPACE}/inst.log 2>&1 || true
       rm -f $WORKDIR/${SCRAM_ARCH}/var/lib/rpm

--- a/cvmfsInstall.sh
+++ b/cvmfsInstall.sh
@@ -7,13 +7,12 @@ function install_package() {
     echo "ERROR: RPM DB error found"
     if [ "${USE_LOCAL_RPMDB}" = "true" ] ; then
       echo "  Trying local DB"
-      rm -rf ${WORKSPACE}/rpm
-      mv $WORKDIR/${SCRAM_ARCH}/var/lib/rpm  ${WORKSPACE}/rpm
-      ln -s ${WORKSPACE}/rpm $WORKDIR/${SCRAM_ARCH}/var/lib/rpm
+      mv $WORKDIR/${SCRAM_ARCH}/var/lib/rpm/Packages  ${WORKSPACE}/Packages
+      ln -s ${WORKSPACE}/Packages $WORKDIR/${SCRAM_ARCH}/var/lib/rpm/Packages
       rm -f ${WORKSPACE}/inst.log
       ${CMSPKG} install -y $@ 2>&1 | tee -a ${WORKSPACE}/inst.log 2>&1 || true
-      rm -f $WORKDIR/${SCRAM_ARCH}/var/lib/rpm
-      mv ${WORKSPACE}/rpm $WORKDIR/${SCRAM_ARCH}/var/lib/rpm
+      rm -f $WORKDIR/${SCRAM_ARCH}/var/lib/rpm/Packages
+      mv ${WORKSPACE}/Packages $WORKDIR/${SCRAM_ARCH}/var/lib/rpm/Packages
       echo "Copr RPM DB back"
       if [ $(grep 'cannot open Packages index using db6' ${WORKSPACE}/inst.log | wc -l) -gt 0 ] ; then
         echo "Still has RPM DB error"
@@ -171,9 +170,9 @@ for REPOSITORY in $REPOSITORIES; do
       if [ "X$RELEASE_NAME" != "X" ] ; then
         x="cms+cmssw-ib+$RELEASE_NAME"
         ${CMSPKG} clean
-        install_package $x || true
-        time install_package ${REINSTALL_ARGS} --ignore-size `echo $x | sed -e 's/cmssw-ib/cmssw/'`       || true
-        time install_package ${REINSTALL_ARGS} --ignore-size `echo $x | sed -e 's/cmssw-ib/cmssw-patch/'` || true
+        install_package $x
+        time install_package ${REINSTALL_ARGS} --ignore-size `echo $x | sed -e 's/cmssw-ib/cmssw/'`
+        time install_package ${REINSTALL_ARGS} --ignore-size `echo $x | sed -e 's/cmssw-ib/cmssw-patch/'`
         relname=`echo $x | awk -F + '{print $NF}'`
         timestamp=`echo $relname | awk -F _ '{print $NF}' | grep '^20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]$' | sed 's|-||g'`
         if [ "X$timestamp" != "X" ] ; then

--- a/cvmfsInstall.sh
+++ b/cvmfsInstall.sh
@@ -4,7 +4,9 @@ function install_package() {
   rm -f ${WORKSPACE}/inst.log
   ${CMSPKG} install -y $@ 2>&1 | tee -a ${WORKSPACE}/inst.log 2>&1 || true
   if [ $(grep 'cannot open Packages index using db6' ${WORKSPACE}/inst.log | wc -l) -gt 0 ] ; then
+    echo "ERROR: RPM DB error found"
     if [ "${USE_LOCAL_RPMDB}" = "true" ] ; then
+      echo "  Trying local DB"
       rm -rf ${WORKSPACE}/rpm
       mv $WORKDIR/${SCRAM_ARCH}/var/lib/rpm  ${WORKSPACE}/rpm
       ln -d ${WORKSPACE}/rpm $WORKDIR/${SCRAM_ARCH}/var/lib/rpm
@@ -12,7 +14,9 @@ function install_package() {
       ${CMSPKG} install -y $@ 2>&1 | tee -a ${WORKSPACE}/inst.log 2>&1 || true
       rm -f $WORKDIR/${SCRAM_ARCH}/var/lib/rpm
       mv ${WORKSPACE}/rpm $WORKDIR/${SCRAM_ARCH}/var/lib/rpm
+      echo "Copr RPM DB back"
       if [ $(grep 'cannot open Packages index using db6' ${WORKSPACE}/inst.log | wc -l) -gt 0 ] ; then
+        echo "Still has RPM DB error"
         touch ${WORKSPACE}/err.txt
       fi
     else
@@ -181,6 +185,7 @@ for REPOSITORY in $REPOSITORIES; do
         fi
       fi
     ) || true
+
 if [ -e ${WORKSPACE}/err.txt ] ; then
   cvmfs_server abort -f
   exit 1


### PR DESCRIPTION
work around for installing packages when RPM database is over 2GB ( see https://cern.service-now.com/service-portal?id=ticket&table=incident&n=INC4478007 for details). This is a generic issue with cvmfs and newer linux kernel. Opening a large file with read/write permission fails. A simple `open("/cvmfs/repo/some/large/file",O_RDWR);` fails on kernel  `5.14.0-503` ( which is installed on our cms-ib.cern.ch cvmfs publishers) while it works on kernel `5.14.0-362` ( which is available on cms.cern.ch cvmfs publisher).

The change here moves the large `Packages` file to local disk, create a symlink on cvmfs and then runs `rpm -ivh` and finally move back the `Packages` file to cvmfs. We can remove this workaround once cvmfs or kernel has a fix for it.