### PR TITLE
Updated CMS_BOT_TEST_BRANCH assignment to pull the pr.number head

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -1275,7 +1275,7 @@ def process_pr(
             cats = get_commenter_categories(author_, int(issue.created_at.strftime("%s")))
             if "externals" in cats or "core" in cats:
                 with open("cms-bot.properties", "w") as f:
-                    f.write("CMS_BOT_TEST_BRANCH={0}\n".format(pr.head.ref))
+                    f.write("CMS_BOT_TEST_BRANCH=pull/{0}/head\n".format(pr.number))
                     f.write("FORCE_PULL_REQUEST={0}\n".format(pr.number))
                     f.write("CMS_BOT_TEST_PRS=cms-sw/cms-bot#{0}\n".format(pr.number))
                 return


### PR DESCRIPTION
This ref always points to the latest commit in the PR, independent of the contributor’s branch name. For example:

```bash
git ls-remote https://github.com/cms-sw/cms-bot.git | grep pull/2616
751babf4...  refs/pull/2616/head
```
Previously we used the contributor’s branch name now use
```bash
git pull --no-rebase https://github.com/cms-sw/cms-bot.git pull/2616/head
```
GitHub has `refs/pull/<PR>/head` for every pull request. So, pull/`<PR>/head` is guaranteed to exist and can be fetched even when the contributor’s branch does not exist on the cms-bot repository.
Resolves [#2587 ](https://github.com/cms-sw/cms-bot/issues/2587)