### PR TITLE
Add `MagneticField/Portable` to `categories_map.py`

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -927,6 +927,7 @@ CMSSW_CATEGORIES = {
         "HeterogeneousTest/ROCmKernel",
         "HeterogeneousTest/ROCmOpaque",
         "HeterogeneousTest/ROCmWrapper",
+        "MagneticField/Portable",
     ],
     "hlt": [
         "CommonTools/TriggerUtils",
@@ -1232,6 +1233,7 @@ CMSSW_CATEGORIES = {
         "MagneticField/Interpolation",
         "MagneticField/Layers",
         "MagneticField/ParametrizedEngine",
+        "MagneticField/Portable",
         "MagneticField/Records",
         "MagneticField/UniformEngine",
         "MagneticField/VolumeBasedEngine",


### PR DESCRIPTION
This PR assigns `MagneticField/Portable` package for `heterogeneous` and `reconstruction`. The package is being added in https://github.com/cms-sw/cmssw/pull/48729, package assignment follows a comment https://github.com/cms-sw/cmssw/pull/48729#issuecomment-3501217605.