### PR TITLE
Run all Run4 HLT menu flavours.

### DIFF
--- a/pr_testing/run-pr-hlt-p2-integration.sh
+++ b/pr_testing/run-pr-hlt-p2-integration.sh
@@ -13,15 +13,16 @@ if [ ! -e "${HLT_BASEDIR}/${HLT_P2_SCRIPT}" ] ; then HLT_BASEDIR="${CMSSW_RELEAS
 cp -r ${HLT_BASEDIR}/${HLT_P2_SCRIPT} $WORKSPACE/rundir
 rm -rf $WORKSPACE/rundir/__pycache__
 
+INTEGRTESTS_LOG="${WORKSPACE}/hlt-p2-integration.log"
+
 pushd $WORKSPACE/rundir
-    INTEGRTESTS_LOG="${WORKSPACE}/hlt-p2-integration.log"
     export LOCALRT=${WORKSPACE}/${CMSSW_VERSION}
-	if ${HLT_BASEDIR}/${HLT_P2_SCRIPT}/hltPhase2UpgradeIntegrationTests --help | grep -w -- "--menu " 2>/dev/null ; then # if the "--menu" option is included in this IB
+	if hltPhase2UpgradeIntegrationTests --help | grep -w -- "--menu " 2>/dev/null ; then # if the "--menu" option is included in this IB
 		for elem in $(python3 -c 'from Configuration.HLT.autoHLT import autoHLT; [print(v) for k,v in autoHLT.items() if "Run4" in k]') ; do
-			timeout $TIMEOUT ${HLT_BASEDIR}/${HLT_P2_SCRIPT}/hltPhase2UpgradeIntegrationTests --menu ${elem} --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG}
+			timeout $TIMEOUT hltPhase2UpgradeIntegrationTests --menu ${elem} --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG}
 		done
 	else # if the "--menu" option is NOT included in this IB
-		timeout $TIMEOUT ${HLT_BASEDIR}/${HLT_P2_SCRIPT}/hltPhase2UpgradeIntegrationTests --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG}
+		timeout $TIMEOUT hltPhase2UpgradeIntegrationTests --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG}
 	fi
 popd
 
@@ -31,7 +32,7 @@ HLT_P2_RES="SUCCESS"
 source $WORKSPACE/cms-bot/jenkins-artifacts
 touch ${RESULTS_DIR}/15-hlt-p2-integration-failed.res
 
-if grep -iE 'Error|failure' "${WORKSPACE}/hlt-p2-integration.log"; then
+if grep -iE 'Error|failure' "${INTEGRTESTS_LOG}"; then
   HLT_P2_RES="ERROR"
 elif [ ! -f $WORKSPACE/rundir/Phase2Timing_resources.json ] ; then
   HLT_P2_RES="ERROR"

--- a/pr_testing/run-pr-hlt-p2-integration.sh
+++ b/pr_testing/run-pr-hlt-p2-integration.sh
@@ -15,18 +15,18 @@ rm -rf $WORKSPACE/rundir/__pycache__
 
 INTEGRTESTS_LOG="${WORKSPACE}/hlt-p2-integration.log"
 
+HLT_P2_RES="SUCCESS"
+
 pushd $WORKSPACE/rundir
     export LOCALRT=${WORKSPACE}/${CMSSW_VERSION}
 	if hltPhase2UpgradeIntegrationTests --help | grep -w -- "--menu " 2>/dev/null ; then # if the "--menu" option is included in this IB
 		for elem in $(python3 -c 'from Configuration.HLT.autoHLT import autoHLT; [print(v) for k,v in autoHLT.items() if "Run4" in k]') ; do
-			timeout $TIMEOUT hltPhase2UpgradeIntegrationTests --menu ${elem} --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG}
+			timeout $TIMEOUT hltPhase2UpgradeIntegrationTests --menu ${elem} --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG} && HLT_P2_RES="ERROR"
 		done
 	else # if the "--menu" option is NOT included in this IB
 		timeout $TIMEOUT hltPhase2UpgradeIntegrationTests --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG}
 	fi
 popd
