### PR TITLE
add git user name and email to avoid Committer identity unknown issues

### DIFF
--- a/pr_testing/_helper_functions.sh
+++ b/pr_testing/_helper_functions.sh
@@ -51,6 +51,8 @@ function git_clone_and_merge (){
             git clone https://github.com/${BASE_REPO} -b ${BASE_BRANCH} || git clone git@github.com:${BASE_REPO} -b ${BASE_BRANCH}
         fi
         pushd ${BASE_REPO_NAME}  >/dev/null 2>&1
+            git config user.name "Cms Build"
+            git config user.email "cmsbuild@cern.ch"
             git pull --no-rebase https://github.com/${TEST_REPO}.git ${TEST_BRANCH}
         popd
     popd


### PR DESCRIPTION
PR bot tests with cms-bot PR are failing with error [a] . This change should allow to avoid such git errors

[a]
```
+ pushd cms-bot
+ git pull --no-rebase https://github.com/VourMa/cms-bot.git updateGPUWfsIn1601
From https://github.com/VourMa/cms-bot
 * branch                updateGPUWfsIn1601 -> FETCH_HEAD
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'cmsbuild@ngt-amd-mi300x-02.(none)')
```