### PR TITLE
Fix wrong name in the generators category

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -78,7 +78,7 @@ CMSSW_L2 = {
     "mandrenguyen": ["reconstruction", "operations"],
     "mdhildreth": ["simulation", "geometry", "fastsim"],
     "mkirsano": ["generators"],
-    "ssen": ["generators"],
+    "sensrcn": ["generators"],
     "lviliani": ["generators"],
     "theofil": ["generators"],
     "ftenchini": ["operations"],


### PR DESCRIPTION
We were using the wrong github account for Sercan Sen (GEN Core Software Integration convener).
This PR is fixing the issue.