-
-HLT_P2_RES="SUCCESS"
 
 # Upload results
 source $WORKSPACE/cms-bot/jenkins-artifacts

--- a/pr_testing/run-pr-hlt-p2-integration.sh
+++ b/pr_testing/run-pr-hlt-p2-integration.sh
@@ -14,8 +14,15 @@ cp -r ${HLT_BASEDIR}/${HLT_P2_SCRIPT} $WORKSPACE/rundir
 rm -rf $WORKSPACE/rundir/__pycache__
 
 pushd $WORKSPACE/rundir
-  export LOCALRT=${WORKSPACE}/${CMSSW_VERSION}
-  timeout $TIMEOUT ${HLT_BASEDIR}/${HLT_P2_SCRIPT}/hltPhase2UpgradeIntegrationTests --parallelJobs $(nproc) 2>&1 | tee -a ${WORKSPACE}/hlt-p2-integration.log
+    INTEGRTESTS_LOG="${WORKSPACE}/hlt-p2-integration.log"
+    export LOCALRT=${WORKSPACE}/${CMSSW_VERSION}
+	if ${HLT_BASEDIR}/${HLT_P2_SCRIPT}/hltPhase2UpgradeIntegrationTests --help | grep -w -- "--menu " 2>/dev/null ; then # if the "--menu" option is included in this IB
+		for elem in $(python3 -c 'from Configuration.HLT.autoHLT import autoHLT; [print(v) for k,v in autoHLT.items() if "Run4" in k]') ; do
+			timeout $TIMEOUT ${HLT_BASEDIR}/${HLT_P2_SCRIPT}/hltPhase2UpgradeIntegrationTests --menu ${elem} --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG}
+		done
+	else # if the "--menu" option is NOT included in this IB
+		timeout $TIMEOUT ${HLT_BASEDIR}/${HLT_P2_SCRIPT}/hltPhase2UpgradeIntegrationTests --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG}
+	fi
 popd
 
 HLT_P2_RES="SUCCESS"

--- a/pr_testing/run-pr-hlt-p2-integration.sh
+++ b/pr_testing/run-pr-hlt-p2-integration.sh
@@ -18,14 +18,16 @@ INTEGRTESTS_LOG="${WORKSPACE}/hlt-p2-integration.log"
 HLT_P2_RES="SUCCESS"
 
 pushd $WORKSPACE/rundir
+    set -o pipefail # required for correct error status piping within the loop
     export LOCALRT=${WORKSPACE}/${CMSSW_VERSION}
 	if hltPhase2UpgradeIntegrationTests --help | grep -w -- "--menu " 2>/dev/null ; then # if the "--menu" option is included in this IB
 		for elem in $(python3 -c 'from Configuration.HLT.autoHLT import autoHLT; [print(v) for k,v in autoHLT.items() if "Run4" in k]') ; do
-			timeout $TIMEOUT hltPhase2UpgradeIntegrationTests --menu ${elem} --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG} && HLT_P2_RES="ERROR"
+			timeout $TIMEOUT hltPhase2UpgradeIntegrationTests --menu ${elem} --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG} || HLT_P2_RES="ERROR"
 		done
 	else # if the "--menu" option is NOT included in this IB
 		timeout $TIMEOUT hltPhase2UpgradeIntegrationTests --parallelJobs $(nproc) 2>&1 | tee -a ${INTEGRTESTS_LOG}
 	fi
+	set +o pipefail
 popd
 
 # Upload results

--- a/run-hlt-validation
+++ b/run-hlt-validation
@@ -43,29 +43,9 @@ ls
 INTEGRTESTS_LOG="${WORKSPACE}/results/hltPhase2UpgradeIntegrationTests.log"
 if which hltPhase2UpgradeIntegrationTests 2>/dev/null ; then
 	if hltPhase2UpgradeIntegrationTests --help | grep -w -- "--menu " 2>/dev/null ; then # if the "--menu" option is included in this IB
