### PR TITLE
Disable running edm_checks during the build but run those at the end

### DIFF
--- a/pr_testing/test_multiple_prs.sh
+++ b/pr_testing/test_multiple_prs.sh
@@ -1236,7 +1236,7 @@ if [ $(echo ${ENABLE_BOT_TESTS} | tr ',' ' ' | tr ' ' '\n' | grep '^MULTI_MICROA
   scram build enable-multi-targets || true
 fi
 COMPILATION_CMD="scram b vclean && BUILD_LOG=yes $USER_FLAGS /usr/bin/time -v scram b ${BUILD_VERBOSE} -k -j ${NCPU}"
-if [ "$BUILD_EXTERNAL" = "true" -a $(grep '^edm_checks:' $WORKSPACE/$CMSSW_IB/config/SCRAM/GMake/Makefile.rules | wc -l) -gt 0 ] ; then
+if [ $(grep '^edm_checks:' $WORKSPACE/$CMSSW_IB/config/SCRAM/GMake/Makefile.rules | wc -l) -gt 0 ] ; then
   COMPILATION_CMD="scram b vclean && BUILD_LOG=yes SCRAM_NOEDM_CHECKS=yes $USER_FLAGS /usr/bin/time -v scram build ${BUILD_VERBOSE} -k -j ${NCPU} && scram b -k -j ${NCPU} edm_checks"
 fi
 echo $COMPILATION_CMD > $WORKSPACE/build.log


### PR DESCRIPTION
see discussion at https://github.com/cms-sw/cmssw/issues/49758 

For external PR tests we anyway run scram in two steps
1. without edm checks
2. run edm checks

This PR proposes to do the same for all PR tests