### PR TITLE
Remove unused RUNALLSTEPS variable and the call to runall_cpu.sh in PR profiling script

### DIFF
--- a/pr_testing/run-pr-profiling.sh
+++ b/pr_testing/run-pr-profiling.sh
@@ -36,8 +36,6 @@ for PROFILING_WORKFLOW in $WORKFLOWS;do
   export RUNALLSTEPS=1
   $WORKSPACE/profiling/Gen_tool/runall.sh $CMSSW_VERSION || true
   $WORKSPACE/profiling/Gen_tool/runall_allocmon.sh $CMSSW_VERSION || true
-  unset RUNALLSTEPS
-  $WORKSPACE/profiling/Gen_tool/runall_cpu.sh $CMSSW_VERSION || true
   if [ ! -d $WORKSPACE/$CMSSW_VERSION/$PROFILING_WORKFLOW ] ; then
     mark_commit_status_all_prs "profiling wf $PROFILING_WORKFLOW" 'success' -u "${BUILD_URL}" -d "Error: failed to run profiling"
     echo "<li>$PROFILING_WORKFLOW: No such directory</li>" >> $WORKSPACE/upload/profiling/index-$PROFILING_WORKFLOW.html


### PR DESCRIPTION
Removes run of Igprof -pp which is not needed anymore.