### PR TITLE
Temp change to use IB clang-format for CMSSW_16_1_X_2026-02-06-1100

### DIFF
--- a/run-pr-code-checks
+++ b/run-pr-code-checks
@@ -144,13 +144,11 @@ if $CODE_FORMAT ; then
       USE_OLD_CODE_FORMAT=false
       if [ "${RELEASE_FORMAT}" == "CMSSW_16_1_X_2026-02-06-1100" ] ; then
         if [ $(diff ${CMSSW_RELEASE_BASE}/src/.clang-format ${CMSSW_BASE}/src/.clang-format | wc -l) -gt 0 ] ; then
-          echo "Clang format file changed in dev area. Using the IB clang format file"
-        fi
-        #if [ $(diff ${CMSSW_RELEASE_BASE}/src/.clang-format ${CMSSW_BASE}/src/.clang-format | wc -l) -gt 0 ] ; then
+          echo "Clang format file changed in dev area. Using the IB clang format file."
           mv  ${CMSSW_BASE}/src/.clang-format ${CMSSW_BASE}/.orig-clang-format
           cp ${CMSSW_RELEASE_BASE}/src/.clang-format ${CMSSW_BASE}/src/.clang-format
           USE_OLD_CODE_FORMAT=true
-        #fi
+        fi
       fi
       scram build -k -j $NUM_PROC code-format USER_CODE_FORMAT_FILE="${UP_DIR}/code-format-files.txt" > ${UP_DIR}/code-format.log 2>&1
       pushd $CMSSW_BASE/src


### PR DESCRIPTION
this change will make sure that bot uses old clang-format file from IB of CMSSW_16_1_X_2026-02-06-1100 if https://github.com/cms-sw/cmssw/pull/50060 is merged but not available in IB yet. This is to avoid any unnecessary changes suggested to clang-format using old LLVM but nw clang-format