### PR TITLE
Format Python code with black 26.1.0 (excluding archive/ folder)

### DIFF
--- a/DMWM/AggregatePylint.py
+++ b/DMWM/AggregatePylint.py
@@ -6,7 +6,7 @@ from optparse import OptionParser
 
 usage = "usage: %prog [options] message"
 parser = OptionParser(usage)
-(options, args) = parser.parse_args()
+options, args = parser.parse_args()
 if len(args) != 1:
     parser.error("You must supply a label")
 

--- a/DMWM/IdentifyPythonFiles.py
+++ b/DMWM/IdentifyPythonFiles.py
@@ -7,7 +7,7 @@ from optparse import OptionParser
 
 usage = "usage: %prog [options] list_of_files.txt"
 parser = OptionParser(usage)
-(options, args) = parser.parse_args()
+options, args = parser.parse_args()
 if len(args) != 1:
     parser.error("You must supply a file with a list of files to check")
 

--- a/DMWM/IssueMessage.py
+++ b/DMWM/IssueMessage.py
@@ -7,7 +7,7 @@ from optparse import OptionParser
 
 usage = "usage: %prog [options] message"
 parser = OptionParser(usage)
-(options, args) = parser.parse_args()
+options, args = parser.parse_args()
 if len(args) != 1:
     parser.error("You must supply a message.")
 

--- a/RelValArgs.py
+++ b/RelValArgs.py
@@ -100,9 +100,7 @@ if "CMS_RELVALS_USER_COMMAND_OPTS" in environ:
 RELVAL_ARGS = []
 RELVAL_ARGS.append({})
 # For SLHC releases
-RELVAL_ARGS[len(RELVAL_ARGS) - 1][
-    "_SLHC(DEV|)_"
-] = """
+RELVAL_ARGS[len(RELVAL_ARGS) - 1]["_SLHC(DEV|)_"] = """
   @USE_INPUT@
   @WORKFLOWS@
 """
@@ -110,9 +108,7 @@ RELVAL_ARGS[len(RELVAL_ARGS) - 1]["CMSSW_4_2_"] = ""
 
 RELVAL_ARGS.append({})
 # For rleease cycles >= 7
-RELVAL_ARGS[len(RELVAL_ARGS) - 1][
-    "CMSSW_([1-9][0-9]|[7-9])_"
-] = """
+RELVAL_ARGS[len(RELVAL_ARGS) - 1]["CMSSW_([1-9][0-9]|[7-9])_"] = """
   @USE_INPUT@
   @JOB_REPORT@
   --command "
@@ -128,9 +124,7 @@ RELVAL_ARGS[len(RELVAL_ARGS) - 1][
 
 RELVAL_ARGS.append({})
 # For all other releases
-RELVAL_ARGS[len(RELVAL_ARGS) - 1][
-    ".+"
-] = """
+RELVAL_ARGS[len(RELVAL_ARGS) - 1][".+"] = """
   @USE_INPUT@
 """
 

--- a/buildLogAnalyzer.py
+++ b/buildLogAnalyzer.py
@@ -4,6 +4,7 @@
 Created by Andreas Pfeiffer on 2008-08-05.
 Copyright (c) 2008 CERN. All rights reserved.
 """
+
 from __future__ import print_function
 import sys, os, re, time
 import getopt

--- a/compareTriggerResults.py
+++ b/compareTriggerResults.py
@@ -3,6 +3,7 @@
 Script to compare the content of edm::TriggerResults collections in EDM files across multiple workflows
  - CMSSW dependencies: edmDumpEventContent, hltDiff
 """
+
 from __future__ import print_function
 import argparse
 import os

