### PR TITLE
Do not move issues to older milestones

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -528,7 +528,7 @@ def updateMilestone(repo, issue, pr, dryRun):
     if pr.state != "open":
         logger.error("PR not open, not setting/checking milestone")
         return
-    if issue.milestone and issue.milestone.number == milestoneId:
+    if issue.milestone and issue.milestone.number >= milestoneId:
         return
     milestone = repo.get_milestone(milestoneId)
     logger.info("Setting milestone to %s", milestone.title)


### PR DESCRIPTION
When opening a new release series, there is a time gap between script moving issues to new milestone and updating master version of cms-bot with new default milestone. During this time gap, cms-bot moves all the issues back to the old milestone.

This PR should fix this behavior: only change milestone if it's id is less than id of "default" milestone.