### PR TITLE
Update reco L2

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -39,6 +39,7 @@ TRIGGER_PR_TESTS = list(
             "sroychow",
             "silviodonato",
             "slava77",
+            "srimanob",
         ]
         + REQUEST_BUILD_RELEASE
         + [a for a in authors if authors[a] > 10 and not a in GITHUB_BLACKLIST_AUTHORS]
@@ -87,7 +88,7 @@ CMSSW_L2 = {
     "ctarricone": ["dqm"],
     "smorovic": ["daq"],
     "smuzaffar": ["core"],
-    "srimanob": ["upgrade"],
+    "srimanob": ["reconstruction"],
     "subirsarkar": ["upgrade"],
     "Moanwar": ["upgrade"],
     "ssekmen": ["fastsim"],


### PR DESCRIPTION
This is to complete the transition done originally in https://github.com/cms-sw/cms-bot/pull/2575 and later replaced by https://github.com/cms-sw/cms-bot/pull/2580 but missing the reassignment.