### PR TITLE
Handover of ECAL DPG conveners.

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -102,7 +102,7 @@ CMSSW_L2 = {
     # dpgs
     "mdelcourt": ["trk-dpg"],
     "henriettepetersen": ["trk-dpg"],
-    "wang0jin": ["ecal-dpg"],
+    "bmarzocc": ["ecal-dpg"],
     "thomreis": ["ecal-dpg"],
     "wang-hui": ["hcal-dpg"],
     "jhakala": ["hcal-dpg"],


### PR DESCRIPTION
Start of `bmarzocc` as ECAL DPG convener and end of `wang0jin`.