### PR TITLE
Report workflows failing maxmem check as a numericly sorted list

### DIFF
--- a/report-pull-request-results.py
+++ b/report-pull-request-results.py
@@ -314,7 +314,7 @@ def read_maxmem_comparison_file(unit_tests_file):
             % err_cnt
         )
         message += "<details>\n<summary>Expand to see workflows ...</summary>\n\n"
-        for message_line in sorted(errors_found, key=lambda s: float(s[2].split("_")[0])):
+        for message_line in sorted(errors_found, key=lambda s: float(s[3].split("_")[0])):
             message += " ".join(message_line)
         message += "</details>\n\n"
         send_message_pr(message)


### PR DESCRIPTION
Tested locally with sample output and produces expected output without python failures.
