### PR TITLE
allow nvidia_t4 to be run on demand

### DIFF
--- a/gpu_flavors_ondemand.txt
+++ b/gpu_flavors_ondemand.txt
@@ -1,0 +1,1 @@
+nvidia_t4


### PR DESCRIPTION
This allow to request `nvidia_t4` gpu tests  on demand ( node that, for now, we have removed nvidia_t4 tests from the default gpu tests list)