### PR TITLE
Reenable amd_mi300x GPU tests as mi300x

### DIFF
--- a/gpu_flavors.txt
+++ b/gpu_flavors.txt
@@ -2,3 +2,4 @@ nvidia_t4
 nvidia_h100
 nvidia_l40s
 amd_w7900
+amd_mi300x


### PR DESCRIPTION
NGT sessiosn for mi300x are working now (rocmIsEnabled  and rocmComputeCapabilities are not hanging any more)