### PR TITLE
Add philippgadow to groups.yaml for BTV

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -9,6 +9,7 @@ btv-pog:
   - Ming-Yan
   - Senphy
   - castaned
+  - pavlo-kashko
   - philippgadow
 ecal-offline:
   - wang0jin


### PR DESCRIPTION
This PR adds the account `philippgadow` (incoming BTV software L3) [edit: and also current BTV software L3 `pavlo-kashko `] to the cms-bot list for BTV PRs.