### PR TITLE
Restore watchers.yaml used for process_pr tests

### DIFF
--- a/repos/iarspider_cmssw/cmssw/watchers.yaml
+++ b/repos/iarspider_cmssw/cmssw/watchers.yaml
@@ -1508,7 +1508,16 @@ missirol:
 - .*L1T
 - .*HL
 - .*Trig
+- CommonTools
+- Configuration
 - EventFilter
+- FWCore
+- Heterogeneous
+- Reco
+- SLHCUpgradeSimulations
+- SimTracker
+- TrackingTools
+- Validation
 sobhatta:
 - RecoEgamma
 - RecoEcal


### PR DESCRIPTION
This file was changed in https://github.com/cms-sw/cms-bot/pull/2552. It should never be changed, otherwise tests will fail. 

