### PR TITLE
IB profiling vtune link -- escape \1 and \2 correctly for running in python subprocess Popen

### DIFF
--- a/report-summary-merged-prs.py
+++ b/report-summary-merged-prs.py
@@ -1732,7 +1732,7 @@ if __name__ == "__main__":
     MAGIC_COMMAND_FIND_VTUNE_CHECKS_FILTER = (
         "ls -v "
         + JENKINS_ARTIFACTS_DIR
-        + '/profiling/RELEASE_NAME/ARCHITECTURE/*/step3-vtune.log 2>/dev/null | tail -1 |  sed "s|.*/RELEASE_NAME/||;s|/step3-vtune.log$||;s/^\\(.*\\/\\)\\(.*\\)/\1\\2\/r-step3-\2-hs/"'
+        + '/profiling/RELEASE_NAME/ARCHITECTURE/*/step3-vtune.log 2>/dev/null | tail -1 |  sed "s|.*/RELEASE_NAME/||;s|/step3-vtune.log$||;s|^\\(.*\\/\\)\\(.*\\)|\\1\\\2\/r-step3-\\2-hs|"'
     )
     CHECK_HLT_PATH = (
         JENKINS_ARTIFACTS_DIR + "/HLT-Validation/RELEASE_NAME/ARCHITECTURE/jenkins.log"


### PR DESCRIPTION
Tested with subprocess Popen
```
 >>> command_to_execute = 'echo /SDT/jenkins-artifacts/profiling/CMSSW_16_1_X_2026-03-03-2300/el8_amd64_gcc13/13034.21/step3-vtune.log | sed -e "s|.*/CMSSW_16_1_X_2026-03-03-2300/||;s|/step3-vtune.log$||;s|^\\(.*\\/\\)\\(.*\\)|\\1\\2/r-step3-\\2-hs|"'
 >>> print(command_to_execute)
echo /SDT/jenkins-artifacts/profiling/CMSSW_16_1_X_2026-03-03-2300/el8_amd64_gcc13/13034.21/step3-vtune.log | sed -e "s|.*/CMSSW_16_1_X_2026-03-03-2300/||;s|/step3-vtune.log$||;s|^\(.*\/\)\(.*\)|\1\2/r-step3-\2-hs|"
>>> p = subprocess.Popen(command_to_execute, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
>>> out, err = p.communicate()
>>> print(out)
b'el8_amd64_gcc13/13034.21/r-step3-13034.21-hs\n'
```