### PR TITLE
added diskfailure full for all the jobs

### DIFF
--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -295,7 +295,6 @@
                 ],
                 "action": "nodeOff",
                 "allJobs": "true"
-
             }
         }
     }


### PR DESCRIPTION
The "No space left on device message" was not showing on the jenkin. Now this message will be available for all jobs