### PR TITLE
Include Eigen/Core in Validate.C

### DIFF
--- a/comparisons/validate.C
+++ b/comparisons/validate.C
@@ -17,7 +17,12 @@
 #include "TSQLResult.h"
 #include "TSQLRow.h"
 #include <cmath>
-#include <Eigen/Core>
+#ifdef __has_include
+  #if __has_include(<Eigen/Core>)
+    #include <Eigen/Core>
+  #endif
+#endif
+
 
 bool detailed = true;
 bool detailed1 = false;//higher level of detail


### PR DESCRIPTION
This PR adds #include <Eigen/Core> to Validate.C to fix the crash got in [#49568](https://github.com/cms-sw/cmssw/issues/49568) related to Eigen columns in SoA.
Tagging @jfernan2