--- a/compareTriggerResultsSummary.py
+++ b/compareTriggerResultsSummary.py
@@ -3,6 +3,7 @@
 Script to summarise the outputs of compareTriggerResults
 (i.e. the outputs of hltDiff in .json format)
 """
+
 from __future__ import print_function
 import argparse
 import os

--- a/comparisons/analyzeFWComparison.py
+++ b/comparisons/analyzeFWComparison.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         help="Generate the thresholds for the relmon comparisons",
         default=False,
     )
-    (options, args) = parser.parse_args()
+    options, args = parser.parse_args()
 
     # -----------------------------------------------------------------------------------
     # ---- Review of arguments

--- a/comparisons/compare-maxmem-summary.py
+++ b/comparisons/compare-maxmem-summary.py
@@ -2,6 +2,7 @@
 """
 Script to summarise the outputs of compare-maxmem.py
 """
+
 from __future__ import print_function
 import argparse
 import os

--- a/comparisons/resources-diff.py
+++ b/comparisons/resources-diff.py
@@ -29,10 +29,8 @@ def diff_from(metrics, data, data_total, dest, dest_total, res):
 
 
 if len(sys.argv) == 1:
-    print(
-        """Usage: resources-diff.py IB_FILE PR_FILE
-Diff the content of two "resources.json" files and print the result to standard output."""
-    )
+    print("""Usage: resources-diff.py IB_FILE PR_FILE
+Diff the content of two "resources.json" files and print the result to standard output.""")
     sys.exit(1)
 
 with open(sys.argv[1]) as f:

--- a/comparisons/validateJR.py
+++ b/comparisons/validateJR.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
     parser.add_option(
         "--procs", dest="procs", default=None, type=int, help="number of processes to run"
     )
-    (options, args) = parser.parse_args()
+    options, args = parser.parse_args()
 
     if not compile_lib():
         sys.exit()

--- a/githublabels.py
+++ b/githublabels.py
@@ -25,10 +25,10 @@ LABEL_TYPES = {
 }
 
 # TYPE_COMMANDS[LABEL_NAME]=[LABEL_COLOR,
-#                           REGEXP_TO_MATCH_CCOMMENT",
-#                           TYPE
-#                                type: only apply the last comment
-#                                mtype: accomulate all comments]
+# REGEXP_TO_MATCH_CCOMMENT",
+# TYPE
+# type: only apply the last comment
+# mtype: accomulate all comments]
 TYPE_COMMANDS = {
     "bug-fix": [LABEL_COLORS["bug"], "bug(?:-?fix)?", "type"],
     "new-feature": [LABEL_COLORS["info"], "(?:new-)?(?:feature|idea)", "type"],

--- a/jenkins/jenkins-kill-placeholder-job.py
+++ b/jenkins/jenkins-kill-placeholder-job.py
@@ -3,6 +3,7 @@
 This job will check if there are queued jobs for jenkins slaves with 'condor' label and how many.
 Then it will kill needed amount of placeholder jobs.
 """
+
 from pprint import pprint
 import re, sys
 from os.path import dirname, abspath, join, exists

