### PR TITLE
check the contents of toolfiles instead of version/revision

### DIFF
--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -800,7 +800,7 @@ if ${BUILD_EXTERNAL} ; then
         echo "Checking ${name}"
 		if ! diff -u \
              <(sed -r 's|"/([^/]+/)+([^"]+)"|"/PATH/\2"|g; s|^[[:space:]]+||; s|[[:space:]\r]+$||; s|[[:space:]]+| |g' ${xml}) \
-             <(sed -r 's|"/([^/]+/)+([^"]+)"|"/PATH/\2"|g; s|^[[:space:]]+||; s|[[:space:]\r]+$||; s|[[:space:]]+| |g' ${BTOOLS}/$name  ; then
+             <(sed -r 's|"/([^/]+/)+([^"]+)"|"/PATH/\2"|g; s|^[[:space:]]+||; s|[[:space:]\r]+$||; s|[[:space:]]+| |g' ${BTOOLS}/$name)  ; then
           DEP_NAMES="$DEP_NAMES echo_${tool}_USED_BY"
           echo "  Tool changed/updated: ${name}"
         fi


### PR DESCRIPTION
Do not just rely on tool version/revision but make sure that a tool should be considered changed it its contents also changed. For PRs like https://github.com/cms-sw/cmsdist/pull/9679 where contents (cuda-flags) were changed but as version of cuda and toolfile revision remain same so bot did not checkout/build every package which require cuda. This change will make sure that we actually check for toolfile contents too