### PR TITLE
Add cmsPkgUpdateError error category for cmspkg update failures

### DIFF
--- a/jenkins/parser/jobs-config.json
+++ b/jenkins/parser/jobs-config.json
@@ -64,7 +64,8 @@
             {
                 "jobName": "build-any-ib",
                 "errorType": [
-                    "gitErrors"
+                    "gitErrors",
+                    "cmsPkgUpdateError"
                 ],
                 "maxTime": "18"
             },
@@ -233,6 +234,12 @@
                 ],
                 "action": "retryLate",
                 "allJobs": "true"
+            },
+            "cmsPkgUpdateError": {
+                "errorStr": [
+                    "ERROR: Error while executing cmspkg update"
+                ],
+                "action": "retryLate"
             },
             "busError": {
                 "errorStr": [


### PR DESCRIPTION
Add cmsSdtConnection error category for cmspkg update failures

- Added `cmsSdtConnection` to [jobs-config.json](https://github.com/akritkbehera/cms-bot/blob/cmspkg_update_retry/jenkins/parser/jobs-config.json) to catch "Error while executing cmspkg update".
- Configured to `retryLate`.
- Enabled this error check for the `build-any-ib` job.