### PR TITLE
do not mount /etc/pki/ca-trust from host for el10 containers

### DIFF
--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -79,7 +79,12 @@ if [ "X$DOCKER_IMG" != X -a "X$RUN_NATIVE" = "X" ]; then
   fi
   BUILD_BASEDIR=$(dirname $WORKSPACE)
   export KRB5CCNAME=$(klist | grep 'Ticket cache: FILE:' | sed 's|.* ||')
-  MOUNT_POINTS="/cvmfs,/tmp,$(echo $WORKSPACE | cut -d/ -f1,2),/var/run/user,/run/user,/etc/pki/ca-trust,${EXTRA_MOUNTS}"
+  MOUNT_POINTS="/cvmfs,/tmp,$(echo $WORKSPACE | cut -d/ -f1,2),/var/run/user,/run/user,${EXTRA_MOUNTS}"
+  # el10 ca-certificate issue
+  # Python3: urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate
+  if [[ $DOCKER_IMG != */el10:* ]] ; then
+    MOUNT_POINTS="/etc/pki/ca-trust,${MOUNT_POINTS}"
+  fi
   grid_dirs="/cvmfs/grid.cern.ch/etc/grid-security:/etc/grid-security /cvmfs/grid.cern.ch/etc/grid-security/vomses:/etc/vomses"
   if [ -e "/cvmfs/grid.cern.ch/etc/grid-security/vomses/voms-cms-auth.app.cern.ch" ] ; then
     grid_dirs="${grid_dirs} /cvmfs/grid.cern.ch/etc/grid-security/vomses/voms-cms-auth.cern.ch:/etc/vomses/voms-cms-auth.app.cern.ch"


### PR DESCRIPTION
In el10 container we get errors like [a]. Normally we mount `/etc/pki/ca-trust` from host where ca-certificate are kept up to date but in el10 container python3 does not like the contents of host `/etc/pki/ca-trust` and complain about certificate verification failed. This PR proposes to not mount `/etc/pki/ca-trust`  for el10

```
Error while downloading https://repo.radeon.com/rocm/rhel10/7.0.2/main/rocminfo-1.0.0.70002-56.el10.x86_64.rpm: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)>
(<function fetchSources at 0x7f3bc29ec7c0>, <Package name=rocm>, <scheduler.Scheduler object at 0x7f3bc37a0b00>, 'https://repo.radeon.com/rocm/rhel10/7.0.2/main/rocprim-devel-4.0.1.70002-56.el10.x86_64.rpm') done
(<function fetchSources at 0x7f3bc29ec7c0>, <Package name=rocm>, <scheduler.Scheduler object at 0x7f3bc37a0b00>, 'https://repo.radeon.com/rocm/rhel10/7.0.2/main/rocminfo-1.0.0.70002-56.el10.x86_64.rpm') done
Error while downloading https://repo.radeon.com/rocm/rhel10/7.0.2/main/rocprofiler-2.0.70002.70002-56.el10.x86_64.rpm: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (
```