### PR TITLE
Added cmsTraceFunction for DEVEL_X RelVals

### DIFF
--- a/RelValArgs.py
+++ b/RelValArgs.py
@@ -42,10 +42,16 @@ RELVAL_KEYS["customiseWithTimeMemorySummary"].append(
     [".+", "--customise Validation/Performance/TimeMemorySummary.customiseWithTimeMemorySummary"]
 )
 RELVAL_KEYS["PREFIX"].append(
-    ["CMSSW_[1-7]_.+", "--prefix '%s timeout --signal SIGSEGV @TIMEOUT@ @TRACE_FUNCTION@ '" % monitor_script]
+    [
+        "CMSSW_[1-7]_.+",
+        "--prefix '%s timeout --signal SIGSEGV @TIMEOUT@ @TRACE_FUNCTION@ '" % monitor_script,
+    ]
 )
 RELVAL_KEYS["PREFIX"].append(
-    ["CMSSW_.+", "--prefix '%s timeout --signal SIGTERM @TIMEOUT@ @TRACE_FUNCTION@'" % monitor_script]
+    [
+        "CMSSW_.+",
+        "--prefix '%s timeout --signal SIGTERM @TIMEOUT@ @TRACE_FUNCTION@'" % monitor_script,
+    ]
 )
 RELVAL_KEYS["TRACE_FUNCTION"].append(
     ["CMSSW_.+_DEVEL_.+", "cmsTraceFunction --startAfterFunction ScheduleItems::initMisc setenv"]


### PR DESCRIPTION
As suggested in https://github.com/cms-sw/cmssw/issues/46002#issuecomment-3055822370, this PR enable running of DEVEL_X IB RelVals under `cmsTraceFunction --startAfterFunction ScheduleItems::initMisc setenv` to see where we call `setenv`