### PR TITLE
Fix bug in reporting max memory threshold exceeded.

### DIFF
--- a/report-pull-request-results.py
+++ b/report-pull-request-results.py
@@ -303,7 +303,7 @@ def read_maxmem_comparison_file(unit_tests_file):
     for line in openlog(unit_tests_file):
         if "exceeds" in line.lower():
             err_cnt += 1
-            errors_found += " - " + line.split(":")[1] + "\n"
+            errors_found += " - " + line.split(":")[1:] + "\n"
 
     if err_cnt > 0:
         message = (


### PR DESCRIPTION
Added `Error:` to message with latest changes so splitting output of grep on colon needs all fields after first, not just second field. 