--- a/jenkins/jenkins-project-report-to-markdown.py
+++ b/jenkins/jenkins-project-report-to-markdown.py
@@ -4,6 +4,7 @@ File       : jenkins-project-report-to-markdown.py
 Author     : Zygimantas Matonis
 Description: This script will generate markdown files from Jenkins project reports
 """
+
 import json
 import os
 import re
@@ -106,9 +107,7 @@ def write_markdown_file(view_data_dict, all_project_dict, markdown_output_dir):
 
 ---
 
-""".format(
-                cron_message
-            )
+""".format(cron_message)
             output_f.write(periodic_builds_message)
 
 
@@ -119,9 +118,7 @@ def write_readme(markdown_output_dir):
 This is automatically generated documentation of Jenkins jobs. **All changes in this directory will be overwritten 
 by scheduled job.** In oder to update the documentation, edit project description in Jenkins instead.
 
-""".format(
-        project_report_section_name
-    )
+""".format(project_report_section_name)
     with open(markdown_output_dir + "/README.md", "w") as output_f:
         output_f.write(readme_message)
 

--- a/jenkins/parser/actions.py
+++ b/jenkins/parser/actions.py
@@ -6,7 +6,6 @@ import datetime
 
 import helpers
 
-
 email_addresses = "cms-sdt-logs@cern.ch"
 
 html_file_path = os.environ.get("HOME") + "/builds/jenkins-test-parser-monitor/json-web-info.json"

--- a/jenkins/parser/paser-config-unittest.py
+++ b/jenkins/parser/paser-config-unittest.py
@@ -4,7 +4,6 @@ import re
 from subprocess import getstatusoutput
 import time
 
-
 jobs_config_path = "jenkins/parser/jobs-config.json"
 error_types = []
 

--- a/jenkins/report-jenkins-jobs.py
+++ b/jenkins/report-jenkins-jobs.py
@@ -27,7 +27,6 @@ parents = defaultdict(list)
 import json
 import time
 
-
 try:
     fd = open("/tmp/report_gen.txt")
     txt = fd.read()

--- a/jenkins_monitor_queue.py
+++ b/jenkins_monitor_queue.py
@@ -12,23 +12,17 @@ try:
 except:
     JENKINS_PREFIX = "jenkins"
 
-query_pending_builds = (
-    """{
+query_pending_builds = """{
 "query": {"bool": {"must": {"query_string": {"query": "_index:cmssdt-jenkins-queue-* AND in_queue:1 AND jenkins_server:%s", "default_operator": "AND"}}}},
 "from": 0,
 "size": 10000
-}"""
-    % JENKINS_PREFIX
-)
+}""" % JENKINS_PREFIX
 
-query_offline_nodes = (
-    """{
+query_offline_nodes = """{
 "query": {"bool": {"must": {"query_string": {"query": "jenkins_server:%s", "default_operator": "AND"}}}},
 "from": 0,
 "size": 10000
-}"""
-    % JENKINS_PREFIX
-)
+}""" % JENKINS_PREFIX
 
 
 queue_index = "cmssdt-jenkins-offline-nodes"

--- a/logRootQA.py
+++ b/logRootQA.py
@@ -447,7 +447,7 @@ if run in ["all", "JR"]:
             json.dump([nDiff, nAll, nOK], f)
     else:
         with open("comparison-JR.json") as f:
-            (nDiff, nAll, nOK) = json.load(f)
+            nDiff, nAll, nOK = json.load(f)
     print("SUMMARY Reco comparison results:", nDiff, "differences found in the comparisons")
     if nAll != nOK:
         print("SUMMARY Reco comparison had ", nAll - nOK, "failed jobs")

--- a/modify_comment.py
+++ b/modify_comment.py
@@ -2,6 +2,7 @@
 """
 Modifies last cmsbot message on Github
 """
+
 from github import Github
 from os.path import expanduser, dirname, abspath, join, exists
 from optparse import OptionParser

--- a/parse_iwyu_logs.py
+++ b/parse_iwyu_logs.py
@@ -9,8 +9,7 @@ excludes = 0
 pkg_name = "/".join(sys.argv[1].split("/")[-3:-1])
 files = 0
 splitline = sys.argv[2] + "/src/"
-print(
-    """<!DOCTYPE html>
+print("""<!DOCTYPE html>
 <html>
 <head>
 <style>
@@ -23,8 +22,7 @@ th, td {
     text-align: left;
 }
 </style>
-</head>"""
-)
+</head>""")
 print("<a href=" + '"' + sys.argv[1].split("/")[-1] + '"' + ">" + "Access BuildLog" + "</a><br/>")
 print('<table  align="center">')
 lines_seen = set()

--- a/parse_jenkins_builds.py
+++ b/parse_jenkins_builds.py
@@ -99,24 +99,18 @@ def grep(filename, pattern, verbose=False):
                     return True
 
 
-query_running_builds = (
-    """{
+query_running_builds = """{
 "query": {"bool": {"must": {"query_string": {"query": "job_status:Running AND jenkins_server:%s", "default_operator": "AND"}}}},
 "from": 0,
 "size": 10000
-}"""
-    % JENKINS_PREFIX
-)
+}""" % JENKINS_PREFIX
 
 # Query job with in_queue=1
-query_inqueue1 = (
-    """{
+query_inqueue1 = """{
 "query": {"bool": {"must": {"query_string": {"query": "in_queue: 1 AND start_time: 0 AND jenkins_server: %s", "default_operator": "AND"}}}},
 "from": 0,
 "size": 10000
-}"""
-    % JENKINS_PREFIX
-)
+}""" % JENKINS_PREFIX
 
 # Query jobs with in_queue=0
 query_inqueue0 = """{

--- a/pr-checks/check-pr-files.py
+++ b/pr-checks/check-pr-files.py
@@ -36,7 +36,7 @@ def check_commits_files(repo, pr, detail=False):
             print(o)
             return all_ok
         for l in [re.sub("\\s+", " ", x.strip()) for x in o.split("\n") if x.strip()]:
-            (t, f) = l.split(" ")
+            t, f = l.split(" ")
             if not f in data:
                 data[f] = []
                 details[f] = {}

--- a/process-error-reports.py
+++ b/process-error-reports.py
@@ -332,7 +332,7 @@ if __name__ == "__main__":
         # steps to it.
         for workflow, info in workflows.items():
             for step in info["steps"]:
-                (h, errorTitle, errorMessage) = understandError(name, t, p, info)
+                h, errorTitle, errorMessage = understandError(name, t, p, info)
                 if not h in validErrorReport:
                     validErrorReport[h] = {
                         "queue": t,

--- a/process-pull-request.py
+++ b/process-pull-request.py
@@ -2,6 +2,7 @@
 """
 Returns top commit of a PR (mostly used to comments)
 """
+
 from os.path import expanduser, dirname, abspath, join, exists
 from optparse import OptionParser
 from socket import setdefaulttimeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 99
 target-version = ['py36', 'py37', 'py38', 'py39', 'py310', 'py311']
-exclude = 'crab/python26/functools.py'
+exclude = 'crab/python26/functools.py|archive/.*'
 
 [tool.pylint.main]
 # Analyse import fallback blocks. This can be used to support both Python 2 and 3

--- a/reco_profiling/profileRunner.py
+++ b/reco_profiling/profileRunner.py
@@ -256,9 +256,7 @@ do
    echo "attempt $n"
    {} && break
    n=$((n+1))
-done""".format(
-        cmd
-    )
+done""".format(cmd)
     return s
 
 
@@ -266,9 +264,7 @@ def echoBefore(cmd, msg):
     s = """
 echo "{}"
 {}
-""".format(
-        msg, cmd
-    )
+""".format(msg, cmd)
     return s
 
 

--- a/report-pull-request-results.py
+++ b/report-pull-request-results.py
@@ -98,7 +98,7 @@ parser.add_option(
     default="",
 )
 
-(options, args) = parser.parse_args()
+options, args = parser.parse_args()
 
 
 def openlog(log, mode="r"):

--- a/report-summary-merged-prs.py
+++ b/report-summary-merged-prs.py
@@ -2,6 +2,7 @@
 """
 This script generates json file (like CMSSW_10_0_X.json) which is then used to render cmssdt ib page.
 """
+
 from __future__ import print_function
 from optparse import OptionParser
 import subprocess
@@ -47,7 +48,7 @@ parser.add_option(
     default=False,
 )
 
-(options, args) = parser.parse_args()
+options, args = parser.parse_args()
 
 """
 -----------------------------------------------------------------------------------

--- a/simple-cms-bot.py
+++ b/simple-cms-bot.py
@@ -2,6 +2,7 @@
 """
 Returns top commit of a PR (mostly used to comments)
 """
+
 from os.path import expanduser, dirname, abspath, join, exists
 from optparse import OptionParser
 from socket import setdefaulttimeout

--- a/tests/test_config-map.py
+++ b/tests/test_config-map.py
@@ -11,5 +11,5 @@ if __name__ == "__main__":
         l = l.strip(";")
         for p in l.split(";"):
             assert "=" in p
-            (key, value) = p.split("=")
+            key, value = p.split("=")
             assert re.match(KEYS_RE, key)


### PR DESCRIPTION
This PR updates formatting to Black 26.1.0, which introduces the stable 2026 style. Changes are formatting-only and include removal of unnecessary parentheses, consistent blank lines after imports, improved handling of # fmt: skip on one-liners, more compact multi-line string formatting, and standardized type comments. 