-
-		TEMPDIR="IntergrTest_temp"
-		TEMPFILE="autoHLT.py"
-		mkdir ${TEMPDIR}
-		cp ${CMSSW_RELEASE_BASE}/src/Configuration/HLT/python/${TEMPFILE} ${TEMPDIR}/${TEMPFILE}
-
-		PYTHON_SCRIPT=$(cat << 'EOF'
-from test import autoHLT
-for k, v in autoHLT.items():
-    if "Run4" in k:
-        print(v)
-EOF
-					 )
-
-		mapfile -t menus < <(python3 -c "$PYTHON_SCRIPT")
-
-		for elem in "${menus[@]}"; do
+		for elem in $(python3 -c 'from Configuration.HLT.autoHLT import autoHLT; [print(v) for k,v in autoHLT.items() if "Run4" in k]') ; do
 			hltPhase2UpgradeIntegrationTests --menu ${elem} --parallelJobs $(nproc) | tee -a ${INTEGRTESTS_LOG}
 		done
-
-		rm ${TEMPDIR}/${TEMPFILE}
-		rmdir ${TEMPDIR}
-
 	else # if the "--menu" option is NOT included in this IB
 		hltPhase2UpgradeIntegrationTests --parallelJobs $(nproc) | tee -a ${INTEGRTESTS_LOG}
 	fi

--- a/run-hlt-validation
+++ b/run-hlt-validation
@@ -39,11 +39,40 @@ cd HLTrigger/Configuration/test/
 ls
 ./runAll.csh IB | tee -a $WORKSPACE/results/runIB.log
 ./examLogs.csh | tee -a $WORKSPACE/results/examLogs.out
+
+INTEGRTESTS_LOG="${WORKSPACE}/results/hltPhase2UpgradeIntegrationTests.log"
 if which hltPhase2UpgradeIntegrationTests 2>/dev/null ; then
-    hltPhase2UpgradeIntegrationTests --parallelJobs $(nproc) | tee -a  $WORKSPACE/results/hltPhase2UpgradeIntegrationTests.log
+	if hltPhase2UpgradeIntegrationTests --help | grep -w -- "--menu " 2>/dev/null ; then # if the "--menu" option is included in this IB
+
+		TEMPDIR="IntergrTest_temp"
+		TEMPFILE="autoHLT.py"
+		mkdir ${TEMPDIR}
+		cp ${CMSSW_RELEASE_BASE}/src/Configuration/HLT/python/${TEMPFILE} ${TEMPDIR}/${TEMPFILE}
+
+		PYTHON_SCRIPT=$(cat << 'EOF'
+from test import autoHLT
+for k, v in autoHLT.items():
+    if "Run4" in k:
+        print(v)
+EOF
+					 )
+
+		mapfile -t menus < <(python3 -c "$PYTHON_SCRIPT")
+
+		for elem in "${menus[@]}"; do
+			hltPhase2UpgradeIntegrationTests --menu ${elem} --parallelJobs $(nproc) | tee -a ${INTEGRTESTS_LOG}
+		done
+
+		rm ${TEMPDIR}/${TEMPFILE}
+		rmdir ${TEMPDIR}
+
+	else # if the "--menu" option is NOT included in this IB
+		hltPhase2UpgradeIntegrationTests --parallelJobs $(nproc) | tee -a ${INTEGRTESTS_LOG}
+	fi
 else
     echo "hltPhase2UpgradeIntegrationTests not found, skipping"
 fi
+
 ls
 cp *.log $WORKSPACE/results
 cp *.out $WORKSPACE/results


### PR DESCRIPTION
Runs the phase 2 integration tests for all HLT menu flavours if the ```--menu``` option (introduced in [#48664 in CMSSW](https://github.com/cms-sw/cmssw/pull/48664)) is supported by ```hltPhase2UpgradeIntegrationTests```. It simply filters the keys present in ```Configuration/HLT/python/autoHLT.py``` with the "Run4" substring.
Tested in my local CMSSW release; further tests are necessary @mmusich.