### PR TITLE
ModuleAllocMonitor diff table: If the module type/label/record triplet is missing from the PR or IB data show the missing numbers as N/A; add more transitions.

### DIFF
--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -24,7 +24,13 @@ NALLOC_BEGIN_LUMI_KEYS = [
     "nAlloc global begin luminosity block",
     "nAlloc stream begin luminosity block",
 ]
-NALLOC_TOTAL_KEYS = ["nAlloc construction", "nAlloc event", "nAlloc event setup"]
+NALLOC_TOTAL_KEYS = [
+    "nAlloc construction",
+    "nAlloc event",
+    "nAlloc event setup",
+    *NALLOC_BEGIN_RUN_KEYS,
+    *NALLOC_BEGIN_LUMI_KEYS,
+]
 
 
 def module_key(module):

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -42,7 +42,9 @@ def sum_numeric_values(data, keys, default="N/A"):
 
 
 def sum_with_suffix(data, metric_keys, suffix, default="N/A"):
-    return sum_numeric_values(data, ["%s %s" % (metric, suffix) for metric in metric_keys], default)
+    return sum_numeric_values(
+        data, ["%s %s" % (metric, suffix) for metric in metric_keys], default
+    )
 
 
 def format_metric(value):
@@ -51,7 +53,8 @@ def format_metric(value):
 
 def append_triplet_cell(summary_lines, ib, pr, diff, attrs='align="right"'):
     summary_lines.append(
-        '<td %s>%s<br>%s<br>%s</td>' % (attrs, format_metric(ib), format_metric(pr), format_metric(diff))
+        "<td %s>%s<br>%s<br>%s</td>"
+        % (attrs, format_metric(ib), format_metric(pr), format_metric(diff))
     )
 
 
@@ -167,8 +170,10 @@ def build_summary_header(ibdata, prdata, results):
         ),
         '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
         % (
-            ibdata["total"]["nAlloc global begin run"] + ibdata["total"]["nAlloc stream begin run"],
-            prdata["total"]["nAlloc global begin run"] + prdata["total"]["nAlloc stream begin run"],
+            ibdata["total"]["nAlloc global begin run"]
+            + ibdata["total"]["nAlloc stream begin run"],
+            prdata["total"]["nAlloc global begin run"]
+            + prdata["total"]["nAlloc stream begin run"],
             results["total"]["nAlloc global begin run diff"]
             + results["total"]["nAlloc stream begin run diff"],
         ),

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -18,6 +18,7 @@ def diff_from(metrics, data, dest, res):
             dmetric = dest.get(metric) - data.get(metric)
             res[metric + " diff"] = dmetric
 
+
 if len(sys.argv) == 1:
     print("""Usage: resources-diff.py IB_FILE PR_FILE
 Diff the content of two "resources.json" files and print the result to standard output.""")
@@ -100,9 +101,7 @@ results["total"] = {}
 results["total"]["type"] = prdata["total"]["type"]
 results["total"]["label"] = prdata["total"]["label"]
 
-diff_from(
-    metrics, ibdata["total"], prdata["total"], results["total"]
-)
+diff_from(metrics, ibdata["total"], prdata["total"], results["total"])
 
 results["modules"] = []
 keys = set()
@@ -133,7 +132,9 @@ for key in sorted(keys):
 
 datamapres = {}
 for module in results["modules"]:
-    datamapres["%s|%s|%s" % (module.get("label", ""), module.get("type", ""), module.get("record", ""))] = module
+    datamapres[
+        "%s|%s|%s" % (module.get("label", ""), module.get("type", ""), module.get("record", ""))
+    ] = module
 threshold = 5000.0
 error_threshold = 20000.0
 
@@ -257,7 +258,11 @@ summaryLines += [
 ]
 
 for item in datamapres.items():
-    key = "%s|%s|%s" % (item[1].get("label", ""), item[1].get("type", ""), item[1].get("record", ""))
+    key = "%s|%s|%s" % (
+        item[1].get("label", ""),
+        item[1].get("type", ""),
+        item[1].get("record", ""),
+    )
     if not key == "None|None|None" and not key == "||":
         moduleib = datamapib.get(key, {})
         modulepr = datamappr.get(key, {})
@@ -299,7 +304,11 @@ for item in sorted(
     key=lambda x: x[1].get("added total diff", float("nan")),
     reverse=True,
 ):
-    key = "%s|%s|%s" % (item[1].get("label", ""), item[1].get("type", ""), item[1].get("record", ""))
+    key = "%s|%s|%s" % (
+        item[1].get("label", ""),
+        item[1].get("type", ""),
+        item[1].get("record", ""),
+    )
     if not key == "None|None|None" and not key == "||":
         moduleib = datamapib.get(key, {})
         modulepr = datamappr.get(key, {})
@@ -326,8 +335,8 @@ for item in sorted(
             % (moduleres.get("label", ""), moduleres.get("type", ""), moduleres.get("record", "")),
             '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
             % (
-                moduleib.get("added construction",float("nan")),
-                modulepr.get("added construction",float("nan")),
+                moduleib.get("added construction", float("nan")),
+                modulepr.get("added construction", float("nan")),
                 moduleres.get("added construction diff", float("nan")),
             ),
             '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
@@ -337,7 +346,7 @@ for item in sorted(
                 modulepr.get("added global begin run", float("nan"))
                 + modulepr.get("added stream begin run", float("nan")),
                 moduleres.get("added global begin run diff", float("nan"))
-                + moduleres.get("added stream begin run diff", float("nan"))
+                + moduleres.get("added stream begin run diff", float("nan")),
             ),
             '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
             % (
@@ -346,49 +355,50 @@ for item in sorted(
                 modulepr.get("added global begin luminosity block", float("nan"))
                 + modulepr.get("added stream begin luminosity block", float("nan")),
                 moduleres.get("added global begin luminosity block diff", float("nan"))
-                + moduleres.get("added stream begin luminosity block diff", float("nan"))
+                + moduleres.get("added stream begin luminosity block diff", float("nan")),
             ),
             '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
             % (
                 moduleib.get("added event", float("nan")),
                 modulepr.get("added event", float("nan")),
-                moduleres.get("added event diff", float("nan"))
+                moduleres.get("added event diff", float("nan")),
             ),
             '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
             % (
                 moduleib.get("added event setup", float("nan")),
                 modulepr.get("added event setup", float("nan")),
-                moduleres.get("added event setup diff", float("nan"))
+                moduleres.get("added event setup diff", float("nan")),
             ),
             cellString
             + "%0.2f<br> %0.2f<br> %0.2f</td>"
-            % ( moduleib.get("added event setup", float("nan"))
-            + moduleib.get("added event", float("nan")) 
-            + moduleib.get("added construction", float("nan"))
-            + moduleib.get("added global begin run", float("nan"))
-            + moduleib.get("added stream begin run", float("nan"))
-            + moduleib.get("added global begin luminosity block", float("nan"))
-            + moduleib.get("added stream begin luminosity block", float("nan")),
-            modulepr.get("added event setup", float("nan"))
-            + modulepr.get("added event", float("nan"))
-            + modulepr.get("added construction", float("nan"))
-            + modulepr.get("added global begin run", float("nan"))
-            + modulepr.get("added stream begin run", float("nan"))
-            + modulepr.get("added global begin luminosity block", float("nan"))
-            + modulepr.get("added stream begin luminosity block", float("nan")),
-            moduleres.get("added event setup diff", float("nan"))
-            + moduleres.get("added event diff", float("nan"))
-            + moduleres.get("added construction diff", float("nan"))
-            + moduleres.get("added global begin run diff", float("nan"))
-            + moduleres.get("added stream begin run diff", float("nan"))
-            + moduleres.get("added global begin luminosity block diff", float("nan"))
-            + moduleres.get("added stream begin luminosity block diff", float("nan"))
+            % (
+                moduleib.get("added event setup", float("nan"))
+                + moduleib.get("added event", float("nan"))
+                + moduleib.get("added construction", float("nan"))
+                + moduleib.get("added global begin run", float("nan"))
+                + moduleib.get("added stream begin run", float("nan"))
+                + moduleib.get("added global begin luminosity block", float("nan"))
+                + moduleib.get("added stream begin luminosity block", float("nan")),
+                modulepr.get("added event setup", float("nan"))
+                + modulepr.get("added event", float("nan"))
+                + modulepr.get("added construction", float("nan"))
+                + modulepr.get("added global begin run", float("nan"))
+                + modulepr.get("added stream begin run", float("nan"))
+                + modulepr.get("added global begin luminosity block", float("nan"))
+                + modulepr.get("added stream begin luminosity block", float("nan")),
+                moduleres.get("added event setup diff", float("nan"))
+                + moduleres.get("added event diff", float("nan"))
+                + moduleres.get("added construction diff", float("nan"))
+                + moduleres.get("added global begin run diff", float("nan"))
+                + moduleres.get("added stream begin run diff", float("nan"))
+                + moduleres.get("added global begin luminosity block diff", float("nan"))
+                + moduleres.get("added stream begin luminosity block diff", float("nan")),
             ),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
             % (
                 moduleib.get("nAlloc construction", float("nan")),
                 modulepr.get("nAlloc construction", float("nan")),
-                moduleres.get("nAlloc construction diff", float("nan")  ),
+                moduleres.get("nAlloc construction diff", float("nan")),
             ),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
             % (
@@ -401,7 +411,7 @@ for item in sorted(
             ),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
             % (
-                moduleib.get("nAlloc global begin luminosity block", float("nan")) 
+                moduleib.get("nAlloc global begin luminosity block", float("nan"))
                 + moduleib.get("nAlloc stream begin luminosity block", float("nan")),
                 modulepr.get("nAlloc global begin luminosity block", float("nan"))
                 + modulepr.get("nAlloc stream begin luminosity block", float("nan")),
@@ -409,9 +419,11 @@ for item in sorted(
                 + moduleres.get("nAlloc stream begin luminosity block diff", float("nan")),
             ),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-            % (moduleib.get("nAlloc event", float("nan")),
+            % (
+                moduleib.get("nAlloc event", float("nan")),
                 modulepr.get("nAlloc event", float("nan")),
-                moduleres.get("nAlloc event diff", float("nan"))),
+                moduleres.get("nAlloc event diff", float("nan")),
+            ),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
             % (
                 moduleib.get("nAlloc event setup", float("nan")),
@@ -431,7 +443,11 @@ for item in sorted(
                 + moduleres.get("nAlloc construction diff", float("nan")),
             ),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-             % ( moduleib.get("transitions", float("nan")), modulepr.get("transitions", float("nan")), moduleres.get("transitions diff", float("nan"))),
+            % (
+                moduleib.get("transitions", float("nan")),
+                modulepr.get("transitions", float("nan")),
+                moduleres.get("transitions diff", float("nan")),
+            ),
             "</tr>",
         ]
 

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -268,11 +268,12 @@ def build_summary_header(ibdata, prdata, results):
 
 
 def append_module_columns_prefix(summary_lines, moduleres, prefix):
-    addedtotaldiff = numeric_value(moduleres, "added total diff", float("-inf"))
-    color = added_total_color(addedtotaldiff)
     cell_attrs = 'align="right"'
-    if color:
-        cell_attrs += " " + color
+    if prefix == "added":
+        addedtotaldiff = numeric_value(moduleres, "added total diff", float("-inf"))
+        color = added_total_color(addedtotaldiff)
+        if color:
+            cell_attrs += " " + color
     append_triplet_cell(
         summary_lines,
         sum_with_prefix_suffix(moduleres, BEGIN_JOB_KEYS, prefix=prefix, suffix="IB"),

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -5,15 +5,20 @@ import json
 import os
 import math
 
+threshold = 5000.0
+error_threshold = 20000.0
 
 def diff_from(metrics, data, dest, res):
     for metric in metrics:
         ibkey = "%s IB" % metric
-        res[ibkey] = data.get(metric, float("nan"))
+        res[ibkey] = data.get(metric, "N/A")
         prkey = "%s PR" % metric
-        res[prkey] = dest.get(metric, float("nan"))
-        if math.isnan(res[ibkey]) or math.isnan(res[prkey]):
-            res[metric + " diff"] = float("nan")
+        res[prkey] = dest.get(metric, "N/A")
+        if res[ibkey] == "N/A" or res[prkey] == "N/A":
+            if res[prkey] != "N/A":
+                res[metric + " diff"] = res[prkey] - 0
+            elif res[ibkey] != "N/A":
+                res[metric + " diff"] = 0 - res[ibkey]
         else:
             dmetric = dest.get(metric) - data.get(metric)
             res[metric + " diff"] = dmetric
@@ -121,8 +126,6 @@ for module in results["modules"]:
     datamapres[
         "%s|%s|%s" % (module.get("label", ""), module.get("type", ""), module.get("record", ""))
     ] = module
-threshold = 5000.0
-error_threshold = 20000.0
 
 
 summaryLines = []
@@ -254,32 +257,34 @@ for item in datamapres.items():
         modulepr = datamappr.get(key, {})
         moduleres = datamapres.get(key, {})
         added_total_pr = (
-            modulepr.get("added event setup", float("nan"))
-            + modulepr.get("added event", float("nan"))
-            + modulepr.get("added construction", float("nan"))
-            + modulepr.get("added global begin run", float("nan"))
-            + modulepr.get("added stream begin run", float("nan"))
-            + modulepr.get("added global begin luminosity block", float("nan"))
-            + modulepr.get("added stream begin luminosity block", float("nan"))
-        )
+            moduleres.get("added event setup PR", 0)
+            + moduleres.get("added event PR", 0)
+            + moduleres.get("added construction PR", 0)
+            + moduleres.get("added global begin run PR", 0)
+            + moduleres.get("added stream begin run PR", 0)
+            + moduleres.get("added global begin luminosity block PR", 0)
+            + moduleres.get("added stream begin luminosity block PR", 0)
+        ) if isinstance(moduleres.get("added event setup PR", 0), (int, float)) and isinstance(moduleres.get("added event PR", 0), (int, float)) and isinstance(moduleres.get("added construction PR", 0), (int, float)) and isinstance(moduleres.get("added global begin run PR", 0), (int, float)) and isinstance(moduleres.get("added stream begin run PR", 0), (int, float)) and isinstance(moduleres.get("added global begin luminosity block PR", 0), (int, float)) and isinstance(moduleres.get("added stream begin luminosity block PR", 0), (int, float)) else "N/A"
+        moduleres["added total PR"] = added_total_pr
         added_total_ib = (
-            moduleib.get("added event setup", float("nan"))
-            + moduleib.get("added event", float("nan"))
-            + moduleib.get("added construction", float("nan"))
-            + moduleib.get("added global begin run", float("nan"))
-            + moduleib.get("added stream begin run", float("nan"))
-            + moduleib.get("added global begin luminosity block", float("nan"))
-            + moduleib.get("added stream begin luminosity block", float("nan"))
-        )
+            moduleres.get("added event setup IB", 0)
+            + moduleres.get("added event IB", 0)
+            + moduleres.get("added construction IB", 0)
+            + moduleres.get("added global begin run IB", 0)
+            + moduleres.get("added stream begin run IB", 0)
+            + moduleres.get("added global begin luminosity block IB", 0)
+            + moduleres.get("added stream begin luminosity block IB", 0)
+        ) if isinstance(moduleres.get("added event setup IB", 0), (int, float)) and isinstance(moduleres.get("added event IB", 0), (int, float)) and isinstance(moduleres.get("added construction IB", 0), (int, float)) and isinstance(moduleres.get("added global begin run IB", 0), (int, float)) and isinstance(moduleres.get("added stream begin run IB", 0), (int, float)) and isinstance(moduleres.get("added global begin luminosity block IB", 0), (int, float)) and isinstance(moduleres.get("added stream begin luminosity block IB", 0), (int, float)) else "N/A"
+        moduleres["added total IB"] = added_total_ib
         added_total_diff = (
-            moduleres.get("added event setup diff", float("nan"))
-            + moduleres.get("added event diff", float("nan"))
-            + moduleres.get("added construction diff", float("nan"))
-            + moduleres.get("added global begin run diff", float("nan"))
-            + moduleres.get("added stream begin run diff", float("nan"))
-            + moduleres.get("added global begin luminosity block diff", float("nan"))
-            + moduleres.get("added stream begin luminosity block diff", float("nan"))
-        )
+            moduleres.get("added event setup diff", 0)
+            + moduleres.get("added event diff", 0)
+            + moduleres.get("added construction diff", 0)
+            + moduleres.get("added global begin run diff", 0)
+            + moduleres.get("added stream begin run diff", 0)
+            + moduleres.get("added global begin luminosity block diff", 0)
+            + moduleres.get("added stream begin luminosity block diff", 0)
+        ) if isinstance(moduleres.get("added event setup diff", 0), (int, float)) and isinstance(moduleres.get("added event diff", 0), (int, float)) and isinstance(moduleres.get("added construction diff", 0), (int, float)) and isinstance(moduleres.get("added global begin run diff", 0), (int, float)) and isinstance(moduleres.get("added stream begin run diff", 0), (int, float)) and isinstance(moduleres.get("added global begin luminosity block diff", 0), (int, float)) and isinstance(moduleres.get("added stream begin luminosity block diff", 0), (int, float)) else "N/A"
         moduleres["added total diff"] = added_total_diff
 dumpfile = (
     os.path.dirname(os.path.realpath(sys.argv[2]))
@@ -292,7 +297,7 @@ with open(dumpfile, "w") as f:
 
 for item in sorted(
     datamapres.items(),
-    key=lambda x: x[1].get("added total diff", float("nan")),
+    key=lambda x: x[1].get("added total diff", float("-inf")) if isinstance(x[1].get("added total diff", float("-inf")), (int, float)) else float("-inf"),
     reverse=True,
 ):
     key = "%s|%s|%s" % (
@@ -304,12 +309,9 @@ for item in sorted(
         moduleib = datamapib.get(key, {})
         modulepr = datamappr.get(key, {})
         moduleres = datamapres.get(key, {})
-        if moduleres.get("added total diff", float("nan")) == math.nan:
-            print("Error: module %s is not in diff results" % key)
-            continue
         cellString = '<td align="right" '
         color = ""
-        addedtotaldiff = moduleres.get("added total diff", float("nan"))
+        addedtotaldiff = moduleres.get("added total diff", float("-inf")) if isinstance(moduleres.get("added total diff", float("-inf")), (int, float)) else float("-inf")
         if addedtotaldiff > threshold:
             color = 'bgcolor="orange"'
         if addedtotaldiff > error_threshold:
@@ -323,124 +325,118 @@ for item in sorted(
         summaryLines += [
             "<tr>",
             '<td align="center">%s<BR>%s<BR> %s</td>'
-            % (moduleres.get("label", ""), moduleres.get("type", ""), moduleres.get("record", "")),
-            '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
-            % (
-                moduleib.get("added construction", float("nan")),
-                modulepr.get("added construction", float("nan")),
-                moduleres.get("added construction diff", float("nan")),
-            ),
-            '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
-            % (
-                moduleib.get("added global begin run", float("nan"))
-                + moduleib.get("added stream begin run", float("nan")),
-                modulepr.get("added global begin run", float("nan"))
-                + modulepr.get("added stream begin run", float("nan")),
-                moduleres.get("added global begin run diff", float("nan"))
-                + moduleres.get("added stream begin run diff", float("nan")),
-            ),
-            '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
-            % (
-                moduleib.get("added global begin luminosity block", float("nan"))
-                + moduleib.get("added stream begin luminosity block", float("nan")),
-                modulepr.get("added global begin luminosity block", float("nan"))
-                + modulepr.get("added stream begin luminosity block", float("nan")),
-                moduleres.get("added global begin luminosity block diff", float("nan"))
-                + moduleres.get("added stream begin luminosity block diff", float("nan")),
-            ),
-            '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
-            % (
-                moduleib.get("added event", float("nan")),
-                modulepr.get("added event", float("nan")),
-                moduleres.get("added event diff", float("nan")),
-            ),
-            '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
-            % (
-                moduleib.get("added event setup", float("nan")),
-                modulepr.get("added event setup", float("nan")),
-                moduleres.get("added event setup diff", float("nan")),
-            ),
+            % (moduleres.get("label", ""), moduleres.get("type", ""), moduleres.get("record", ""))
+        ]
+        added_construction_ib = moduleres.get("added construction IB", "N/A") if isinstance(moduleres.get("added construction IB", "N/A"), (int, float)) else "N/A"
+        added_construction_pr = moduleres.get("added construction PR", "N/A") if isinstance(moduleres.get("added construction PR", "N/A"), (int, float)) else "N/A"
+        added_construction_diff = moduleres.get("added construction diff", "N/A") if isinstance(moduleres.get("added construction diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right"> {added_construction_ib}<br> {added_construction_pr}<br> {added_construction_diff}</td>'
+        ]
+        added_begin_run_ib = (moduleib.get("added global begin run", "N/A") + moduleib.get("added stream begin run", "N/A")) if isinstance(moduleib.get("added global begin run", "N/A"), (int, float)) and isinstance(moduleib.get("added stream begin run", "N/A"), (int, float)) else "N/A"
+        added_begin_run_pr = (modulepr.get("added global begin run", "N/A") + modulepr.get("added stream begin run", "N/A")) if isinstance(modulepr.get("added global begin run", "N/A"), (int, float)) and isinstance(modulepr.get("added stream begin run", "N/A"), (int, float)) else "N/A"
+        added_begin_run_diff = (moduleres.get("added global begin run diff", "N/A") + moduleres.get("added stream begin run diff", "N/A")) if isinstance(moduleres.get("added global begin run diff", "N/A"), (int, float)) and isinstance(moduleres.get("added stream begin run diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right"> {added_begin_run_ib}<br> {added_begin_run_pr}<br> {added_begin_run_diff}</td>'
+        ]
+        added_luminosity_block_ib = (moduleib.get("added global begin luminosity block", "N/A") + moduleib.get("added stream begin luminosity block", "N/A")) if isinstance(moduleib.get("added global begin luminosity block", "N/A"), (int, float)) and isinstance(moduleib.get("added stream begin luminosity block", "N/A"), (int, float)) else "N/A"
+        added_luminosity_block_pr = (modulepr.get("added global begin luminosity block", "N/A") + modulepr.get("added stream begin luminosity block", "N/A")) if isinstance(modulepr.get("added global begin luminosity block", "N/A"), (int, float)) and isinstance(modulepr.get("added stream begin luminosity block", "N/A"), (int, float)) else "N/A"
+        added_luminosity_block_diff = (moduleres.get("added global begin luminosity block diff", "N/A") + moduleres.get("added stream begin luminosity block diff", "N/A")) if isinstance(moduleres.get("added global begin luminosity block diff", "N/A"), (int, float)) and isinstance(moduleres.get("added stream begin luminosity block diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right"> {added_luminosity_block_ib}<br> {added_luminosity_block_pr}<br> {added_luminosity_block_diff}</td>'
+        ]
+        added_event_ib = moduleib.get("added event", "N/A") if isinstance(moduleib.get("added event", "N/A"), (int, float)) else "N/A"
+        added_event_pr = modulepr.get("added event", "N/A") if isinstance(modulepr.get("added event", "N/A"), (int, float)) else "N/A"
+        added_event_diff = moduleres.get("added event diff", "N/A") if isinstance(moduleres.get("added event diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right"> {added_event_ib}<br> {added_event_pr}<br> {added_event_diff}</td>'
+        ]
+        added_event_setup_ib = moduleib.get("added event setup", "N/A") if isinstance(moduleib.get("added event setup", "N/A"), (int, float)) else "N/A"
+        added_event_setup_pr = modulepr.get("added event setup", "N/A") if isinstance(modulepr.get("added event setup", "N/A"), (int, float)) else "N/A"
+        added_event_setup_diff = moduleres.get("added event setup diff", "N/A") if isinstance(moduleres.get("added event setup diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right"> {added_event_setup_ib}<br> {added_event_setup_pr}<br> {added_event_setup_diff}</td>'
+        ]
+        added_total_ib = (moduleib.get("added event setup", "N/A") 
+                + moduleib.get("added event", "N/A")
+                + moduleib.get("added construction", "N/A")
+                + moduleib.get("added global begin run", "N/A")
+                + moduleib.get("added stream begin run", "N/A")
+                + moduleib.get("added global begin luminosity block", "N/A")
+                + moduleib.get("added stream begin luminosity block", "N/A")) if isinstance(moduleib.get("added event setup", "N/A"), (int, float)) and isinstance(moduleib.get("added event", "N/A"), (int, float)) and isinstance(moduleib.get("added construction", "N/A"), (int, float)) and isinstance(moduleib.get("added global begin run", "N/A"), (int, float)) and isinstance(moduleib.get("added stream begin run", "N/A"), (int, float)) and isinstance(moduleib.get("added global begin luminosity block", "N/A"), (int, float)) and isinstance(moduleib.get("added stream begin luminosity block", "N/A"), (int, float)) else "N/A"
+        added_total_pr = (modulepr.get("added event setup", "N/A")
+                + modulepr.get("added event", "N/A")
+                + modulepr.get("added construction", "N/A")
+                + modulepr.get("added global begin run", "N/A")
+                + modulepr.get("added stream begin run", "N/A")
+                + modulepr.get("added global begin luminosity block", "N/A")
+                + modulepr.get("added stream begin luminosity block", "N/A")) if isinstance(modulepr.get("added event setup", "N/A"), (int, float)) and isinstance(modulepr.get("added event", "N/A"), (int, float)) and isinstance(modulepr.get("added construction", "N/A"), (int, float)) and isinstance(modulepr.get("added global begin run", "N/A"), (int, float)) and isinstance(modulepr.get("added stream begin run", "N/A"), (int, float)) and isinstance(modulepr.get("added global begin luminosity block", "N/A"), (int, float)) and isinstance(modulepr.get("added stream begin luminosity block", "N/A"), (int, float)) else "N/A"
+        added_total_diff = (moduleres.get("added event setup diff", "N/A")
+                + moduleres.get("added event diff", "N/A")
+                + moduleres.get("added construction diff", "N/A")
+                + moduleres.get("added global begin run diff", "N/A")
+                + moduleres.get("added stream begin run diff", "N/A")
+                + moduleres.get("added global begin luminosity block diff", "N/A")
+                + moduleres.get("added stream begin luminosity block diff", "N/A")) if isinstance(moduleres.get("added event setup diff", "N/A"), (int, float)) and isinstance(moduleres.get("added event diff", "N/A"), (int, float)) and isinstance(moduleres.get("added construction diff", "N/A"), (int, float)) and isinstance(moduleres.get("added global begin run diff", "N/A"), (int, float)) and isinstance(moduleres.get("added stream begin run diff", "N/A"), (int, float)) and isinstance(moduleres.get("added global begin luminosity block diff", "N/A"), (int, float)) and isinstance(moduleres.get("added stream begin luminosity block diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
             cellString
-            + "%0.2f<br> %0.2f<br> %0.2f</td>"
-            % (
-                moduleib.get("added event setup", float("nan"))
-                + moduleib.get("added event", float("nan"))
-                + moduleib.get("added construction", float("nan"))
-                + moduleib.get("added global begin run", float("nan"))
-                + moduleib.get("added stream begin run", float("nan"))
-                + moduleib.get("added global begin luminosity block", float("nan"))
-                + moduleib.get("added stream begin luminosity block", float("nan")),
-                modulepr.get("added event setup", float("nan"))
-                + modulepr.get("added event", float("nan"))
-                + modulepr.get("added construction", float("nan"))
-                + modulepr.get("added global begin run", float("nan"))
-                + modulepr.get("added stream begin run", float("nan"))
-                + modulepr.get("added global begin luminosity block", float("nan"))
-                + modulepr.get("added stream begin luminosity block", float("nan")),
-                moduleres.get("added event setup diff", float("nan"))
-                + moduleres.get("added event diff", float("nan"))
-                + moduleres.get("added construction diff", float("nan"))
-                + moduleres.get("added global begin run diff", float("nan"))
-                + moduleres.get("added stream begin run diff", float("nan"))
-                + moduleres.get("added global begin luminosity block diff", float("nan"))
-                + moduleres.get("added stream begin luminosity block diff", float("nan")),
-            ),
-            '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-            % (
-                moduleib.get("nAlloc construction", float("nan")),
-                modulepr.get("nAlloc construction", float("nan")),
-                moduleres.get("nAlloc construction diff", float("nan")),
-            ),
-            '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-            % (
-                moduleib.get("nAlloc global begin run", float("nan"))
-                + moduleib.get("nAlloc stream begin run", float("nan")),
-                modulepr.get("nAlloc global begin run", float("nan"))
-                + modulepr.get("nAlloc stream begin run", float("nan")),
-                moduleres.get("nAlloc global begin run diff", float("nan"))
-                + moduleres.get("nAlloc stream begin run diff", float("nan")),
-            ),
-            '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-            % (
-                moduleib.get("nAlloc global begin luminosity block", float("nan"))
-                + moduleib.get("nAlloc stream begin luminosity block", float("nan")),
-                modulepr.get("nAlloc global begin luminosity block", float("nan"))
-                + modulepr.get("nAlloc stream begin luminosity block", float("nan")),
-                moduleres.get("nAlloc global begin luminosity block diff", float("nan"))
-                + moduleres.get("nAlloc stream begin luminosity block diff", float("nan")),
-            ),
-            '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-            % (
-                moduleib.get("nAlloc event", float("nan")),
-                modulepr.get("nAlloc event", float("nan")),
-                moduleres.get("nAlloc event diff", float("nan")),
-            ),
-            '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-            % (
-                moduleib.get("nAlloc event setup", float("nan")),
-                modulepr.get("nAlloc event setup", float("nan")),
-                moduleres.get("nAlloc event setup diff", float("nan")),
-            ),
-            '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-            % (
-                moduleib.get("nAlloc event setup", float("nan"))
-                + moduleib.get("nAlloc event", float("nan"))
-                + moduleib.get("nAlloc construction", float("nan")),
-                modulepr.get("nAlloc event setup", float("nan"))
-                + modulepr.get("nAlloc event", float("nan"))
-                + modulepr.get("nAlloc construction", float("nan")),
-                moduleres.get("nAlloc event setup diff", float("nan"))
-                + moduleres.get("nAlloc event diff", float("nan"))
-                + moduleres.get("nAlloc construction diff", float("nan")),
-            ),
-            '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-            % (
-                moduleib.get("transitions", float("nan")),
-                modulepr.get("transitions", float("nan")),
-                moduleib.get("transitions", float("nan"))
-                - modulepr.get("transitions", float("nan")),
-            ),
-            "</tr>",
+            + f"{added_total_ib}<br>{added_total_pr}<br>{added_total_diff}</td>"
+        ]
+        nAlloc_construction_ib = moduleres.get("nAlloc construction IB", "N/A") if isinstance(moduleres.get("nAlloc construction IB", "N/A"), (int, float)) else "N/A"
+        nAlloc_construction_pr = moduleres.get("nAlloc construction PR", "N/A") if isinstance(moduleres.get("nAlloc construction PR", "N/A"), (int, float)) else "N/A"
+        nAlloc_construction_diff = moduleres.get("nAlloc construction diff", "N/A") if isinstance(moduleres.get("nAlloc construction diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right">{nAlloc_construction_ib}<br>{nAlloc_construction_pr}<br>{nAlloc_construction_diff}</td>'
+        ]
+        nAlloc_begin_run_ib = (moduleres.get("nAlloc global begin run IB", "N/A") + moduleres.get("nAlloc stream begin run IB", "N/A")) if isinstance(moduleres.get("nAlloc global begin run IB", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin run IB", "N/A"), (int, float)) else "N/A"
+        nAlloc_begin_run_pr = (moduleres.get("nAlloc global begin run PR", "N/A") + moduleres.get("nAlloc stream begin run PR", "N/A")) if isinstance(moduleres.get("nAlloc global begin run PR", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin run PR", "N/A"), (int, float)) else "N/A"
+        nAlloc_begin_run_diff = (moduleres.get("nAlloc global begin run diff", "N/A") + moduleres.get("nAlloc stream begin run diff", "N/A")) if isinstance(moduleres.get("nAlloc global begin run diff", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin run diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right">{nAlloc_begin_run_ib}<br>{nAlloc_begin_run_pr}<br>{nAlloc_begin_run_diff}</td>'
+        ]
+        nAlloc_begin_luminosity_block_ib = (moduleres.get("nAlloc global begin luminosity block IB", "N/A") + moduleres.get("nAlloc stream begin luminosity block IB", "N/A")) if isinstance(moduleres.get("nAlloc global begin luminosity block IB", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin luminosity block IB", "N/A"), (int, float)) else "N/A"
+        nAlloc_begin_luminosity_block_pr = (moduleres.get("nAlloc global begin luminosity block PR", "N/A") + moduleres.get("nAlloc stream begin luminosity block PR", "N/A")) if isinstance(moduleres.get("nAlloc global begin luminosity block PR", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin luminosity block PR", "N/A"), (int, float)) else "N/A"
+        nAlloc_begin_luminosity_block_diff = (moduleres.get("nAlloc global begin luminosity block diff", "N/A") + moduleres.get("nAlloc stream begin luminosity block diff", "N/A")) if isinstance(moduleres.get("nAlloc global begin luminosity block diff", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin luminosity block diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right">{nAlloc_begin_luminosity_block_ib}<br>{nAlloc_begin_luminosity_block_pr}<br>{nAlloc_begin_luminosity_block_diff}</td>'
+        ]
+        nAlloc_event_ib = moduleres.get("nAlloc event IB", "N/A") if isinstance(moduleres.get("nAlloc event IB", "N/A"), (int, float)) else "N/A"
+        nAlloc_event_pr = moduleres.get("nAlloc event PR", "N/A") if isinstance(moduleres.get("nAlloc event PR", "N/A"), (int, float)) else "N/A"
+        nAlloc_event_diff = moduleres.get("nAlloc event diff", "N/A") if isinstance(moduleres.get("nAlloc event diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right">{nAlloc_event_ib}<br>{nAlloc_event_pr}<br>{nAlloc_event_diff}</td>'
+        ]
+        nAlloc_event_setup_ib = moduleres.get("nAlloc event setup IB", "N/A") if isinstance(moduleres.get("nAlloc event setup IB", "N/A"), (int, float)) else "N/A"
+        nAlloc_event_setup_pr = moduleres.get("nAlloc event setup PR", "N/A") if isinstance(moduleres.get("nAlloc event setup PR", "N/A"), (int, float)) else "N/A"
+        nAlloc_event_setup_diff = moduleres.get("nAlloc event setup diff", "N/A") if isinstance(moduleres.get("nAlloc event setup diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right">{nAlloc_event_setup_ib}<br>{nAlloc_event_setup_pr}<br>{nAlloc_event_setup_diff}</td>'
+        ]
+        nAlloc_total_ib = (
+                    moduleres.get("nAlloc event setup IB", "N/A") + moduleres.get("nAlloc event IB", "N/A")
+               + moduleres.get("nAlloc construction IB", "N/A") ) if isinstance(moduleres.get("nAlloc event setup IB", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc construction IB", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc event IB", "N/A"), (int, float)) else "N/A"
+        nAlloc_total_pr = (
+                moduleres.get("nAlloc event setup PR", "N/A")
+                + moduleres.get("nAlloc event PR", "N/A")
+                + moduleres.get("nAlloc construction PR", "N/A")) if isinstance(moduleres.get("nAlloc event setup PR", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc construction PR", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc event PR", "N/A"), (int, float)) else "N/A"
+        nAlloc_total_diff = (
+                moduleres.get("nAlloc event setup diff", "N/A")
+                + moduleres.get("nAlloc event diff", "N/A")
+                + moduleres.get("nAlloc construction diff", "N/A")) if isinstance(moduleres.get("nAlloc event setup diff", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc construction diff", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc event diff", "N/A"), (int, float)) else "N/A"
+        summaryLines += [
+            f'<td align="right">{nAlloc_total_ib}<br>{nAlloc_total_pr}<br>{nAlloc_total_diff}</td>'
+        ]
+        transitions_ib = moduleib.get("transitions", "N/A") if isinstance(moduleib.get("transitions", "N/A"), (int, float)) else "N/A"
+        transitions_pr = modulepr.get("transitions", "N/A")  if isinstance(modulepr.get("transitions", "N/A"), (int, float)) else "N/A"
+        if isinstance(transitions_ib, (int, float)) and isinstance(transitions_pr, (int, float)):
+            transitions_diff = (transitions_ib - transitions_pr)
+        else:
+            if not isinstance(transitions_ib, (int, float)) and isinstance(transitions_pr, (int, float)):
+                transitions_diff = transitions_pr - 0
+            elif isinstance(transitions_ib, (int, float)) and not isinstance(transitions_pr, (int, float)):
+                transitions_diff = 0 -transitions_ib
+        summaryLines += [
+            f'<td align="right">{transitions_ib}<br>{transitions_pr}<br>{transitions_diff}</td>'
         ]
 
 summaryLines += []

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -3,10 +3,329 @@
 import sys
 import json
 import os
-import math
 
 threshold = 5000.0
 error_threshold = 20000.0
+
+ADDED_BEGIN_RUN_KEYS = ["added global begin run", "added stream begin run"]
+ADDED_BEGIN_LUMI_KEYS = [
+    "added global begin luminosity block",
+    "added stream begin luminosity block",
+]
+ADDED_TOTAL_KEYS = [
+    "added construction",
+    "added event",
+    "added event setup",
+    *ADDED_BEGIN_RUN_KEYS,
+    *ADDED_BEGIN_LUMI_KEYS,
+]
+NALLOC_BEGIN_RUN_KEYS = ["nAlloc global begin run", "nAlloc stream begin run"]
+NALLOC_BEGIN_LUMI_KEYS = [
+    "nAlloc global begin luminosity block",
+    "nAlloc stream begin luminosity block",
+]
+NALLOC_TOTAL_KEYS = ["nAlloc construction", "nAlloc event", "nAlloc event setup"]
+
+
+def module_key(module):
+    return "%s|%s|%s" % (module.get("label", ""), module.get("type", ""), module.get("record", ""))
+
+
+def numeric_value(data, key, default="N/A"):
+    value = data.get(key, default)
+    return value if isinstance(value, (int, float)) else default
+
+
+def sum_numeric_values(data, keys, default="N/A"):
+    values = [data.get(key, default) for key in keys]
+    return sum(values) if all(isinstance(value, (int, float)) for value in values) else default
+
+
+def sum_with_suffix(data, metric_keys, suffix, default="N/A"):
+    return sum_numeric_values(data, ["%s %s" % (metric, suffix) for metric in metric_keys], default)
+
+
+def format_metric(value):
+    return f"{value:.2f}" if isinstance(value, float) else str(value)
+
+
+def append_triplet_cell(summary_lines, ib, pr, diff, attrs='align="right"'):
+    summary_lines.append(
+        '<td %s>%s<br>%s<br>%s</td>' % (attrs, format_metric(ib), format_metric(pr), format_metric(diff))
+    )
+
+
+def added_total_color(diff_value):
+    if not isinstance(diff_value, (int, float)):
+        return ""
+    if diff_value > error_threshold:
+        return 'bgcolor="red"'
+    if diff_value > threshold:
+        return 'bgcolor="orange"'
+    if diff_value < -1.0 * error_threshold:
+        return 'bgcolor="green"'
+    if diff_value < -1.0 * threshold:
+        return 'bgcolor="cyan"'
+    return ""
+
+
+def is_valid_module_key(key):
+    return key != "None|None|None" and key != "||"
+
+
+def transitions_diff_value(transitions_ib, transitions_pr):
+    if isinstance(transitions_ib, (int, float)) and isinstance(transitions_pr, (int, float)):
+        return transitions_ib - transitions_pr
+    if not isinstance(transitions_ib, (int, float)) and isinstance(transitions_pr, (int, float)):
+        return transitions_pr - 0
+    if isinstance(transitions_ib, (int, float)) and not isinstance(transitions_pr, (int, float)):
+        return 0 - transitions_ib
+    return "N/A"
+
+
+def update_added_totals(datamapres):
+    for module in datamapres.values():
+        key = module_key(module)
+        if not is_valid_module_key(key):
+            continue
+        module["added total PR"] = sum_with_suffix(module, ADDED_TOTAL_KEYS, "PR")
+        module["added total IB"] = sum_with_suffix(module, ADDED_TOTAL_KEYS, "IB")
+        module["added total diff"] = sum_with_suffix(module, ADDED_TOTAL_KEYS, "diff")
+
+
+def build_summary_header(ibdata, prdata, results):
+    return [
+        "<html>",
+        "<head><style>",
+        "table, th, td {border: 1px solid black;}</style>",
+        "<style> th, td {padding: 15px;}</style></head>",
+        "<body><h3>ModuleAllocMonitor Resources Difference</h3><table>",
+        '</table><table><tr><td bgcolor="orange">',
+        "warn threshold %0.2f kB" % threshold,
+        '</td></tr><tr><td bgcolor="red">',
+        "error threshold %0.2f kB" % error_threshold,
+        '</td></tr><tr><td bgcolor="green">',
+        "warn threshold -%0.2f kB" % threshold,
+        '</td></tr><tr><td bgcolor="cyan">',
+        "warn threshold -%0.2f kB" % error_threshold,
+        "</td></tr>",
+        "<tr><td>metric:<BR>&lt;baseline&gt;<BR>&lt;pull request&gt;<BR>&lt;PR - baseline&gt; </td>",
+        "</tr></table>",
+        "<table>",
+        '<tr><td align="center">Type<BR>Label</td>',
+        '<td align="center">added construction</td>',
+        '<td align="center">added begin run</td>',
+        '<td align="center">added begin luminosity block</td>',
+        '<td align="center">added event</td>',
+        '<td align="center">added event setup</td>',
+        '<td align="center">nAlloc construction</td>',
+        '<td align="center">nAlloc begin run</td>',
+        '<td align="center">nAlloc begin luminosity block</td>',
+        '<td align="center">nAlloc event</td>',
+        '<td align="center">nAlloc event setup</td>',
+        "</tr>",
+        "<td>%s<BR>%s</td>" % (prdata["total"]["type"], prdata["total"]["label"]),
+        '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
+        % (
+            ibdata["total"]["added construction"],
+            prdata["total"]["added construction"],
+            results["total"]["added construction diff"],
+        ),
+        '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
+        % (
+            ibdata["total"]["added global begin run"] + ibdata["total"]["added stream begin run"],
+            prdata["total"]["added global begin run"] + prdata["total"]["added stream begin run"],
+            results["total"]["added global begin run diff"]
+            + results["total"]["added stream begin run diff"],
+        ),
+        '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
+        % (
+            ibdata["total"]["added global begin luminosity block"]
+            + ibdata["total"]["added stream begin luminosity block"],
+            prdata["total"]["added global begin luminosity block"]
+            + prdata["total"]["added stream begin luminosity block"],
+            results["total"]["added global begin luminosity block diff"]
+            + results["total"]["added stream begin luminosity block diff"],
+        ),
+        '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
+        % (
+            ibdata["total"]["added event"],
+            prdata["total"]["added event"],
+            results["total"]["added event diff"],
+        ),
+        '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
+        % (
+            ibdata["total"]["added event setup"],
+            prdata["total"]["added event setup"],
+            results["total"]["added event setup diff"],
+        ),
+        '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
+        % (
+            ibdata["total"]["nAlloc construction"],
+            prdata["total"]["nAlloc construction"],
+            results["total"]["nAlloc construction diff"],
+        ),
+        '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
+        % (
+            ibdata["total"]["nAlloc global begin run"] + ibdata["total"]["nAlloc stream begin run"],
+            prdata["total"]["nAlloc global begin run"] + prdata["total"]["nAlloc stream begin run"],
+            results["total"]["nAlloc global begin run diff"]
+            + results["total"]["nAlloc stream begin run diff"],
+        ),
+        '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
+        % (
+            ibdata["total"]["nAlloc global begin luminosity block"]
+            + ibdata["total"]["nAlloc stream begin luminosity block"],
+            prdata["total"]["nAlloc global begin luminosity block"]
+            + prdata["total"]["nAlloc stream begin luminosity block"],
+            results["total"]["nAlloc global begin luminosity block diff"]
+            + results["total"]["nAlloc stream begin luminosity block diff"],
+        ),
+        '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
+        % (
+            ibdata["total"]["nAlloc event"],
+            prdata["total"]["nAlloc event"],
+            results["total"]["nAlloc event diff"],
+        ),
+        '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
+        % (
+            ibdata["total"]["nAlloc event setup"],
+            prdata["total"]["nAlloc event setup"],
+            results["total"]["nAlloc event setup diff"],
+        ),
+        "</tr></table>",
+        '<table><tr><td align="center">Module label<BR>Module type<BR>Module record</td>',
+        '<td align="center">added construction (kB)</td>',
+        '<td align="center">added begin run (kB)</td>',
+        '<td align="center">added begin luminosity block (kB)</td>',
+        '<td align="center">added event (kB)</td>',
+        '<td align="center">added event setup (kB)</td>',
+        '<td align="center">added total (kB)</td>',
+        '<td align="center">nAlloc construction</td>',
+        '<td align="center">nAlloc begin run</td>',
+        '<td align="center">nAlloc begin luminosity block</td>',
+        '<td align="center">nAlloc event</td>',
+        '<td align="center">nAlloc event setup</td>',
+        '<td align="center">nAlloc total</td>',
+        '<td align="center">transitions</td>',
+        "</tr>",
+    ]
+
+
+def append_module_row(summary_lines, moduleib, modulepr, moduleres):
+    addedtotaldiff = numeric_value(moduleres, "added total diff", float("-inf"))
+    color = added_total_color(addedtotaldiff)
+    cell_attrs = 'align="right"'
+    if color:
+        cell_attrs += " " + color
+
+    summary_lines += [
+        "<tr>",
+        '<td align="center">%s<BR>%s<BR> %s</td>'
+        % (moduleres.get("label", ""), moduleres.get("type", ""), moduleres.get("record", "")),
+    ]
+    append_triplet_cell(
+        summary_lines,
+        numeric_value(moduleres, "added construction IB"),
+        numeric_value(moduleres, "added construction PR"),
+        numeric_value(moduleres, "added construction diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_numeric_values(moduleib, ADDED_BEGIN_RUN_KEYS),
+        sum_numeric_values(modulepr, ADDED_BEGIN_RUN_KEYS),
+        sum_with_suffix(moduleres, ADDED_BEGIN_RUN_KEYS, "diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_numeric_values(moduleib, ADDED_BEGIN_LUMI_KEYS),
+        sum_numeric_values(modulepr, ADDED_BEGIN_LUMI_KEYS),
+        sum_with_suffix(moduleres, ADDED_BEGIN_LUMI_KEYS, "diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        numeric_value(moduleib, "added event"),
+        numeric_value(modulepr, "added event"),
+        numeric_value(moduleres, "added event diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        numeric_value(moduleib, "added event setup"),
+        numeric_value(modulepr, "added event setup"),
+        numeric_value(moduleres, "added event setup diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_numeric_values(moduleib, ADDED_TOTAL_KEYS),
+        sum_numeric_values(modulepr, ADDED_TOTAL_KEYS),
+        sum_with_suffix(moduleres, ADDED_TOTAL_KEYS, "diff"),
+        attrs=cell_attrs,
+    )
+
+    append_triplet_cell(
+        summary_lines,
+        numeric_value(moduleres, "nAlloc construction IB"),
+        numeric_value(moduleres, "nAlloc construction PR"),
+        numeric_value(moduleres, "nAlloc construction diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_with_suffix(moduleres, NALLOC_BEGIN_RUN_KEYS, "IB"),
+        sum_with_suffix(moduleres, NALLOC_BEGIN_RUN_KEYS, "PR"),
+        sum_with_suffix(moduleres, NALLOC_BEGIN_RUN_KEYS, "diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_with_suffix(moduleres, NALLOC_BEGIN_LUMI_KEYS, "IB"),
+        sum_with_suffix(moduleres, NALLOC_BEGIN_LUMI_KEYS, "PR"),
+        sum_with_suffix(moduleres, NALLOC_BEGIN_LUMI_KEYS, "diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        numeric_value(moduleres, "nAlloc event IB"),
+        numeric_value(moduleres, "nAlloc event PR"),
+        numeric_value(moduleres, "nAlloc event diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        numeric_value(moduleres, "nAlloc event setup IB"),
+        numeric_value(moduleres, "nAlloc event setup PR"),
+        numeric_value(moduleres, "nAlloc event setup diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_with_suffix(moduleres, NALLOC_TOTAL_KEYS, "IB"),
+        sum_with_suffix(moduleres, NALLOC_TOTAL_KEYS, "PR"),
+        sum_with_suffix(moduleres, NALLOC_TOTAL_KEYS, "diff"),
+    )
+
+    transitions_ib = numeric_value(moduleib, "transitions")
+    transitions_pr = numeric_value(modulepr, "transitions")
+    transitions_diff = transitions_diff_value(transitions_ib, transitions_pr)
+    append_triplet_cell(summary_lines, transitions_ib, transitions_pr, transitions_diff)
+
+
+def append_sorted_module_rows(summary_lines, datamapib, datamappr, datamapres):
+    for item in sorted(
+        datamapres.items(),
+        key=lambda x: numeric_value(x[1], "added total diff", float("-inf")),
+        reverse=True,
+    ):
+        key = module_key(item[1])
+        if not is_valid_module_key(key):
+            continue
+        moduleib = datamapib.get(key, {})
+        modulepr = datamappr.get(key, {})
+        moduleres = datamapres.get(key, {})
+        append_module_row(summary_lines, moduleib, modulepr, moduleres)
+
+
+def build_summary_lines(ibdata, prdata, results, datamapib, datamappr, datamapres):
+    summary_lines = build_summary_header(ibdata, prdata, results)
+    update_added_totals(datamapres)
+    append_sorted_module_rows(summary_lines, datamapib, datamappr, datamapres)
+    summary_lines += ["</body></html>"]
+    return summary_lines
 
 
 def diff_from(metrics, data, dest, res):
@@ -41,10 +360,7 @@ for resource in ibdata["resources"]:
         for key in resource:
             metrics.append(key)
 
-datamapib = {
-    module["label"] + "|" + module["type"] + "|" + module["record"]: module
-    for module in ibdata["modules"]
-}
+datamapib = {module_key(module): module for module in ibdata["modules"]}
 
 datacumulsib = {}
 for module in ibdata["modules"]:
@@ -66,10 +382,7 @@ if ibdata["resources"] != prdata["resources"]:
     print("Error: input files describe different metrics")
     sys.exit(1)
 
-datamappr = {
-    module["label"] + "|" + module["type"] + "|" + module["record"]: module
-    for module in prdata["modules"]
-}
+datamappr = {module_key(module): module for module in prdata["modules"]}
 
 
 if ibdata["total"]["label"] != prdata["total"]["label"]:
@@ -98,11 +411,9 @@ diff_from(metrics, ibdata["total"], prdata["total"], results["total"])
 results["modules"] = []
 keys = set()
 for module in prdata["modules"]:
-    key = module["label"] + "|" + module["type"] + "|" + module["record"]
-    keys.add(key)
+    keys.add(module_key(module))
 for module in ibdata["modules"]:
-    key = module["label"] + "|" + module["type"] + "|" + module["record"]
-    keys.add(key)
+    keys.add(module_key(module))
 for key in sorted(keys):
     result = {}
     if key in datamapib and key not in datamappr:
@@ -124,211 +435,10 @@ for key in sorted(keys):
 
 datamapres = {}
 for module in results["modules"]:
-    datamapres[
-        "%s|%s|%s" % (module.get("label", ""), module.get("type", ""), module.get("record", ""))
-    ] = module
+    datamapres[module_key(module)] = module
 
 
-summaryLines = []
-summaryLines += [
-    "<html>",
-    "<head><style>",
-    "table, th, td {border: 1px solid black;}</style>",
-    "<style> th, td {padding: 15px;}</style></head>",
-    "<body><h3>ModuleAllocMonitor Resources Difference</h3><table>",
-    '</table><table><tr><td bgcolor="orange">',
-    "warn threshold %0.2f kB" % threshold,
-    '</td></tr><tr><td bgcolor="red">',
-    "error threshold %0.2f kB" % error_threshold,
-    '</td></tr><tr><td bgcolor="green">',
-    "warn threshold -%0.2f kB" % threshold,
-    '</td></tr><tr><td bgcolor="cyan">',
-    "warn threshold -%0.2f kB" % error_threshold,
-    "</td></tr>",
-    "<tr><td>metric:<BR>&lt;baseline&gt;<BR>&lt;pull request&gt;<BR>&lt;PR - baseline&gt; </td>",
-    "</tr></table>",
-    "<table>",
-    '<tr><td align="center">Type<BR>Label</td>',
-    '<td align="center">added construction</td>',
-    '<td align="center">added begin run</td>',
-    '<td align="center">added begin luminosity block</td>',
-    '<td align="center">added event</td>',
-    '<td align="center">added event setup</td>',
-    '<td align="center">nAlloc construction</td>',
-    '<td align="center">nAlloc begin run</td>',
-    '<td align="center">nAlloc begin luminosity block</td>',
-    '<td align="center">nAlloc event</td>',
-    '<td align="center">nAlloc event setup</td>',
-    "</tr>",
-    "<td>%s<BR>%s</td>" % (prdata["total"]["type"], prdata["total"]["label"]),
-    '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
-    % (
-        ibdata["total"]["added construction"],
-        prdata["total"]["added construction"],
-        results["total"]["added construction diff"],
-    ),
-    '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
-    % (
-        ibdata["total"]["added global begin run"] + ibdata["total"]["added stream begin run"],
-        prdata["total"]["added global begin run"] + prdata["total"]["added stream begin run"],
-        results["total"]["added global begin run diff"]
-        + results["total"]["added stream begin run diff"],
-    ),
-    '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
-    % (
-        ibdata["total"]["added global begin luminosity block"]
-        + ibdata["total"]["added stream begin luminosity block"],
-        prdata["total"]["added global begin luminosity block"]
-        + prdata["total"]["added stream begin luminosity block"],
-        results["total"]["added global begin luminosity block diff"]
-        + results["total"]["added stream begin luminosity block diff"],
-    ),
-    '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
-    % (
-        ibdata["total"]["added event"],
-        prdata["total"]["added event"],
-        results["total"]["added event diff"],
-    ),
-    '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
-    % (
-        ibdata["total"]["added event setup"],
-        prdata["total"]["added event setup"],
-        results["total"]["added event setup diff"],
-    ),
-    '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-    % (
-        ibdata["total"]["nAlloc construction"],
-        prdata["total"]["nAlloc construction"],
-        results["total"]["nAlloc construction diff"],
-    ),
-    '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-    % (
-        ibdata["total"]["nAlloc global begin run"] + ibdata["total"]["nAlloc stream begin run"],
-        prdata["total"]["nAlloc global begin run"] + prdata["total"]["nAlloc stream begin run"],
-        results["total"]["nAlloc global begin run diff"]
-        + results["total"]["nAlloc stream begin run diff"],
-    ),
-    '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-    % (
-        ibdata["total"]["nAlloc global begin luminosity block"]
-        + ibdata["total"]["nAlloc stream begin luminosity block"],
-        prdata["total"]["nAlloc global begin luminosity block"]
-        + prdata["total"]["nAlloc stream begin luminosity block"],
-        results["total"]["nAlloc global begin luminosity block diff"]
-        + results["total"]["nAlloc stream begin luminosity block diff"],
-    ),
-    '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-    % (
-        ibdata["total"]["nAlloc event"],
-        prdata["total"]["nAlloc event"],
-        results["total"]["nAlloc event diff"],
-    ),
-    '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-    % (
-        ibdata["total"]["nAlloc event setup"],
-        prdata["total"]["nAlloc event setup"],
-        results["total"]["nAlloc event setup diff"],
-    ),
-    "</tr></table>",
-    '<table><tr><td align="center">Module label<BR>Module type<BR>Module record</td>',
-    '<td align="center">added construction (kB)</td>',
-    '<td align="center">added begin run (kB)</td>',
-    '<td align="center">added begin luminosity block (kB)</td>',
-    '<td align="center">added event (kB)</td>',
-    '<td align="center">added event setup (kB)</td>',
-    '<td align="center">added total (kB)</td>',
-    '<td align="center">nAlloc construction</td>',
-    '<td align="center">nAlloc begin run</td>',
-    '<td align="center">nAlloc begin luminosity block</td>',
-    '<td align="center">nAlloc event</td>',
-    '<td align="center">nAlloc event setup</td>',
-    '<td align="center">nAlloc total</td>',
-    '<td align="center">transitions</td>',
-    "</tr>",
-]
-
-for item in datamapres.items():
-    key = "%s|%s|%s" % (
-        item[1].get("label", ""),
-        item[1].get("type", ""),
-        item[1].get("record", ""),
-    )
-    if not key == "None|None|None" and not key == "||":
-        moduleib = datamapib.get(key, {})
-        modulepr = datamappr.get(key, {})
-        moduleres = datamapres.get(key, {})
-        added_total_pr = (
-            (
-                moduleres.get("added event setup PR", 0)
-                + moduleres.get("added event PR", 0)
-                + moduleres.get("added construction PR", 0)
-                + moduleres.get("added global begin run PR", 0)
-                + moduleres.get("added stream begin run PR", 0)
-                + moduleres.get("added global begin luminosity block PR", 0)
-                + moduleres.get("added stream begin luminosity block PR", 0)
-            )
-            if isinstance(moduleres.get("added event setup PR", 0), (int, float))
-            and isinstance(moduleres.get("added event PR", 0), (int, float))
-            and isinstance(moduleres.get("added construction PR", 0), (int, float))
-            and isinstance(moduleres.get("added global begin run PR", 0), (int, float))
-            and isinstance(moduleres.get("added stream begin run PR", 0), (int, float))
-            and isinstance(
-                moduleres.get("added global begin luminosity block PR", 0), (int, float)
-            )
-            and isinstance(
-                moduleres.get("added stream begin luminosity block PR", 0), (int, float)
-            )
-            else "N/A"
-        )
-        moduleres["added total PR"] = added_total_pr
-        added_total_ib = (
-            (
-                moduleres.get("added event setup IB", 0)
-                + moduleres.get("added event IB", 0)
-                + moduleres.get("added construction IB", 0)
-                + moduleres.get("added global begin run IB", 0)
-                + moduleres.get("added stream begin run IB", 0)
-                + moduleres.get("added global begin luminosity block IB", 0)
-                + moduleres.get("added stream begin luminosity block IB", 0)
-            )
-            if isinstance(moduleres.get("added event setup IB", 0), (int, float))
-            and isinstance(moduleres.get("added event IB", 0), (int, float))
-            and isinstance(moduleres.get("added construction IB", 0), (int, float))
-            and isinstance(moduleres.get("added global begin run IB", 0), (int, float))
-            and isinstance(moduleres.get("added stream begin run IB", 0), (int, float))
-            and isinstance(
-                moduleres.get("added global begin luminosity block IB", 0), (int, float)
-            )
-            and isinstance(
-                moduleres.get("added stream begin luminosity block IB", 0), (int, float)
-            )
-            else "N/A"
-        )
-        moduleres["added total IB"] = added_total_ib
-        added_total_diff = (
-            (
-                moduleres.get("added event setup diff", 0)
-                + moduleres.get("added event diff", 0)
-                + moduleres.get("added construction diff", 0)
-                + moduleres.get("added global begin run diff", 0)
-                + moduleres.get("added stream begin run diff", 0)
-                + moduleres.get("added global begin luminosity block diff", 0)
-                + moduleres.get("added stream begin luminosity block diff", 0)
-            )
-            if isinstance(moduleres.get("added event setup diff", 0), (int, float))
-            and isinstance(moduleres.get("added event diff", 0), (int, float))
-            and isinstance(moduleres.get("added construction diff", 0), (int, float))
-            and isinstance(moduleres.get("added global begin run diff", 0), (int, float))
-            and isinstance(moduleres.get("added stream begin run diff", 0), (int, float))
-            and isinstance(
-                moduleres.get("added global begin luminosity block diff", 0), (int, float)
-            )
-            and isinstance(
-                moduleres.get("added stream begin luminosity block diff", 0), (int, float)
-            )
-            else "N/A"
-        )
-        moduleres["added total diff"] = added_total_diff
+summaryLines = build_summary_lines(ibdata, prdata, results, datamapib, datamappr, datamapres)
 dumpfile = (
     os.path.dirname(os.path.realpath(sys.argv[2]))
     + "/diff-"
@@ -337,496 +447,6 @@ dumpfile = (
 )
 with open(dumpfile, "w") as f:
     json.dump(results, f, indent=2)
-
-for item in sorted(
-    datamapres.items(),
-    key=lambda x: (
-        x[1].get("added total diff", float("-inf"))
-        if isinstance(x[1].get("added total diff", float("-inf")), (int, float))
-        else float("-inf")
-    ),
-    reverse=True,
-):
-    key = "%s|%s|%s" % (
-        item[1].get("label", ""),
-        item[1].get("type", ""),
-        item[1].get("record", ""),
-    )
-    if not key == "None|None|None" and not key == "||":
-        moduleib = datamapib.get(key, {})
-        modulepr = datamappr.get(key, {})
-        moduleres = datamapres.get(key, {})
-        cellString = '<td align="right" '
-        color = ""
-        addedtotaldiff = (
-            moduleres.get("added total diff", float("-inf"))
-            if isinstance(moduleres.get("added total diff", float("-inf")), (int, float))
-            else float("-inf")
-        )
-        if addedtotaldiff > threshold:
-            color = 'bgcolor="orange"'
-        if addedtotaldiff > error_threshold:
-            color = 'bgcolor="red"'
-        if addedtotaldiff < -1.0 * threshold:
-            color = 'bgcolor="cyan"'
-        if addedtotaldiff < -1.0 * error_threshold:
-            color = 'bgcolor="green"'
-        cellString += color
-        cellString += ">"
-        summaryLines += [
-            "<tr>",
-            '<td align="center">%s<BR>%s<BR> %s</td>'
-            % (moduleres.get("label", ""), moduleres.get("type", ""), moduleres.get("record", "")),
-        ]
-        added_construction_ib = (
-            moduleres.get("added construction IB", "N/A")
-            if isinstance(moduleres.get("added construction IB", "N/A"), (int, float))
-            else "N/A"
-        )
-        added_construction_pr = (
-            moduleres.get("added construction PR", "N/A")
-            if isinstance(moduleres.get("added construction PR", "N/A"), (int, float))
-            else "N/A"
-        )
-        added_construction_diff = (
-            moduleres.get("added construction diff", "N/A")
-            if isinstance(moduleres.get("added construction diff", "N/A"), (int, float))
-            else "N/A"
-        )
-        summaryLines += [
-            '<td align="right">'
-            + f'{added_construction_ib:{".2f" if isinstance(added_construction_ib, (float)) else ""}}'
-            + "<br>"
-            + f'{added_construction_pr:{".2f" if isinstance(added_construction_pr, (float)) else ""}}'
-            + "<br>"
-            + f'{added_construction_diff:{".2f" if isinstance(added_construction_diff, (float)) else ""}}'
-            + "</td>"
-        ]
-        added_begin_run_ib = (
-            (
-                moduleib.get("added global begin run", "N/A")
-                + moduleib.get("added stream begin run", "N/A")
-            )
-            if isinstance(moduleib.get("added global begin run", "N/A"), (int, float))
-            and isinstance(moduleib.get("added stream begin run", "N/A"), (int, float))
-            else "N/A"
-        )
-        added_begin_run_pr = (
-            (
-                modulepr.get("added global begin run", "N/A")
-                + modulepr.get("added stream begin run", "N/A")
-            )
-            if isinstance(modulepr.get("added global begin run", "N/A"), (int, float))
-            and isinstance(modulepr.get("added stream begin run", "N/A"), (int, float))
-            else "N/A"
-        )
-        added_begin_run_diff = (
-            (
-                moduleres.get("added global begin run diff", "N/A")
-                + moduleres.get("added stream begin run diff", "N/A")
-            )
-            if isinstance(moduleres.get("added global begin run diff", "N/A"), (int, float))
-            and isinstance(moduleres.get("added stream begin run diff", "N/A"), (int, float))
-            else "N/A"
-        )
-        summaryLines += [
-            (
-                '<td align="right">'
-                + f'{added_begin_run_ib:{".2f" if isinstance(added_begin_run_ib, (float)) else ""}}'
-                + "<br>"
-                + f'{added_begin_run_pr:{".2f" if isinstance(added_begin_run_pr, (float)) else ""}}'
-                + "<br>"
-                + f'{added_begin_run_diff:{".2f" if isinstance(added_begin_run_diff, (float)) else ""}}'
-                + "</td>"
-            )
-        ]
-        added_luminosity_block_ib = (
-            (
-                moduleib.get("added global begin luminosity block", "N/A")
-                + moduleib.get("added stream begin luminosity block", "N/A")
-            )
-            if isinstance(moduleib.get("added global begin luminosity block", "N/A"), (int, float))
-            and isinstance(
-                moduleib.get("added stream begin luminosity block", "N/A"), (int, float)
-            )
-            else "N/A"
-        )
-        added_luminosity_block_pr = (
-            (
-                modulepr.get("added global begin luminosity block", "N/A")
-                + modulepr.get("added stream begin luminosity block", "N/A")
-            )
-            if isinstance(modulepr.get("added global begin luminosity block", "N/A"), (int, float))
-            and isinstance(
-                modulepr.get("added stream begin luminosity block", "N/A"), (int, float)
-            )
-            else "N/A"
-        )
-        added_luminosity_block_diff = (
-            (
-                moduleres.get("added global begin luminosity block diff", "N/A")
-                + moduleres.get("added stream begin luminosity block diff", "N/A")
-            )
-            if isinstance(
-                moduleres.get("added global begin luminosity block diff", "N/A"), (int, float)
-            )
-            and isinstance(
-                moduleres.get("added stream begin luminosity block diff", "N/A"), (int, float)
-            )
-            else "N/A"
-        )
-        summaryLines += [
-            (
-                '<td align="right">'
-                + f'{added_luminosity_block_ib:{".2f" if isinstance(added_luminosity_block_ib, (float)) else ""}}'
-                + "<br>"
-                + f'{added_luminosity_block_pr:{".2f" if isinstance(added_luminosity_block_pr, (float)) else ""}}'
-                + "<br>"
-                + f'{added_luminosity_block_diff:{".2f" if isinstance(added_luminosity_block_diff, (float)) else ""}}'
-                + "</td>"
-            )
-        ]
-        added_event_ib = (
-            moduleib.get("added event", "N/A")
-            if isinstance(moduleib.get("added event", "N/A"), (int, float))
-            else "N/A"
-        )
-        added_event_pr = (
-            modulepr.get("added event", "N/A")
-            if isinstance(modulepr.get("added event", "N/A"), (int, float))
-            else "N/A"
-        )
-        added_event_diff = (
-            moduleres.get("added event diff", "N/A")
-            if isinstance(moduleres.get("added event diff", "N/A"), (int, float))
-            else "N/A"
-        )
-        summaryLines += [
-            (
-                '<td align="right">'
-                + f'{added_event_ib:{".2f" if isinstance(added_event_ib, (float)) else ""}}'
-                + "<br>"
-                + f'{added_event_pr:{".2f" if isinstance(added_event_pr, (float)) else ""}}'
-                + "<br>"
-                + f'{added_event_diff:{".2f" if isinstance(added_event_diff, (float)) else ""}}'
-                + "</td>"
-            )
-        ]
-        added_event_setup_ib = (
-            moduleib.get("added event setup", "N/A")
-            if isinstance(moduleib.get("added event setup", "N/A"), (int, float))
-            else "N/A"
-        )
-        added_event_setup_pr = (
-            modulepr.get("added event setup", "N/A")
-            if isinstance(modulepr.get("added event setup", "N/A"), (int, float))
-            else "N/A"
-        )
-        added_event_setup_diff = (
-            moduleres.get("added event setup diff", "N/A")
-            if isinstance(moduleres.get("added event setup diff", "N/A"), (int, float))
-            else "N/A"
-        )
-        summaryLines += [
-            (
-                '<td align="right">'
-                + f'{added_event_setup_ib:{".2f" if isinstance(added_event_setup_ib, (float)) else ""}}'
-                + "<br>"
-                + f'{added_event_setup_pr:{".2f" if isinstance(added_event_setup_pr, (float)) else ""}}'
-                + "<br>"
-                + f'{added_event_setup_diff:{".2f" if isinstance(added_event_setup_diff, (float)) else ""}}'
-                + "</td>"
-            )
-        ]
-        added_total_ib = (
-            (
-                moduleib.get("added event setup", "N/A")
-                + moduleib.get("added event", "N/A")
-                + moduleib.get("added construction", "N/A")
-                + moduleib.get("added global begin run", "N/A")
-                + moduleib.get("added stream begin run", "N/A")
-                + moduleib.get("added global begin luminosity block", "N/A")
-                + moduleib.get("added stream begin luminosity block", "N/A")
-            )
-            if isinstance(moduleib.get("added event setup", "N/A"), (int, float))
-            and isinstance(moduleib.get("added event", "N/A"), (int, float))
-            and isinstance(moduleib.get("added construction", "N/A"), (int, float))
-            and isinstance(moduleib.get("added global begin run", "N/A"), (int, float))
-            and isinstance(moduleib.get("added stream begin run", "N/A"), (int, float))
-            and isinstance(
-                moduleib.get("added global begin luminosity block", "N/A"), (int, float)
-            )
-            and isinstance(
-                moduleib.get("added stream begin luminosity block", "N/A"), (int, float)
-            )
-            else "N/A"
-        )
-        added_total_pr = (
-            (
-                modulepr.get("added event setup", "N/A")
-                + modulepr.get("added event", "N/A")
-                + modulepr.get("added construction", "N/A")
-                + modulepr.get("added global begin run", "N/A")
-                + modulepr.get("added stream begin run", "N/A")
-                + modulepr.get("added global begin luminosity block", "N/A")
-                + modulepr.get("added stream begin luminosity block", "N/A")
-            )
-            if isinstance(modulepr.get("added event setup", "N/A"), (int, float))
-            and isinstance(modulepr.get("added event", "N/A"), (int, float))
-            and isinstance(modulepr.get("added construction", "N/A"), (int, float))
-            and isinstance(modulepr.get("added global begin run", "N/A"), (int, float))
-            and isinstance(modulepr.get("added stream begin run", "N/A"), (int, float))
-            and isinstance(
-                modulepr.get("added global begin luminosity block", "N/A"), (int, float)
-            )
-            and isinstance(
-                modulepr.get("added stream begin luminosity block", "N/A"), (int, float)
-            )
-            else "N/A"
-        )
-        added_total_diff = (
-            (
-                moduleres.get("added event setup diff", "N/A")
-                + moduleres.get("added event diff", "N/A")
-                + moduleres.get("added construction diff", "N/A")
-                + moduleres.get("added global begin run diff", "N/A")
-                + moduleres.get("added stream begin run diff", "N/A")
-                + moduleres.get("added global begin luminosity block diff", "N/A")
-                + moduleres.get("added stream begin luminosity block diff", "N/A")
-            )
-            if isinstance(moduleres.get("added event setup diff", "N/A"), (int, float))
-            and isinstance(moduleres.get("added event diff", "N/A"), (int, float))
-            and isinstance(moduleres.get("added construction diff", "N/A"), (int, float))
-            and isinstance(moduleres.get("added global begin run diff", "N/A"), (int, float))
-            and isinstance(moduleres.get("added stream begin run diff", "N/A"), (int, float))
-            and isinstance(
-                moduleres.get("added global begin luminosity block diff", "N/A"), (int, float)
-            )
-            and isinstance(
-                moduleres.get("added stream begin luminosity block diff", "N/A"), (int, float)
-            )
-            else "N/A"
-        )
-        summaryLines += [
-            (
-                cellString
-                + f"{added_total_ib:{'.2f' if isinstance(added_total_ib, (float)) else ''}}"
-                + "<br>"
-                + f"{added_total_pr:{'.2f' if isinstance(added_total_pr, (float)) else ''}}"
-                + "<br>"
-                + f"{added_total_diff:{'.2f' if isinstance(added_total_diff, (float)) else ''}}"
-                + "</td>"
-            )
-        ]
-        nAlloc_construction_ib = (
-            moduleres.get("nAlloc construction IB", "N/A")
-            if isinstance(moduleres.get("nAlloc construction IB", "N/A"), (int, float))
-            else "N/A"
-        )
-        nAlloc_construction_pr = (
-            moduleres.get("nAlloc construction PR", "N/A")
-            if isinstance(moduleres.get("nAlloc construction PR", "N/A"), (int, float))
-            else "N/A"
-        )
-        nAlloc_construction_diff = (
-            moduleres.get("nAlloc construction diff", "N/A")
-            if isinstance(moduleres.get("nAlloc construction diff", "N/A"), (int, float))
-            else "N/A"
-        )
-        summaryLines += [
-            f'<td align="right">{nAlloc_construction_ib:{".2f" if isinstance(nAlloc_construction_ib, (float)) else ""}}'
-            + f'<br>{nAlloc_construction_pr:{".2f" if isinstance(nAlloc_construction_pr, (float)) else ""}}'
-            + f'<br>{nAlloc_construction_diff:{".2f" if isinstance(nAlloc_construction_diff, (float)) else ""}}</td>'
-        ]
-        nAlloc_begin_run_ib = (
-            (
-                moduleres.get("nAlloc global begin run IB", "N/A")
-                + moduleres.get("nAlloc stream begin run IB", "N/A")
-            )
-            if isinstance(moduleres.get("nAlloc global begin run IB", "N/A"), (int, float))
-            and isinstance(moduleres.get("nAlloc stream begin run IB", "N/A"), (int, float))
-            else "N/A"
-        )
-        nAlloc_begin_run_pr = (
-            (
-                moduleres.get("nAlloc global begin run PR", "N/A")
-                + moduleres.get("nAlloc stream begin run PR", "N/A")
-            )
-            if isinstance(moduleres.get("nAlloc global begin run PR", "N/A"), (int, float))
-            and isinstance(moduleres.get("nAlloc stream begin run PR", "N/A"), (int, float))
-            else "N/A"
-        )
-        nAlloc_begin_run_diff = (
-            (
-                moduleres.get("nAlloc global begin run diff", "N/A")
-                + moduleres.get("nAlloc stream begin run diff", "N/A")
-            )
-            if isinstance(moduleres.get("nAlloc global begin run diff", "N/A"), (int, float))
-            and isinstance(moduleres.get("nAlloc stream begin run diff", "N/A"), (int, float))
-            else "N/A"
-        )
-        summaryLines += [
-            '<td align="right">'
-            + f'{nAlloc_begin_run_ib:{".2f" if isinstance(nAlloc_begin_run_ib, (float)) else ""}}'
-            + f'<br>{nAlloc_begin_run_pr:{".2f" if isinstance(nAlloc_begin_run_pr, (float)) else ""}}'
-            + f'<br>{nAlloc_begin_run_diff:{".2f" if isinstance(nAlloc_begin_run_diff, (float)) else ""}}</td>'
-        ]
-        nAlloc_begin_luminosity_block_ib = (
-            (
-                moduleres.get("nAlloc global begin luminosity block IB", "N/A")
-                + moduleres.get("nAlloc stream begin luminosity block IB", "N/A")
-            )
-            if isinstance(
-                moduleres.get("nAlloc global begin luminosity block IB", "N/A"), (int, float)
-            )
-            and isinstance(
-                moduleres.get("nAlloc stream begin luminosity block IB", "N/A"), (int, float)
-            )
-            else "N/A"
-        )
-        nAlloc_begin_luminosity_block_pr = (
-            (
-                moduleres.get("nAlloc global begin luminosity block PR", "N/A")
-                + moduleres.get("nAlloc stream begin luminosity block PR", "N/A")
-            )
-            if isinstance(
-                moduleres.get("nAlloc global begin luminosity block PR", "N/A"), (int, float)
-            )
-            and isinstance(
-                moduleres.get("nAlloc stream begin luminosity block PR", "N/A"), (int, float)
-            )
-            else "N/A"
-        )
-        nAlloc_begin_luminosity_block_diff = (
-            (
-                moduleres.get("nAlloc global begin luminosity block diff", "N/A")
-                + moduleres.get("nAlloc stream begin luminosity block diff", "N/A")
-            )
-            if isinstance(
-                moduleres.get("nAlloc global begin luminosity block diff", "N/A"), (int, float)
-            )
-            and isinstance(
-                moduleres.get("nAlloc stream begin luminosity block diff", "N/A"), (int, float)
-            )
-            else "N/A"
-        )
-        summaryLines += [
-            '<td align="right">'
-            + f'{nAlloc_begin_luminosity_block_ib:{".2f" if isinstance(nAlloc_begin_luminosity_block_ib, (float)) else ""}}'
-            + f'<br>{nAlloc_begin_luminosity_block_pr:{".2f" if isinstance(nAlloc_begin_luminosity_block_pr, (float)) else ""}}'
-            + f'<br>{nAlloc_begin_luminosity_block_diff:{".2f" if isinstance(nAlloc_begin_luminosity_block_diff, (float)) else ""}}</td>'
-        ]
-        nAlloc_event_ib = (
-            moduleres.get("nAlloc event IB", "N/A")
-            if isinstance(moduleres.get("nAlloc event IB", "N/A"), (int, float))
-            else "N/A"
-        )
-        nAlloc_event_pr = (
-            moduleres.get("nAlloc event PR", "N/A")
-            if isinstance(moduleres.get("nAlloc event PR", "N/A"), (int, float))
-            else "N/A"
-        )
-        nAlloc_event_diff = (
-            moduleres.get("nAlloc event diff", "N/A")
-            if isinstance(moduleres.get("nAlloc event diff", "N/A"), (int, float))
-            else "N/A"
-        )
-        summaryLines += [
-            '<td align="right">'
-            + f'{nAlloc_event_ib:{".2f" if isinstance(nAlloc_event_ib, (float)) else ""}}'
-            + f'<br>{nAlloc_event_pr:{".2f" if isinstance(nAlloc_event_pr, (float)) else ""}}'
-            + f'<br>{nAlloc_event_diff:{".2f" if isinstance(nAlloc_event_diff, (float)) else ""}}</td>'
-        ]
-        nAlloc_event_setup_ib = (
-            moduleres.get("nAlloc event setup IB", "N/A")
-            if isinstance(moduleres.get("nAlloc event setup IB", "N/A"), (int, float))
-            else "N/A"
-        )
-        nAlloc_event_setup_pr = (
-            moduleres.get("nAlloc event setup PR", "N/A")
-            if isinstance(moduleres.get("nAlloc event setup PR", "N/A"), (int, float))
-            else "N/A"
-        )
-        nAlloc_event_setup_diff = (
-            moduleres.get("nAlloc event setup diff", "N/A")
-            if isinstance(moduleres.get("nAlloc event setup diff", "N/A"), (int, float))
-            else "N/A"
-        )
-        summaryLines += [
-            '<td align="right">'
-            + f'{nAlloc_event_setup_ib:{".2f" if isinstance(nAlloc_event_setup_ib, (float)) else ""}}'
-            + f'<br>{nAlloc_event_setup_pr:{".2f" if isinstance(nAlloc_event_setup_pr, (float)) else ""}}'
-            + f'<br>{nAlloc_event_setup_diff:{".2f" if isinstance(nAlloc_event_setup_diff, (float)) else ""}}</td>'
-        ]
-        nAlloc_total_ib = (
-            (
-                moduleres.get("nAlloc event setup IB", "N/A")
-                + moduleres.get("nAlloc event IB", "N/A")
-                + moduleres.get("nAlloc construction IB", "N/A")
-            )
-            if isinstance(moduleres.get("nAlloc event setup IB", "N/A"), (int, float))
-            and isinstance(moduleres.get("nAlloc construction IB", "N/A"), (int, float))
-            and isinstance(moduleres.get("nAlloc event IB", "N/A"), (int, float))
-            else "N/A"
-        )
-        nAlloc_total_pr = (
-            (
-                moduleres.get("nAlloc event setup PR", "N/A")
-                + moduleres.get("nAlloc event PR", "N/A")
-                + moduleres.get("nAlloc construction PR", "N/A")
-            )
-            if isinstance(moduleres.get("nAlloc event setup PR", "N/A"), (int, float))
-            and isinstance(moduleres.get("nAlloc construction PR", "N/A"), (int, float))
-            and isinstance(moduleres.get("nAlloc event PR", "N/A"), (int, float))
-            else "N/A"
-        )
-        nAlloc_total_diff = (
-            (
-                moduleres.get("nAlloc event setup diff", "N/A")
-                + moduleres.get("nAlloc event diff", "N/A")
-                + moduleres.get("nAlloc construction diff", "N/A")
-            )
-            if isinstance(moduleres.get("nAlloc event setup diff", "N/A"), (int, float))
-            and isinstance(moduleres.get("nAlloc construction diff", "N/A"), (int, float))
-            and isinstance(moduleres.get("nAlloc event diff", "N/A"), (int, float))
-            else "N/A"
-        )
-        summaryLines += [
-            '<td align="right">'
-            + f'{nAlloc_total_ib:{".2f" if isinstance(nAlloc_total_ib, (float)) else ""}}'
-            + f'<br>{nAlloc_total_pr:{".2f" if isinstance(nAlloc_total_pr, (float)) else ""}}'
-            + f'<br>{nAlloc_total_diff:{".2f" if isinstance(nAlloc_total_diff, (float)) else ""}}</td>'
-        ]
-        transitions_ib = (
-            moduleib.get("transitions", "N/A")
-            if isinstance(moduleib.get("transitions", "N/A"), (int, float))
-            else "N/A"
-        )
-        transitions_pr = (
-            modulepr.get("transitions", "N/A")
-            if isinstance(modulepr.get("transitions", "N/A"), (int, float))
-            else "N/A"
-        )
-        if isinstance(transitions_ib, (int, float)) and isinstance(transitions_pr, (int, float)):
-            transitions_diff = transitions_ib - transitions_pr
-        else:
-            if not isinstance(transitions_ib, (int, float)) and isinstance(
-                transitions_pr, (int, float)
-            ):
-                transitions_diff = transitions_pr - 0
-            elif isinstance(transitions_ib, (int, float)) and not isinstance(
-                transitions_pr, (int, float)
-            ):
-                transitions_diff = 0 - transitions_ib
-        summaryLines += [
-            '<td align="right">'
-            + f'{transitions_ib:{".2f" if isinstance(transitions_ib, (float)) else ""}}'
-            + f'<br>{transitions_pr:{".2f" if isinstance(transitions_pr, (float)) else ""}}'
-            + f'<br>{transitions_diff:{".2f" if isinstance(transitions_diff, (float)) else ""}}</td>'
-        ]
-
-summaryLines += []
-summaryLines += ["</body></html>"]
 
 summaryFile = (
     os.path.dirname(os.path.realpath(sys.argv[2]))

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -65,20 +65,6 @@ datamappr = {
     for module in prdata["modules"]
 }
 
-datacumulspr = {}
-for module in prdata["modules"]:
-    datacumul = datacumulspr.get(module["type"])
-    if datacumul:
-        datacumul["count"] += 1
-        for metric in metrics:
-            datacumul[metric] += module[metric]
-    else:
-        datacumul = {}
-        datacumul["count"] = 1
-        for metric in metrics:
-            datacumul[metric] = module[metric]
-        datacumulspr[module["type"]] = datacumul
-# print(datacumulspr)
 
 if ibdata["total"]["label"] != prdata["total"]["label"]:
     print("Warning: input files describe different process names")
@@ -295,7 +281,12 @@ for item in datamapres.items():
             + moduleres.get("added stream begin luminosity block diff", float("nan"))
         )
         moduleres["added total diff"] = added_total_diff
-dumpfile = os.path.dirname(sys.argv[2]) + "/diff-" + os.path.basename(sys.argv[2])
+dumpfile = (
+    os.path.dirname(os.path.realpath(sys.argv[2]))
+    + "/diff-"
+    + os.path.basename(os.path.realpath(sys.argv[2]))
+    + ".json"
+)
 with open(dumpfile, "w") as f:
     json.dump(results, f, indent=2)
 
@@ -454,11 +445,12 @@ for item in sorted(
 summaryLines += []
 summaryLines += ["</body></html>"]
 
-summaryFile = os.path.dirname(sys.argv[2]) + "/diff-" + os.path.basename(sys.argv[2]) + ".html"
+summaryFile = (
+    os.path.dirname(os.path.realpath(sys.argv[2]))
+    + "/diff-"
+    + os.path.basename(os.path.realpath(sys.argv[2]))
+    + ".html"
+)
 with open(summaryFile, "w") as g:
     for summaryLine in summaryLines:
         print(summaryLine, file=g)
-
-dumpfile = os.path.dirname(sys.argv[2]) + "/diff-" + os.path.basename(sys.argv[2])
-with open(dumpfile, "w") as f:
-    json.dump(results, f, indent=2)

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -394,7 +394,10 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right"> {added_construction_ib}<br> {added_construction_pr}<br> {added_construction_diff}</td>'
+            '<td align="right">' + f'{added_construction_ib:{".2f" if isinstance(added_construction_ib, (float)) else ""}}'
+            + "<br>" + f'{added_construction_pr:{".2f" if isinstance(added_construction_pr, (float)) else ""}}'
+            + "<br>" + f'{added_construction_diff:{".2f" if isinstance(added_construction_diff, (float)) else ""}}'
+            + "</td>"
         ]
         added_begin_run_ib = (
             (
@@ -424,7 +427,12 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right"> {added_begin_run_ib}<br> {added_begin_run_pr}<br> {added_begin_run_diff}</td>'
+            (
+                '<td align="right">' + f'{added_begin_run_ib:{".2f" if isinstance(added_begin_run_ib, (float)) else ""}}'
+                + "<br>" + f'{added_begin_run_pr:{".2f" if isinstance(added_begin_run_pr, (float)) else ""}}'
+                + "<br>" + f'{added_begin_run_diff:{".2f" if isinstance(added_begin_run_diff, (float)) else ""}}'
+                + "</td>"
+            )
         ]
         added_luminosity_block_ib = (
             (
@@ -462,7 +470,12 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right"> {added_luminosity_block_ib}<br> {added_luminosity_block_pr}<br> {added_luminosity_block_diff}</td>'
+            (
+                '<td align="right">' + f'{added_luminosity_block_ib:{".2f" if isinstance(added_luminosity_block_ib, (float)) else ""}}'
+                + "<br>" + f'{added_luminosity_block_pr:{".2f" if isinstance(added_luminosity_block_pr, (float)) else ""}}'
+                + "<br>" + f'{added_luminosity_block_diff:{".2f" if isinstance(added_luminosity_block_diff, (float)) else ""}}'
+                + "</td>"
+            )
         ]
         added_event_ib = (
             moduleib.get("added event", "N/A")
@@ -480,7 +493,12 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right"> {added_event_ib}<br> {added_event_pr}<br> {added_event_diff}</td>'
+            (
+                '<td align="right">' + f'{added_event_ib:{".2f" if isinstance(added_event_ib, (float)) else ""}}'
+                + "<br>" + f'{added_event_pr:{".2f" if isinstance(added_event_pr, (float)) else ""}}'
+                + "<br>" + f'{added_event_diff:{".2f" if isinstance(added_event_diff, (float)) else ""}}'
+                + "</td>"
+            )
         ]
         added_event_setup_ib = (
             moduleib.get("added event setup", "N/A")
@@ -498,7 +516,12 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right"> {added_event_setup_ib}<br> {added_event_setup_pr}<br> {added_event_setup_diff}</td>'
+            (
+                '<td align="right">' + f'{added_event_setup_ib:{".2f" if isinstance(added_event_setup_ib, (float)) else ""}}'
+                + "<br>" + f'{added_event_setup_pr:{".2f" if isinstance(added_event_setup_pr, (float)) else ""}}'
+                + "<br>" + f'{added_event_setup_diff:{".2f" if isinstance(added_event_setup_diff, (float)) else ""}}'
+                + "</td>"
+            )
         ]
         added_total_ib = (
             (
@@ -570,7 +593,12 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            cellString + f"{added_total_ib}<br>{added_total_pr}<br>{added_total_diff}</td>"
+            (
+                cellString + f"{added_total_ib:{'.2f' if isinstance(added_total_ib, (float)) else ''}}"
+                    + "<br>" + f"{added_total_pr:{'.2f' if isinstance(added_total_pr, (float)) else ''}}"
+                    + "<br>" + f"{added_total_diff:{'.2f' if isinstance(added_total_diff, (float)) else ''}}"
+                    + "</td>"
+            )
         ]
         nAlloc_construction_ib = (
             moduleres.get("nAlloc construction IB", "N/A")
@@ -588,7 +616,9 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right">{nAlloc_construction_ib}<br>{nAlloc_construction_pr}<br>{nAlloc_construction_diff}</td>'
+            f'<td align="right">{nAlloc_construction_ib:{".2f" if isinstance(nAlloc_construction_ib, (float)) else ""}}'
+            + f'<br>{nAlloc_construction_pr:{".2f" if isinstance(nAlloc_construction_pr, (float)) else ""}}'
+            + f'<br>{nAlloc_construction_diff:{".2f" if isinstance(nAlloc_construction_diff, (float)) else ""}}</td>'
         ]
         nAlloc_begin_run_ib = (
             (
@@ -618,7 +648,9 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right">{nAlloc_begin_run_ib}<br>{nAlloc_begin_run_pr}<br>{nAlloc_begin_run_diff}</td>'
+            '<td align="right">' + f'{nAlloc_begin_run_ib:{".2f" if isinstance(nAlloc_begin_run_ib, (float)) else ""}}'
+            + f'<br>{nAlloc_begin_run_pr:{".2f" if isinstance(nAlloc_begin_run_pr, (float)) else ""}}'
+            + f'<br>{nAlloc_begin_run_diff:{".2f" if isinstance(nAlloc_begin_run_diff, (float)) else ""}}</td>'
         ]
         nAlloc_begin_luminosity_block_ib = (
             (
@@ -660,7 +692,9 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right">{nAlloc_begin_luminosity_block_ib}<br>{nAlloc_begin_luminosity_block_pr}<br>{nAlloc_begin_luminosity_block_diff}</td>'
+            '<td align="right">' + f'{nAlloc_begin_luminosity_block_ib:{".2f" if isinstance(nAlloc_begin_luminosity_block_ib, (float)) else ""}}'
+            + f'<br>{nAlloc_begin_luminosity_block_pr:{".2f" if isinstance(nAlloc_begin_luminosity_block_pr, (float)) else ""}}'
+            + f'<br>{nAlloc_begin_luminosity_block_diff:{".2f" if isinstance(nAlloc_begin_luminosity_block_diff, (float)) else ""}}</td>'
         ]
         nAlloc_event_ib = (
             moduleres.get("nAlloc event IB", "N/A")
@@ -678,7 +712,9 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right">{nAlloc_event_ib}<br>{nAlloc_event_pr}<br>{nAlloc_event_diff}</td>'
+            '<td align="right">' + f'{nAlloc_event_ib:{".2f" if isinstance(nAlloc_event_ib, (float)) else ""}}'
+            + f'<br>{nAlloc_event_pr:{".2f" if isinstance(nAlloc_event_pr, (float)) else ""}}'
+            + f'<br>{nAlloc_event_diff:{".2f" if isinstance(nAlloc_event_diff, (float)) else ""}}</td>'
         ]
         nAlloc_event_setup_ib = (
             moduleres.get("nAlloc event setup IB", "N/A")
@@ -696,7 +732,9 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right">{nAlloc_event_setup_ib}<br>{nAlloc_event_setup_pr}<br>{nAlloc_event_setup_diff}</td>'
+            '<td align="right">' + f'{nAlloc_event_setup_ib:{".2f" if isinstance(nAlloc_event_setup_ib, (float)) else ""}}'
+            + f'<br>{nAlloc_event_setup_pr:{".2f" if isinstance(nAlloc_event_setup_pr, (float)) else ""}}'
+            + f'<br>{nAlloc_event_setup_diff:{".2f" if isinstance(nAlloc_event_setup_diff, (float)) else ""}}</td>'
         ]
         nAlloc_total_ib = (
             (
@@ -732,7 +770,9 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            f'<td align="right">{nAlloc_total_ib}<br>{nAlloc_total_pr}<br>{nAlloc_total_diff}</td>'
+            '<td align="right">' + f'{nAlloc_total_ib:{".2f" if isinstance(nAlloc_total_ib, (float)) else ""}}'
+            + f'<br>{nAlloc_total_pr:{".2f" if isinstance(nAlloc_total_pr, (float)) else ""}}'
+            + f'<br>{nAlloc_total_diff:{".2f" if isinstance(nAlloc_total_diff, (float)) else ""}}</td>'
         ]
         transitions_ib = (
             moduleib.get("transitions", "N/A")
@@ -756,7 +796,9 @@ for item in sorted(
             ):
                 transitions_diff = 0 - transitions_ib
         summaryLines += [
-            f'<td align="right">{transitions_ib}<br>{transitions_pr}<br>{transitions_diff}</td>'
+            '<td align="right">' + f'{transitions_ib:{".2f" if isinstance(transitions_ib, (float)) else ""}}'
+            + f'<br>{transitions_pr:{".2f" if isinstance(transitions_pr, (float)) else ""}}'
+            + f'<br>{transitions_diff:{".2f" if isinstance(transitions_diff, (float)) else ""}}</td>'
         ]
 
 summaryLines += []

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -394,9 +394,12 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            '<td align="right">' + f'{added_construction_ib:{".2f" if isinstance(added_construction_ib, (float)) else ""}}'
-            + "<br>" + f'{added_construction_pr:{".2f" if isinstance(added_construction_pr, (float)) else ""}}'
-            + "<br>" + f'{added_construction_diff:{".2f" if isinstance(added_construction_diff, (float)) else ""}}'
+            '<td align="right">'
+            + f'{added_construction_ib:{".2f" if isinstance(added_construction_ib, (float)) else ""}}'
+            + "<br>"
+            + f'{added_construction_pr:{".2f" if isinstance(added_construction_pr, (float)) else ""}}'
+            + "<br>"
+            + f'{added_construction_diff:{".2f" if isinstance(added_construction_diff, (float)) else ""}}'
             + "</td>"
         ]
         added_begin_run_ib = (
@@ -428,9 +431,12 @@ for item in sorted(
         )
         summaryLines += [
             (
-                '<td align="right">' + f'{added_begin_run_ib:{".2f" if isinstance(added_begin_run_ib, (float)) else ""}}'
-                + "<br>" + f'{added_begin_run_pr:{".2f" if isinstance(added_begin_run_pr, (float)) else ""}}'
-                + "<br>" + f'{added_begin_run_diff:{".2f" if isinstance(added_begin_run_diff, (float)) else ""}}'
+                '<td align="right">'
+                + f'{added_begin_run_ib:{".2f" if isinstance(added_begin_run_ib, (float)) else ""}}'
+                + "<br>"
+                + f'{added_begin_run_pr:{".2f" if isinstance(added_begin_run_pr, (float)) else ""}}'
+                + "<br>"
+                + f'{added_begin_run_diff:{".2f" if isinstance(added_begin_run_diff, (float)) else ""}}'
                 + "</td>"
             )
         ]
@@ -471,9 +477,12 @@ for item in sorted(
         )
         summaryLines += [
             (
-                '<td align="right">' + f'{added_luminosity_block_ib:{".2f" if isinstance(added_luminosity_block_ib, (float)) else ""}}'
-                + "<br>" + f'{added_luminosity_block_pr:{".2f" if isinstance(added_luminosity_block_pr, (float)) else ""}}'
-                + "<br>" + f'{added_luminosity_block_diff:{".2f" if isinstance(added_luminosity_block_diff, (float)) else ""}}'
+                '<td align="right">'
+                + f'{added_luminosity_block_ib:{".2f" if isinstance(added_luminosity_block_ib, (float)) else ""}}'
+                + "<br>"
+                + f'{added_luminosity_block_pr:{".2f" if isinstance(added_luminosity_block_pr, (float)) else ""}}'
+                + "<br>"
+                + f'{added_luminosity_block_diff:{".2f" if isinstance(added_luminosity_block_diff, (float)) else ""}}'
                 + "</td>"
             )
         ]
@@ -494,9 +503,12 @@ for item in sorted(
         )
         summaryLines += [
             (
-                '<td align="right">' + f'{added_event_ib:{".2f" if isinstance(added_event_ib, (float)) else ""}}'
-                + "<br>" + f'{added_event_pr:{".2f" if isinstance(added_event_pr, (float)) else ""}}'
-                + "<br>" + f'{added_event_diff:{".2f" if isinstance(added_event_diff, (float)) else ""}}'
+                '<td align="right">'
+                + f'{added_event_ib:{".2f" if isinstance(added_event_ib, (float)) else ""}}'
+                + "<br>"
+                + f'{added_event_pr:{".2f" if isinstance(added_event_pr, (float)) else ""}}'
+                + "<br>"
+                + f'{added_event_diff:{".2f" if isinstance(added_event_diff, (float)) else ""}}'
                 + "</td>"
             )
         ]
@@ -517,9 +529,12 @@ for item in sorted(
         )
         summaryLines += [
             (
-                '<td align="right">' + f'{added_event_setup_ib:{".2f" if isinstance(added_event_setup_ib, (float)) else ""}}'
-                + "<br>" + f'{added_event_setup_pr:{".2f" if isinstance(added_event_setup_pr, (float)) else ""}}'
-                + "<br>" + f'{added_event_setup_diff:{".2f" if isinstance(added_event_setup_diff, (float)) else ""}}'
+                '<td align="right">'
+                + f'{added_event_setup_ib:{".2f" if isinstance(added_event_setup_ib, (float)) else ""}}'
+                + "<br>"
+                + f'{added_event_setup_pr:{".2f" if isinstance(added_event_setup_pr, (float)) else ""}}'
+                + "<br>"
+                + f'{added_event_setup_diff:{".2f" if isinstance(added_event_setup_diff, (float)) else ""}}'
                 + "</td>"
             )
         ]
@@ -594,10 +609,13 @@ for item in sorted(
         )
         summaryLines += [
             (
-                cellString + f"{added_total_ib:{'.2f' if isinstance(added_total_ib, (float)) else ''}}"
-                    + "<br>" + f"{added_total_pr:{'.2f' if isinstance(added_total_pr, (float)) else ''}}"
-                    + "<br>" + f"{added_total_diff:{'.2f' if isinstance(added_total_diff, (float)) else ''}}"
-                    + "</td>"
+                cellString
+                + f"{added_total_ib:{'.2f' if isinstance(added_total_ib, (float)) else ''}}"
+                + "<br>"
+                + f"{added_total_pr:{'.2f' if isinstance(added_total_pr, (float)) else ''}}"
+                + "<br>"
+                + f"{added_total_diff:{'.2f' if isinstance(added_total_diff, (float)) else ''}}"
+                + "</td>"
             )
         ]
         nAlloc_construction_ib = (
@@ -648,7 +666,8 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            '<td align="right">' + f'{nAlloc_begin_run_ib:{".2f" if isinstance(nAlloc_begin_run_ib, (float)) else ""}}'
+            '<td align="right">'
+            + f'{nAlloc_begin_run_ib:{".2f" if isinstance(nAlloc_begin_run_ib, (float)) else ""}}'
             + f'<br>{nAlloc_begin_run_pr:{".2f" if isinstance(nAlloc_begin_run_pr, (float)) else ""}}'
             + f'<br>{nAlloc_begin_run_diff:{".2f" if isinstance(nAlloc_begin_run_diff, (float)) else ""}}</td>'
         ]
@@ -692,7 +711,8 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            '<td align="right">' + f'{nAlloc_begin_luminosity_block_ib:{".2f" if isinstance(nAlloc_begin_luminosity_block_ib, (float)) else ""}}'
+            '<td align="right">'
+            + f'{nAlloc_begin_luminosity_block_ib:{".2f" if isinstance(nAlloc_begin_luminosity_block_ib, (float)) else ""}}'
             + f'<br>{nAlloc_begin_luminosity_block_pr:{".2f" if isinstance(nAlloc_begin_luminosity_block_pr, (float)) else ""}}'
             + f'<br>{nAlloc_begin_luminosity_block_diff:{".2f" if isinstance(nAlloc_begin_luminosity_block_diff, (float)) else ""}}</td>'
         ]
@@ -712,7 +732,8 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            '<td align="right">' + f'{nAlloc_event_ib:{".2f" if isinstance(nAlloc_event_ib, (float)) else ""}}'
+            '<td align="right">'
+            + f'{nAlloc_event_ib:{".2f" if isinstance(nAlloc_event_ib, (float)) else ""}}'
             + f'<br>{nAlloc_event_pr:{".2f" if isinstance(nAlloc_event_pr, (float)) else ""}}'
             + f'<br>{nAlloc_event_diff:{".2f" if isinstance(nAlloc_event_diff, (float)) else ""}}</td>'
         ]
@@ -732,7 +753,8 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            '<td align="right">' + f'{nAlloc_event_setup_ib:{".2f" if isinstance(nAlloc_event_setup_ib, (float)) else ""}}'
+            '<td align="right">'
+            + f'{nAlloc_event_setup_ib:{".2f" if isinstance(nAlloc_event_setup_ib, (float)) else ""}}'
             + f'<br>{nAlloc_event_setup_pr:{".2f" if isinstance(nAlloc_event_setup_pr, (float)) else ""}}'
             + f'<br>{nAlloc_event_setup_diff:{".2f" if isinstance(nAlloc_event_setup_diff, (float)) else ""}}</td>'
         ]
@@ -770,7 +792,8 @@ for item in sorted(
             else "N/A"
         )
         summaryLines += [
-            '<td align="right">' + f'{nAlloc_total_ib:{".2f" if isinstance(nAlloc_total_ib, (float)) else ""}}'
+            '<td align="right">'
+            + f'{nAlloc_total_ib:{".2f" if isinstance(nAlloc_total_ib, (float)) else ""}}'
             + f'<br>{nAlloc_total_pr:{".2f" if isinstance(nAlloc_total_pr, (float)) else ""}}'
             + f'<br>{nAlloc_total_diff:{".2f" if isinstance(nAlloc_total_diff, (float)) else ""}}</td>'
         ]
@@ -796,7 +819,8 @@ for item in sorted(
             ):
                 transitions_diff = 0 - transitions_ib
         summaryLines += [
-            '<td align="right">' + f'{transitions_ib:{".2f" if isinstance(transitions_ib, (float)) else ""}}'
+            '<td align="right">'
+            + f'{transitions_ib:{".2f" if isinstance(transitions_ib, (float)) else ""}}'
             + f'<br>{transitions_pr:{".2f" if isinstance(transitions_pr, (float)) else ""}}'
             + f'<br>{transitions_diff:{".2f" if isinstance(transitions_diff, (float)) else ""}}</td>'
         ]

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -8,6 +8,7 @@ import math
 threshold = 5000.0
 error_threshold = 20000.0
 
+
 def diff_from(metrics, data, dest, res):
     for metric in metrics:
         ibkey = "%s IB" % metric
@@ -257,34 +258,76 @@ for item in datamapres.items():
         modulepr = datamappr.get(key, {})
         moduleres = datamapres.get(key, {})
         added_total_pr = (
-            moduleres.get("added event setup PR", 0)
-            + moduleres.get("added event PR", 0)
-            + moduleres.get("added construction PR", 0)
-            + moduleres.get("added global begin run PR", 0)
-            + moduleres.get("added stream begin run PR", 0)
-            + moduleres.get("added global begin luminosity block PR", 0)
-            + moduleres.get("added stream begin luminosity block PR", 0)
-        ) if isinstance(moduleres.get("added event setup PR", 0), (int, float)) and isinstance(moduleres.get("added event PR", 0), (int, float)) and isinstance(moduleres.get("added construction PR", 0), (int, float)) and isinstance(moduleres.get("added global begin run PR", 0), (int, float)) and isinstance(moduleres.get("added stream begin run PR", 0), (int, float)) and isinstance(moduleres.get("added global begin luminosity block PR", 0), (int, float)) and isinstance(moduleres.get("added stream begin luminosity block PR", 0), (int, float)) else "N/A"
+            (
+                moduleres.get("added event setup PR", 0)
+                + moduleres.get("added event PR", 0)
+                + moduleres.get("added construction PR", 0)
+                + moduleres.get("added global begin run PR", 0)
+                + moduleres.get("added stream begin run PR", 0)
+                + moduleres.get("added global begin luminosity block PR", 0)
+                + moduleres.get("added stream begin luminosity block PR", 0)
+            )
+            if isinstance(moduleres.get("added event setup PR", 0), (int, float))
+            and isinstance(moduleres.get("added event PR", 0), (int, float))
+            and isinstance(moduleres.get("added construction PR", 0), (int, float))
+            and isinstance(moduleres.get("added global begin run PR", 0), (int, float))
+            and isinstance(moduleres.get("added stream begin run PR", 0), (int, float))
+            and isinstance(
+                moduleres.get("added global begin luminosity block PR", 0), (int, float)
+            )
+            and isinstance(
+                moduleres.get("added stream begin luminosity block PR", 0), (int, float)
+            )
+            else "N/A"
+        )
         moduleres["added total PR"] = added_total_pr
         added_total_ib = (
-            moduleres.get("added event setup IB", 0)
-            + moduleres.get("added event IB", 0)
-            + moduleres.get("added construction IB", 0)
-            + moduleres.get("added global begin run IB", 0)
-            + moduleres.get("added stream begin run IB", 0)
-            + moduleres.get("added global begin luminosity block IB", 0)
-            + moduleres.get("added stream begin luminosity block IB", 0)
-        ) if isinstance(moduleres.get("added event setup IB", 0), (int, float)) and isinstance(moduleres.get("added event IB", 0), (int, float)) and isinstance(moduleres.get("added construction IB", 0), (int, float)) and isinstance(moduleres.get("added global begin run IB", 0), (int, float)) and isinstance(moduleres.get("added stream begin run IB", 0), (int, float)) and isinstance(moduleres.get("added global begin luminosity block IB", 0), (int, float)) and isinstance(moduleres.get("added stream begin luminosity block IB", 0), (int, float)) else "N/A"
+            (
+                moduleres.get("added event setup IB", 0)
+                + moduleres.get("added event IB", 0)
+                + moduleres.get("added construction IB", 0)
+                + moduleres.get("added global begin run IB", 0)
+                + moduleres.get("added stream begin run IB", 0)
+                + moduleres.get("added global begin luminosity block IB", 0)
+                + moduleres.get("added stream begin luminosity block IB", 0)
+            )
+            if isinstance(moduleres.get("added event setup IB", 0), (int, float))
+            and isinstance(moduleres.get("added event IB", 0), (int, float))
+            and isinstance(moduleres.get("added construction IB", 0), (int, float))
+            and isinstance(moduleres.get("added global begin run IB", 0), (int, float))
+            and isinstance(moduleres.get("added stream begin run IB", 0), (int, float))
+            and isinstance(
+                moduleres.get("added global begin luminosity block IB", 0), (int, float)
+            )
+            and isinstance(
+                moduleres.get("added stream begin luminosity block IB", 0), (int, float)
+            )
+            else "N/A"
+        )
         moduleres["added total IB"] = added_total_ib
         added_total_diff = (
-            moduleres.get("added event setup diff", 0)
-            + moduleres.get("added event diff", 0)
-            + moduleres.get("added construction diff", 0)
-            + moduleres.get("added global begin run diff", 0)
-            + moduleres.get("added stream begin run diff", 0)
-            + moduleres.get("added global begin luminosity block diff", 0)
-            + moduleres.get("added stream begin luminosity block diff", 0)
-        ) if isinstance(moduleres.get("added event setup diff", 0), (int, float)) and isinstance(moduleres.get("added event diff", 0), (int, float)) and isinstance(moduleres.get("added construction diff", 0), (int, float)) and isinstance(moduleres.get("added global begin run diff", 0), (int, float)) and isinstance(moduleres.get("added stream begin run diff", 0), (int, float)) and isinstance(moduleres.get("added global begin luminosity block diff", 0), (int, float)) and isinstance(moduleres.get("added stream begin luminosity block diff", 0), (int, float)) else "N/A"
+            (
+                moduleres.get("added event setup diff", 0)
+                + moduleres.get("added event diff", 0)
+                + moduleres.get("added construction diff", 0)
+                + moduleres.get("added global begin run diff", 0)
+                + moduleres.get("added stream begin run diff", 0)
+                + moduleres.get("added global begin luminosity block diff", 0)
+                + moduleres.get("added stream begin luminosity block diff", 0)
+            )
+            if isinstance(moduleres.get("added event setup diff", 0), (int, float))
+            and isinstance(moduleres.get("added event diff", 0), (int, float))
+            and isinstance(moduleres.get("added construction diff", 0), (int, float))
+            and isinstance(moduleres.get("added global begin run diff", 0), (int, float))
+            and isinstance(moduleres.get("added stream begin run diff", 0), (int, float))
+            and isinstance(
+                moduleres.get("added global begin luminosity block diff", 0), (int, float)
+            )
+            and isinstance(
+                moduleres.get("added stream begin luminosity block diff", 0), (int, float)
+            )
+            else "N/A"
+        )
         moduleres["added total diff"] = added_total_diff
 dumpfile = (
     os.path.dirname(os.path.realpath(sys.argv[2]))
@@ -297,7 +340,11 @@ with open(dumpfile, "w") as f:
 
 for item in sorted(
     datamapres.items(),
-    key=lambda x: x[1].get("added total diff", float("-inf")) if isinstance(x[1].get("added total diff", float("-inf")), (int, float)) else float("-inf"),
+    key=lambda x: (
+        x[1].get("added total diff", float("-inf"))
+        if isinstance(x[1].get("added total diff", float("-inf")), (int, float))
+        else float("-inf")
+    ),
     reverse=True,
 ):
     key = "%s|%s|%s" % (
@@ -311,7 +358,11 @@ for item in sorted(
         moduleres = datamapres.get(key, {})
         cellString = '<td align="right" '
         color = ""
-        addedtotaldiff = moduleres.get("added total diff", float("-inf")) if isinstance(moduleres.get("added total diff", float("-inf")), (int, float)) else float("-inf")
+        addedtotaldiff = (
+            moduleres.get("added total diff", float("-inf"))
+            if isinstance(moduleres.get("added total diff", float("-inf")), (int, float))
+            else float("-inf")
+        )
         if addedtotaldiff > threshold:
             color = 'bgcolor="orange"'
         if addedtotaldiff > error_threshold:
@@ -325,116 +376,385 @@ for item in sorted(
         summaryLines += [
             "<tr>",
             '<td align="center">%s<BR>%s<BR> %s</td>'
-            % (moduleres.get("label", ""), moduleres.get("type", ""), moduleres.get("record", ""))
+            % (moduleres.get("label", ""), moduleres.get("type", ""), moduleres.get("record", "")),
         ]
-        added_construction_ib = moduleres.get("added construction IB", "N/A") if isinstance(moduleres.get("added construction IB", "N/A"), (int, float)) else "N/A"
-        added_construction_pr = moduleres.get("added construction PR", "N/A") if isinstance(moduleres.get("added construction PR", "N/A"), (int, float)) else "N/A"
-        added_construction_diff = moduleres.get("added construction diff", "N/A") if isinstance(moduleres.get("added construction diff", "N/A"), (int, float)) else "N/A"
+        added_construction_ib = (
+            moduleres.get("added construction IB", "N/A")
+            if isinstance(moduleres.get("added construction IB", "N/A"), (int, float))
+            else "N/A"
+        )
+        added_construction_pr = (
+            moduleres.get("added construction PR", "N/A")
+            if isinstance(moduleres.get("added construction PR", "N/A"), (int, float))
+            else "N/A"
+        )
+        added_construction_diff = (
+            moduleres.get("added construction diff", "N/A")
+            if isinstance(moduleres.get("added construction diff", "N/A"), (int, float))
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right"> {added_construction_ib}<br> {added_construction_pr}<br> {added_construction_diff}</td>'
         ]
-        added_begin_run_ib = (moduleib.get("added global begin run", "N/A") + moduleib.get("added stream begin run", "N/A")) if isinstance(moduleib.get("added global begin run", "N/A"), (int, float)) and isinstance(moduleib.get("added stream begin run", "N/A"), (int, float)) else "N/A"
-        added_begin_run_pr = (modulepr.get("added global begin run", "N/A") + modulepr.get("added stream begin run", "N/A")) if isinstance(modulepr.get("added global begin run", "N/A"), (int, float)) and isinstance(modulepr.get("added stream begin run", "N/A"), (int, float)) else "N/A"
-        added_begin_run_diff = (moduleres.get("added global begin run diff", "N/A") + moduleres.get("added stream begin run diff", "N/A")) if isinstance(moduleres.get("added global begin run diff", "N/A"), (int, float)) and isinstance(moduleres.get("added stream begin run diff", "N/A"), (int, float)) else "N/A"
+        added_begin_run_ib = (
+            (
+                moduleib.get("added global begin run", "N/A")
+                + moduleib.get("added stream begin run", "N/A")
+            )
+            if isinstance(moduleib.get("added global begin run", "N/A"), (int, float))
+            and isinstance(moduleib.get("added stream begin run", "N/A"), (int, float))
+            else "N/A"
+        )
+        added_begin_run_pr = (
+            (
+                modulepr.get("added global begin run", "N/A")
+                + modulepr.get("added stream begin run", "N/A")
+            )
+            if isinstance(modulepr.get("added global begin run", "N/A"), (int, float))
+            and isinstance(modulepr.get("added stream begin run", "N/A"), (int, float))
+            else "N/A"
+        )
+        added_begin_run_diff = (
+            (
+                moduleres.get("added global begin run diff", "N/A")
+                + moduleres.get("added stream begin run diff", "N/A")
+            )
+            if isinstance(moduleres.get("added global begin run diff", "N/A"), (int, float))
+            and isinstance(moduleres.get("added stream begin run diff", "N/A"), (int, float))
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right"> {added_begin_run_ib}<br> {added_begin_run_pr}<br> {added_begin_run_diff}</td>'
         ]
-        added_luminosity_block_ib = (moduleib.get("added global begin luminosity block", "N/A") + moduleib.get("added stream begin luminosity block", "N/A")) if isinstance(moduleib.get("added global begin luminosity block", "N/A"), (int, float)) and isinstance(moduleib.get("added stream begin luminosity block", "N/A"), (int, float)) else "N/A"
-        added_luminosity_block_pr = (modulepr.get("added global begin luminosity block", "N/A") + modulepr.get("added stream begin luminosity block", "N/A")) if isinstance(modulepr.get("added global begin luminosity block", "N/A"), (int, float)) and isinstance(modulepr.get("added stream begin luminosity block", "N/A"), (int, float)) else "N/A"
-        added_luminosity_block_diff = (moduleres.get("added global begin luminosity block diff", "N/A") + moduleres.get("added stream begin luminosity block diff", "N/A")) if isinstance(moduleres.get("added global begin luminosity block diff", "N/A"), (int, float)) and isinstance(moduleres.get("added stream begin luminosity block diff", "N/A"), (int, float)) else "N/A"
+        added_luminosity_block_ib = (
+            (
+                moduleib.get("added global begin luminosity block", "N/A")
+                + moduleib.get("added stream begin luminosity block", "N/A")
+            )
+            if isinstance(moduleib.get("added global begin luminosity block", "N/A"), (int, float))
+            and isinstance(
+                moduleib.get("added stream begin luminosity block", "N/A"), (int, float)
+            )
+            else "N/A"
+        )
+        added_luminosity_block_pr = (
+            (
+                modulepr.get("added global begin luminosity block", "N/A")
+                + modulepr.get("added stream begin luminosity block", "N/A")
+            )
+            if isinstance(modulepr.get("added global begin luminosity block", "N/A"), (int, float))
+            and isinstance(
+                modulepr.get("added stream begin luminosity block", "N/A"), (int, float)
+            )
+            else "N/A"
+        )
+        added_luminosity_block_diff = (
+            (
+                moduleres.get("added global begin luminosity block diff", "N/A")
+                + moduleres.get("added stream begin luminosity block diff", "N/A")
+            )
+            if isinstance(
+                moduleres.get("added global begin luminosity block diff", "N/A"), (int, float)
+            )
+            and isinstance(
+                moduleres.get("added stream begin luminosity block diff", "N/A"), (int, float)
+            )
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right"> {added_luminosity_block_ib}<br> {added_luminosity_block_pr}<br> {added_luminosity_block_diff}</td>'
         ]
-        added_event_ib = moduleib.get("added event", "N/A") if isinstance(moduleib.get("added event", "N/A"), (int, float)) else "N/A"
-        added_event_pr = modulepr.get("added event", "N/A") if isinstance(modulepr.get("added event", "N/A"), (int, float)) else "N/A"
-        added_event_diff = moduleres.get("added event diff", "N/A") if isinstance(moduleres.get("added event diff", "N/A"), (int, float)) else "N/A"
+        added_event_ib = (
+            moduleib.get("added event", "N/A")
+            if isinstance(moduleib.get("added event", "N/A"), (int, float))
+            else "N/A"
+        )
+        added_event_pr = (
+            modulepr.get("added event", "N/A")
+            if isinstance(modulepr.get("added event", "N/A"), (int, float))
+            else "N/A"
+        )
+        added_event_diff = (
+            moduleres.get("added event diff", "N/A")
+            if isinstance(moduleres.get("added event diff", "N/A"), (int, float))
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right"> {added_event_ib}<br> {added_event_pr}<br> {added_event_diff}</td>'
         ]
-        added_event_setup_ib = moduleib.get("added event setup", "N/A") if isinstance(moduleib.get("added event setup", "N/A"), (int, float)) else "N/A"
-        added_event_setup_pr = modulepr.get("added event setup", "N/A") if isinstance(modulepr.get("added event setup", "N/A"), (int, float)) else "N/A"
-        added_event_setup_diff = moduleres.get("added event setup diff", "N/A") if isinstance(moduleres.get("added event setup diff", "N/A"), (int, float)) else "N/A"
+        added_event_setup_ib = (
+            moduleib.get("added event setup", "N/A")
+            if isinstance(moduleib.get("added event setup", "N/A"), (int, float))
+            else "N/A"
+        )
+        added_event_setup_pr = (
+            modulepr.get("added event setup", "N/A")
+            if isinstance(modulepr.get("added event setup", "N/A"), (int, float))
+            else "N/A"
+        )
+        added_event_setup_diff = (
+            moduleres.get("added event setup diff", "N/A")
+            if isinstance(moduleres.get("added event setup diff", "N/A"), (int, float))
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right"> {added_event_setup_ib}<br> {added_event_setup_pr}<br> {added_event_setup_diff}</td>'
         ]
-        added_total_ib = (moduleib.get("added event setup", "N/A") 
+        added_total_ib = (
+            (
+                moduleib.get("added event setup", "N/A")
                 + moduleib.get("added event", "N/A")
                 + moduleib.get("added construction", "N/A")
                 + moduleib.get("added global begin run", "N/A")
                 + moduleib.get("added stream begin run", "N/A")
                 + moduleib.get("added global begin luminosity block", "N/A")
-                + moduleib.get("added stream begin luminosity block", "N/A")) if isinstance(moduleib.get("added event setup", "N/A"), (int, float)) and isinstance(moduleib.get("added event", "N/A"), (int, float)) and isinstance(moduleib.get("added construction", "N/A"), (int, float)) and isinstance(moduleib.get("added global begin run", "N/A"), (int, float)) and isinstance(moduleib.get("added stream begin run", "N/A"), (int, float)) and isinstance(moduleib.get("added global begin luminosity block", "N/A"), (int, float)) and isinstance(moduleib.get("added stream begin luminosity block", "N/A"), (int, float)) else "N/A"
-        added_total_pr = (modulepr.get("added event setup", "N/A")
+                + moduleib.get("added stream begin luminosity block", "N/A")
+            )
+            if isinstance(moduleib.get("added event setup", "N/A"), (int, float))
+            and isinstance(moduleib.get("added event", "N/A"), (int, float))
+            and isinstance(moduleib.get("added construction", "N/A"), (int, float))
+            and isinstance(moduleib.get("added global begin run", "N/A"), (int, float))
+            and isinstance(moduleib.get("added stream begin run", "N/A"), (int, float))
+            and isinstance(
+                moduleib.get("added global begin luminosity block", "N/A"), (int, float)
+            )
+            and isinstance(
+                moduleib.get("added stream begin luminosity block", "N/A"), (int, float)
+            )
+            else "N/A"
+        )
+        added_total_pr = (
+            (
+                modulepr.get("added event setup", "N/A")
                 + modulepr.get("added event", "N/A")
                 + modulepr.get("added construction", "N/A")
                 + modulepr.get("added global begin run", "N/A")
                 + modulepr.get("added stream begin run", "N/A")
                 + modulepr.get("added global begin luminosity block", "N/A")
-                + modulepr.get("added stream begin luminosity block", "N/A")) if isinstance(modulepr.get("added event setup", "N/A"), (int, float)) and isinstance(modulepr.get("added event", "N/A"), (int, float)) and isinstance(modulepr.get("added construction", "N/A"), (int, float)) and isinstance(modulepr.get("added global begin run", "N/A"), (int, float)) and isinstance(modulepr.get("added stream begin run", "N/A"), (int, float)) and isinstance(modulepr.get("added global begin luminosity block", "N/A"), (int, float)) and isinstance(modulepr.get("added stream begin luminosity block", "N/A"), (int, float)) else "N/A"
-        added_total_diff = (moduleres.get("added event setup diff", "N/A")
+                + modulepr.get("added stream begin luminosity block", "N/A")
+            )
+            if isinstance(modulepr.get("added event setup", "N/A"), (int, float))
+            and isinstance(modulepr.get("added event", "N/A"), (int, float))
+            and isinstance(modulepr.get("added construction", "N/A"), (int, float))
+            and isinstance(modulepr.get("added global begin run", "N/A"), (int, float))
+            and isinstance(modulepr.get("added stream begin run", "N/A"), (int, float))
+            and isinstance(
+                modulepr.get("added global begin luminosity block", "N/A"), (int, float)
+            )
+            and isinstance(
+                modulepr.get("added stream begin luminosity block", "N/A"), (int, float)
+            )
+            else "N/A"
+        )
+        added_total_diff = (
+            (
+                moduleres.get("added event setup diff", "N/A")
                 + moduleres.get("added event diff", "N/A")
                 + moduleres.get("added construction diff", "N/A")
                 + moduleres.get("added global begin run diff", "N/A")
                 + moduleres.get("added stream begin run diff", "N/A")
                 + moduleres.get("added global begin luminosity block diff", "N/A")
-                + moduleres.get("added stream begin luminosity block diff", "N/A")) if isinstance(moduleres.get("added event setup diff", "N/A"), (int, float)) and isinstance(moduleres.get("added event diff", "N/A"), (int, float)) and isinstance(moduleres.get("added construction diff", "N/A"), (int, float)) and isinstance(moduleres.get("added global begin run diff", "N/A"), (int, float)) and isinstance(moduleres.get("added stream begin run diff", "N/A"), (int, float)) and isinstance(moduleres.get("added global begin luminosity block diff", "N/A"), (int, float)) and isinstance(moduleres.get("added stream begin luminosity block diff", "N/A"), (int, float)) else "N/A"
+                + moduleres.get("added stream begin luminosity block diff", "N/A")
+            )
+            if isinstance(moduleres.get("added event setup diff", "N/A"), (int, float))
+            and isinstance(moduleres.get("added event diff", "N/A"), (int, float))
+            and isinstance(moduleres.get("added construction diff", "N/A"), (int, float))
+            and isinstance(moduleres.get("added global begin run diff", "N/A"), (int, float))
+            and isinstance(moduleres.get("added stream begin run diff", "N/A"), (int, float))
+            and isinstance(
+                moduleres.get("added global begin luminosity block diff", "N/A"), (int, float)
+            )
+            and isinstance(
+                moduleres.get("added stream begin luminosity block diff", "N/A"), (int, float)
+            )
+            else "N/A"
+        )
         summaryLines += [
-            cellString
-            + f"{added_total_ib}<br>{added_total_pr}<br>{added_total_diff}</td>"
+            cellString + f"{added_total_ib}<br>{added_total_pr}<br>{added_total_diff}</td>"
         ]
-        nAlloc_construction_ib = moduleres.get("nAlloc construction IB", "N/A") if isinstance(moduleres.get("nAlloc construction IB", "N/A"), (int, float)) else "N/A"
-        nAlloc_construction_pr = moduleres.get("nAlloc construction PR", "N/A") if isinstance(moduleres.get("nAlloc construction PR", "N/A"), (int, float)) else "N/A"
-        nAlloc_construction_diff = moduleres.get("nAlloc construction diff", "N/A") if isinstance(moduleres.get("nAlloc construction diff", "N/A"), (int, float)) else "N/A"
+        nAlloc_construction_ib = (
+            moduleres.get("nAlloc construction IB", "N/A")
+            if isinstance(moduleres.get("nAlloc construction IB", "N/A"), (int, float))
+            else "N/A"
+        )
+        nAlloc_construction_pr = (
+            moduleres.get("nAlloc construction PR", "N/A")
+            if isinstance(moduleres.get("nAlloc construction PR", "N/A"), (int, float))
+            else "N/A"
+        )
+        nAlloc_construction_diff = (
+            moduleres.get("nAlloc construction diff", "N/A")
+            if isinstance(moduleres.get("nAlloc construction diff", "N/A"), (int, float))
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right">{nAlloc_construction_ib}<br>{nAlloc_construction_pr}<br>{nAlloc_construction_diff}</td>'
         ]
-        nAlloc_begin_run_ib = (moduleres.get("nAlloc global begin run IB", "N/A") + moduleres.get("nAlloc stream begin run IB", "N/A")) if isinstance(moduleres.get("nAlloc global begin run IB", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin run IB", "N/A"), (int, float)) else "N/A"
-        nAlloc_begin_run_pr = (moduleres.get("nAlloc global begin run PR", "N/A") + moduleres.get("nAlloc stream begin run PR", "N/A")) if isinstance(moduleres.get("nAlloc global begin run PR", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin run PR", "N/A"), (int, float)) else "N/A"
-        nAlloc_begin_run_diff = (moduleres.get("nAlloc global begin run diff", "N/A") + moduleres.get("nAlloc stream begin run diff", "N/A")) if isinstance(moduleres.get("nAlloc global begin run diff", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin run diff", "N/A"), (int, float)) else "N/A"
+        nAlloc_begin_run_ib = (
+            (
+                moduleres.get("nAlloc global begin run IB", "N/A")
+                + moduleres.get("nAlloc stream begin run IB", "N/A")
+            )
+            if isinstance(moduleres.get("nAlloc global begin run IB", "N/A"), (int, float))
+            and isinstance(moduleres.get("nAlloc stream begin run IB", "N/A"), (int, float))
+            else "N/A"
+        )
+        nAlloc_begin_run_pr = (
+            (
+                moduleres.get("nAlloc global begin run PR", "N/A")
+                + moduleres.get("nAlloc stream begin run PR", "N/A")
+            )
+            if isinstance(moduleres.get("nAlloc global begin run PR", "N/A"), (int, float))
+            and isinstance(moduleres.get("nAlloc stream begin run PR", "N/A"), (int, float))
+            else "N/A"
+        )
+        nAlloc_begin_run_diff = (
+            (
+                moduleres.get("nAlloc global begin run diff", "N/A")
+                + moduleres.get("nAlloc stream begin run diff", "N/A")
+            )
+            if isinstance(moduleres.get("nAlloc global begin run diff", "N/A"), (int, float))
+            and isinstance(moduleres.get("nAlloc stream begin run diff", "N/A"), (int, float))
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right">{nAlloc_begin_run_ib}<br>{nAlloc_begin_run_pr}<br>{nAlloc_begin_run_diff}</td>'
         ]
-        nAlloc_begin_luminosity_block_ib = (moduleres.get("nAlloc global begin luminosity block IB", "N/A") + moduleres.get("nAlloc stream begin luminosity block IB", "N/A")) if isinstance(moduleres.get("nAlloc global begin luminosity block IB", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin luminosity block IB", "N/A"), (int, float)) else "N/A"
-        nAlloc_begin_luminosity_block_pr = (moduleres.get("nAlloc global begin luminosity block PR", "N/A") + moduleres.get("nAlloc stream begin luminosity block PR", "N/A")) if isinstance(moduleres.get("nAlloc global begin luminosity block PR", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin luminosity block PR", "N/A"), (int, float)) else "N/A"
-        nAlloc_begin_luminosity_block_diff = (moduleres.get("nAlloc global begin luminosity block diff", "N/A") + moduleres.get("nAlloc stream begin luminosity block diff", "N/A")) if isinstance(moduleres.get("nAlloc global begin luminosity block diff", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc stream begin luminosity block diff", "N/A"), (int, float)) else "N/A"
+        nAlloc_begin_luminosity_block_ib = (
+            (
+                moduleres.get("nAlloc global begin luminosity block IB", "N/A")
+                + moduleres.get("nAlloc stream begin luminosity block IB", "N/A")
+            )
+            if isinstance(
+                moduleres.get("nAlloc global begin luminosity block IB", "N/A"), (int, float)
+            )
+            and isinstance(
+                moduleres.get("nAlloc stream begin luminosity block IB", "N/A"), (int, float)
+            )
+            else "N/A"
+        )
+        nAlloc_begin_luminosity_block_pr = (
+            (
+                moduleres.get("nAlloc global begin luminosity block PR", "N/A")
+                + moduleres.get("nAlloc stream begin luminosity block PR", "N/A")
+            )
+            if isinstance(
+                moduleres.get("nAlloc global begin luminosity block PR", "N/A"), (int, float)
+            )
+            and isinstance(
+                moduleres.get("nAlloc stream begin luminosity block PR", "N/A"), (int, float)
+            )
+            else "N/A"
+        )
+        nAlloc_begin_luminosity_block_diff = (
+            (
+                moduleres.get("nAlloc global begin luminosity block diff", "N/A")
+                + moduleres.get("nAlloc stream begin luminosity block diff", "N/A")
+            )
+            if isinstance(
+                moduleres.get("nAlloc global begin luminosity block diff", "N/A"), (int, float)
+            )
+            and isinstance(
+                moduleres.get("nAlloc stream begin luminosity block diff", "N/A"), (int, float)
+            )
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right">{nAlloc_begin_luminosity_block_ib}<br>{nAlloc_begin_luminosity_block_pr}<br>{nAlloc_begin_luminosity_block_diff}</td>'
         ]
-        nAlloc_event_ib = moduleres.get("nAlloc event IB", "N/A") if isinstance(moduleres.get("nAlloc event IB", "N/A"), (int, float)) else "N/A"
-        nAlloc_event_pr = moduleres.get("nAlloc event PR", "N/A") if isinstance(moduleres.get("nAlloc event PR", "N/A"), (int, float)) else "N/A"
-        nAlloc_event_diff = moduleres.get("nAlloc event diff", "N/A") if isinstance(moduleres.get("nAlloc event diff", "N/A"), (int, float)) else "N/A"
+        nAlloc_event_ib = (
+            moduleres.get("nAlloc event IB", "N/A")
+            if isinstance(moduleres.get("nAlloc event IB", "N/A"), (int, float))
+            else "N/A"
+        )
+        nAlloc_event_pr = (
+            moduleres.get("nAlloc event PR", "N/A")
+            if isinstance(moduleres.get("nAlloc event PR", "N/A"), (int, float))
+            else "N/A"
+        )
+        nAlloc_event_diff = (
+            moduleres.get("nAlloc event diff", "N/A")
+            if isinstance(moduleres.get("nAlloc event diff", "N/A"), (int, float))
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right">{nAlloc_event_ib}<br>{nAlloc_event_pr}<br>{nAlloc_event_diff}</td>'
         ]
-        nAlloc_event_setup_ib = moduleres.get("nAlloc event setup IB", "N/A") if isinstance(moduleres.get("nAlloc event setup IB", "N/A"), (int, float)) else "N/A"
-        nAlloc_event_setup_pr = moduleres.get("nAlloc event setup PR", "N/A") if isinstance(moduleres.get("nAlloc event setup PR", "N/A"), (int, float)) else "N/A"
-        nAlloc_event_setup_diff = moduleres.get("nAlloc event setup diff", "N/A") if isinstance(moduleres.get("nAlloc event setup diff", "N/A"), (int, float)) else "N/A"
+        nAlloc_event_setup_ib = (
+            moduleres.get("nAlloc event setup IB", "N/A")
+            if isinstance(moduleres.get("nAlloc event setup IB", "N/A"), (int, float))
+            else "N/A"
+        )
+        nAlloc_event_setup_pr = (
+            moduleres.get("nAlloc event setup PR", "N/A")
+            if isinstance(moduleres.get("nAlloc event setup PR", "N/A"), (int, float))
+            else "N/A"
+        )
+        nAlloc_event_setup_diff = (
+            moduleres.get("nAlloc event setup diff", "N/A")
+            if isinstance(moduleres.get("nAlloc event setup diff", "N/A"), (int, float))
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right">{nAlloc_event_setup_ib}<br>{nAlloc_event_setup_pr}<br>{nAlloc_event_setup_diff}</td>'
         ]
         nAlloc_total_ib = (
-                    moduleres.get("nAlloc event setup IB", "N/A") + moduleres.get("nAlloc event IB", "N/A")
-               + moduleres.get("nAlloc construction IB", "N/A") ) if isinstance(moduleres.get("nAlloc event setup IB", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc construction IB", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc event IB", "N/A"), (int, float)) else "N/A"
+            (
+                moduleres.get("nAlloc event setup IB", "N/A")
+                + moduleres.get("nAlloc event IB", "N/A")
+                + moduleres.get("nAlloc construction IB", "N/A")
+            )
+            if isinstance(moduleres.get("nAlloc event setup IB", "N/A"), (int, float))
+            and isinstance(moduleres.get("nAlloc construction IB", "N/A"), (int, float))
+            and isinstance(moduleres.get("nAlloc event IB", "N/A"), (int, float))
+            else "N/A"
+        )
         nAlloc_total_pr = (
+            (
                 moduleres.get("nAlloc event setup PR", "N/A")
                 + moduleres.get("nAlloc event PR", "N/A")
-                + moduleres.get("nAlloc construction PR", "N/A")) if isinstance(moduleres.get("nAlloc event setup PR", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc construction PR", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc event PR", "N/A"), (int, float)) else "N/A"
+                + moduleres.get("nAlloc construction PR", "N/A")
+            )
+            if isinstance(moduleres.get("nAlloc event setup PR", "N/A"), (int, float))
+            and isinstance(moduleres.get("nAlloc construction PR", "N/A"), (int, float))
+            and isinstance(moduleres.get("nAlloc event PR", "N/A"), (int, float))
+            else "N/A"
+        )
         nAlloc_total_diff = (
+            (
                 moduleres.get("nAlloc event setup diff", "N/A")
                 + moduleres.get("nAlloc event diff", "N/A")
-                + moduleres.get("nAlloc construction diff", "N/A")) if isinstance(moduleres.get("nAlloc event setup diff", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc construction diff", "N/A"), (int, float)) and isinstance(moduleres.get("nAlloc event diff", "N/A"), (int, float)) else "N/A"
+                + moduleres.get("nAlloc construction diff", "N/A")
+            )
+            if isinstance(moduleres.get("nAlloc event setup diff", "N/A"), (int, float))
+            and isinstance(moduleres.get("nAlloc construction diff", "N/A"), (int, float))
+            and isinstance(moduleres.get("nAlloc event diff", "N/A"), (int, float))
+            else "N/A"
+        )
         summaryLines += [
             f'<td align="right">{nAlloc_total_ib}<br>{nAlloc_total_pr}<br>{nAlloc_total_diff}</td>'
         ]
-        transitions_ib = moduleib.get("transitions", "N/A") if isinstance(moduleib.get("transitions", "N/A"), (int, float)) else "N/A"
-        transitions_pr = modulepr.get("transitions", "N/A")  if isinstance(modulepr.get("transitions", "N/A"), (int, float)) else "N/A"
+        transitions_ib = (
+            moduleib.get("transitions", "N/A")
+            if isinstance(moduleib.get("transitions", "N/A"), (int, float))
+            else "N/A"
+        )
+        transitions_pr = (
+            modulepr.get("transitions", "N/A")
+            if isinstance(modulepr.get("transitions", "N/A"), (int, float))
+            else "N/A"
+        )
         if isinstance(transitions_ib, (int, float)) and isinstance(transitions_pr, (int, float)):
-            transitions_diff = (transitions_ib - transitions_pr)
+            transitions_diff = transitions_ib - transitions_pr
         else:
-            if not isinstance(transitions_ib, (int, float)) and isinstance(transitions_pr, (int, float)):
+            if not isinstance(transitions_ib, (int, float)) and isinstance(
+                transitions_pr, (int, float)
+            ):
                 transitions_diff = transitions_pr - 0
-            elif isinstance(transitions_ib, (int, float)) and not isinstance(transitions_pr, (int, float)):
-                transitions_diff = 0 -transitions_ib
+            elif isinstance(transitions_ib, (int, float)) and not isinstance(
+                transitions_pr, (int, float)
+            ):
+                transitions_diff = 0 - transitions_ib
         summaryLines += [
             f'<td align="right">{transitions_ib}<br>{transitions_pr}<br>{transitions_diff}</td>'
         ]

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -7,6 +7,7 @@ import os
 threshold = 5000.0
 error_threshold = 20000.0
 
+BEGIN_JOB_KEYS = ["begin job"]
 BEGIN_RUN_KEYS = ["global begin run", "stream begin run"]
 BEGIN_LUMI_KEYS = [
     "global begin luminosity block",
@@ -17,11 +18,10 @@ EVENT_KEYS = ["event"]
 EVENT_SETUP_KEYS = ["event setup"]
 TOTAL_KEYS = [
     *CONSTRUCTION_KEYS,
-    *EVENT_KEYS,
-    *EVENT_SETUP_KEYS,
-    *BEGIN_LUMI_KEYS,
     *BEGIN_RUN_KEYS,
     *BEGIN_LUMI_KEYS,
+    *EVENT_KEYS,
+    *EVENT_SETUP_KEYS,
 ]
 
 METRICS_KEYS = ["added", "nAlloc", "nDealloc", "maxTemp", "max1Alloc"]
@@ -103,8 +103,47 @@ def update_added_totals(datamapres):
             )
 
 
-def build_summary_header(ibdata, prdata, results):
+def build_header_row():
     return [
+        '<td align="center">added begin job</td>',
+        '<td align="center">added construction</td>',
+        '<td align="center">added begin run</td>',
+        '<td align="center">added begin luminosity block</td>',
+        '<td align="center">added event</td>',
+        '<td align="center">added event setup</td>',
+        '<td align="center">added total</td>',
+        '<td align="center">nAlloc begin job</td>',
+        '<td align="center">nAlloc construction</td>',
+        '<td align="center">nAlloc begin run</td>',
+        '<td align="center">nAlloc begin luminosity block</td>',
+        '<td align="center">nAlloc event</td>',
+        '<td align="center">nAlloc event setup</td>',
+        '<td align="center">nAlloc total</td>',
+        '<td align="center">nDealloc begin job</td>',
+        '<td align="center">nDealloc construction</td>',
+        '<td align="center">nDealloc begin run</td>',
+        '<td align="center">nDealloc begin luminosity block</td>',
+        '<td align="center">nDealloc event</td>',
+        '<td align="center">nDealloc event setup</td>',
+        '<td align="center">nDealloc total</td>',
+        '<td align="center">maxTemp begin job</td>',
+        '<td align="center">maxTemp construction</td>',
+        '<td align="center">maxTemp begin run</td>',
+        '<td align="center">maxTemp begin luminosity block</td>',
+        '<td align="center">maxTemp event</td>',
+        '<td align="center">maxTemp event setup</td>',
+        '<td align="center">maxTemp total</td>',
+        '<td align="center">max1Alloc begin job</td>',
+        '<td align="center">max1Alloc construction</td>',
+        '<td align="center">max1Alloc begin run</td>',
+        '<td align="center">max1Alloc begin luminosity block</td>',
+        '<td align="center">max1Alloc event</td>',
+        '<td align="center">max1Alloc event setup</td>',
+        '<td align="center">max1Alloc total</td>',
+    ]
+
+def build_summary_header(ibdata, prdata, results):
+    summary_header = [
         "<html>",
         "<head><style>",
         "table, th, td {border: 1px solid black;}</style>",
@@ -123,123 +162,66 @@ def build_summary_header(ibdata, prdata, results):
         "</tr></table>",
         "<table>",
         '<tr><td align="center">Type<BR>Label</td>',
-        '<td align="center">added construction</td>',
-        '<td align="center">added begin run</td>',
-        '<td align="center">added begin luminosity block</td>',
-        '<td align="center">added event</td>',
-        '<td align="center">added event setup</td>',
-        '<td align="center">nAlloc construction</td>',
-        '<td align="center">nAlloc begin run</td>',
-        '<td align="center">nAlloc begin luminosity block</td>',
-        '<td align="center">nAlloc event</td>',
-        '<td align="center">nAlloc event setup</td>',
+    ]
+    summary_header += build_header_row()
+    summary_header += [
         "</tr>",
+        "<tr>",
         "<td>%s<BR>%s</td>" % (prdata["total"]["type"], prdata["total"]["label"]),
-        '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
-        % (
-            ibdata["total"]["added construction"],
-            prdata["total"]["added construction"],
-            results["total"]["added construction diff"],
-        ),
-        '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
-        % (
-            ibdata["total"]["added global begin run"] + ibdata["total"]["added stream begin run"],
-            prdata["total"]["added global begin run"] + prdata["total"]["added stream begin run"],
-            results["total"]["added global begin run diff"]
-            + results["total"]["added stream begin run diff"],
-        ),
-        '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
-        % (
-            ibdata["total"]["added global begin luminosity block"]
-            + ibdata["total"]["added stream begin luminosity block"],
-            prdata["total"]["added global begin luminosity block"]
-            + prdata["total"]["added stream begin luminosity block"],
-            results["total"]["added global begin luminosity block diff"]
-            + results["total"]["added stream begin luminosity block diff"],
-        ),
-        '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
-        % (
-            ibdata["total"]["added event"],
-            prdata["total"]["added event"],
-            results["total"]["added event diff"],
-        ),
-        '<td align="right">%0.2f<br>%0.2f<br>%0.2f</td>'
-        % (
-            ibdata["total"]["added event setup"],
-            prdata["total"]["added event setup"],
-            results["total"]["added event setup diff"],
-        ),
-        '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-        % (
-            ibdata["total"]["nAlloc construction"],
-            prdata["total"]["nAlloc construction"],
-            results["total"]["nAlloc construction diff"],
-        ),
-        '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-        % (
-            ibdata["total"]["nAlloc global begin run"]
-            + ibdata["total"]["nAlloc stream begin run"],
-            prdata["total"]["nAlloc global begin run"]
-            + prdata["total"]["nAlloc stream begin run"],
-            results["total"]["nAlloc global begin run diff"]
-            + results["total"]["nAlloc stream begin run diff"],
-        ),
-        '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-        % (
-            ibdata["total"]["nAlloc global begin luminosity block"]
-            + ibdata["total"]["nAlloc stream begin luminosity block"],
-            prdata["total"]["nAlloc global begin luminosity block"]
-            + prdata["total"]["nAlloc stream begin luminosity block"],
-            results["total"]["nAlloc global begin luminosity block diff"]
-            + results["total"]["nAlloc stream begin luminosity block diff"],
-        ),
-        '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-        % (
-            ibdata["total"]["nAlloc event"],
-            prdata["total"]["nAlloc event"],
-            results["total"]["nAlloc event diff"],
-        ),
-        '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-        % (
-            ibdata["total"]["nAlloc event setup"],
-            prdata["total"]["nAlloc event setup"],
-            results["total"]["nAlloc event setup diff"],
-        ),
+    ]
+    for metric in METRICS_KEYS:
+        append_triplet_cell(
+        summary_header,
+        sum_numeric_values(results["total"], ['%s %s IB' % (metric , key) for key in BEGIN_JOB_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s PR' % (metric , key) for key in BEGIN_JOB_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in BEGIN_JOB_KEYS]),
+        )
+        append_triplet_cell(
+        summary_header,
+        sum_numeric_values(results["total"], ['%s %s IB' % (metric , key) for key in CONSTRUCTION_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s PR' % (metric , key) for key in CONSTRUCTION_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in CONSTRUCTION_KEYS]),
+        )
+        append_triplet_cell(
+        summary_header,
+        sum_numeric_values(results["total"], ['%s %s IB' % (metric, key) for key in BEGIN_RUN_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s PR' % (metric, key) for key in BEGIN_RUN_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in BEGIN_RUN_KEYS]),
+        )
+        append_triplet_cell(
+        summary_header,
+        sum_numeric_values(results["total"], ['%s %s IB' % (metric, key) for key in BEGIN_LUMI_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s PR' % (metric, key) for key in BEGIN_LUMI_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in BEGIN_LUMI_KEYS]),
+        )
+        append_triplet_cell(
+        summary_header,
+        sum_numeric_values(results["total"], ['%s %s IB' % (metric, key) for key in EVENT_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s PR' % (metric, key) for key in EVENT_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in EVENT_KEYS]),
+        )
+        append_triplet_cell(
+        summary_header,
+        sum_numeric_values(results["total"], ['%s %s IB' % (metric, key) for key in EVENT_SETUP_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s PR' % (metric, key) for key in EVENT_SETUP_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in EVENT_SETUP_KEYS]),
+        )
+        append_triplet_cell(
+        summary_header,
+        sum_numeric_values(results["total"], ['%s %s IB' % (metric, key) for key in TOTAL_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s PR' % (metric, key) for key in TOTAL_KEYS]),
+        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in TOTAL_KEYS]),
+        )
+    summary_header += [
         "</tr></table>",
-        '<table><tr><td align="center">Module label<BR>Module type<BR>Module record</td>',
-        '<td align="center">added construction</td>',
-        '<td align="center">added begin run</td>',
-        '<td align="center">added begin luminosity block</td>',
-        '<td align="center">added event</td>',
-        '<td align="center">added event setup</td>',
-        '<td align="center">added total</td>',
-        '<td align="center">nAlloc construction</td>',
-        '<td align="center">nAlloc begin run</td>',
-        '<td align="center">nAlloc begin luminosity block</td>',
-        '<td align="center">nAlloc event</td>',
-        '<td align="center">nAlloc event setup</td>',
-        '<td align="center">nAlloc total</td>',
-        '<td align="center">nDealloc construction</td>',
-        '<td align="center">nDealloc begin run</td>',
-        '<td align="center">nDealloc begin luminosity block</td>',
-        '<td align="center">nDealloc event</td>',
-        '<td align="center">nDealloc event setup</td>',
-        '<td align="center">nDealloc total</td>',
-        '<td align="center">maxTemp construction</td>',
-        '<td align="center">maxTemp begin run</td>',
-        '<td align="center">maxTemp begin luminosity block</td>',
-        '<td align="center">maxTemp event</td>',
-        '<td align="center">maxTemp event setup</td>',
-        '<td align="center">maxTemp total</td>',
-        '<td align="center">max1Alloc construction</td>',
-        '<td align="center">max1Alloc begin run</td>',
-        '<td align="center">max1Alloc begin luminosity block</td>',
-        '<td align="center">max1Alloc event</td>',
-        '<td align="center">max1Alloc event setup</td>',
-        '<td align="center">max1Alloc total</td>',
+        '<table style="width: 100%"><tr><td align="center">Module label<BR>Module type<BR>Module record</td>',
+    ]
+    summary_header += build_header_row()
+    summary_header += [
         '<td align="center">transitions</td>',
         "</tr>",
     ]
+    return summary_header
 
 
 def append_module_columns_prefix(summary_lines, moduleres, prefix):
@@ -248,7 +230,12 @@ def append_module_columns_prefix(summary_lines, moduleres, prefix):
     cell_attrs = 'align="right"'
     if color:
         cell_attrs += " " + color
-
+    append_triplet_cell(
+        summary_lines,
+        sum_with_prefix_suffix(moduleres, BEGIN_JOB_KEYS, prefix=prefix, suffix="IB"),
+        sum_with_prefix_suffix(moduleres, BEGIN_JOB_KEYS, prefix=prefix, suffix="PR"),
+        sum_with_prefix_suffix(moduleres, BEGIN_JOB_KEYS, prefix=prefix, suffix="diff"),
+    )
     append_triplet_cell(
         summary_lines,
         sum_with_prefix_suffix(moduleres, CONSTRUCTION_KEYS, prefix=prefix, suffix="IB"),
@@ -296,12 +283,11 @@ def append_module_rows(summary_lines, moduleib, modulepr, moduleres):
     ]
     for metric in METRICS_KEYS:
         append_module_columns_prefix(summary_lines, moduleres, metric)
-
     transitions_ib = numeric_value(moduleib, "transitions")
     transitions_pr = numeric_value(modulepr, "transitions")
     transitions_diff = transitions_diff_value(transitions_ib, transitions_pr)
     append_triplet_cell(summary_lines, transitions_ib, transitions_pr, transitions_diff)
-
+    summary_lines += ["</tr>"]
 
 def append_sorted_module_rows(summary_lines, datamapib, datamappr, datamapres):
     for item in sorted(
@@ -441,7 +427,6 @@ dumpfile = (
     os.path.dirname(os.path.realpath(sys.argv[2]))
     + "/diff-"
     + os.path.basename(os.path.realpath(sys.argv[2]))
-    + ".json"
 )
 with open(dumpfile, "w") as f:
     json.dump(results, f, indent=2)

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -142,6 +142,7 @@ def build_header_row():
         '<td align="center">max1Alloc total</td>',
     ]
 
+
 def build_summary_header(ibdata, prdata, results):
     summary_header = [
         "<html>",
@@ -171,46 +172,88 @@ def build_summary_header(ibdata, prdata, results):
     ]
     for metric in METRICS_KEYS:
         append_triplet_cell(
-        summary_header,
-        sum_numeric_values(results["total"], ['%s %s IB' % (metric , key) for key in BEGIN_JOB_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s PR' % (metric , key) for key in BEGIN_JOB_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in BEGIN_JOB_KEYS]),
+            summary_header,
+            sum_numeric_values(
+                results["total"], ["%s %s IB" % (metric, key) for key in BEGIN_JOB_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s PR" % (metric, key) for key in BEGIN_JOB_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s diff" % (metric, key) for key in BEGIN_JOB_KEYS]
+            ),
         )
         append_triplet_cell(
-        summary_header,
-        sum_numeric_values(results["total"], ['%s %s IB' % (metric , key) for key in CONSTRUCTION_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s PR' % (metric , key) for key in CONSTRUCTION_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in CONSTRUCTION_KEYS]),
+            summary_header,
+            sum_numeric_values(
+                results["total"], ["%s %s IB" % (metric, key) for key in CONSTRUCTION_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s PR" % (metric, key) for key in CONSTRUCTION_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s diff" % (metric, key) for key in CONSTRUCTION_KEYS]
+            ),
         )
         append_triplet_cell(
-        summary_header,
-        sum_numeric_values(results["total"], ['%s %s IB' % (metric, key) for key in BEGIN_RUN_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s PR' % (metric, key) for key in BEGIN_RUN_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in BEGIN_RUN_KEYS]),
+            summary_header,
+            sum_numeric_values(
+                results["total"], ["%s %s IB" % (metric, key) for key in BEGIN_RUN_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s PR" % (metric, key) for key in BEGIN_RUN_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s diff" % (metric, key) for key in BEGIN_RUN_KEYS]
+            ),
         )
         append_triplet_cell(
-        summary_header,
-        sum_numeric_values(results["total"], ['%s %s IB' % (metric, key) for key in BEGIN_LUMI_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s PR' % (metric, key) for key in BEGIN_LUMI_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in BEGIN_LUMI_KEYS]),
+            summary_header,
+            sum_numeric_values(
+                results["total"], ["%s %s IB" % (metric, key) for key in BEGIN_LUMI_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s PR" % (metric, key) for key in BEGIN_LUMI_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s diff" % (metric, key) for key in BEGIN_LUMI_KEYS]
+            ),
         )
         append_triplet_cell(
-        summary_header,
-        sum_numeric_values(results["total"], ['%s %s IB' % (metric, key) for key in EVENT_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s PR' % (metric, key) for key in EVENT_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in EVENT_KEYS]),
+            summary_header,
+            sum_numeric_values(
+                results["total"], ["%s %s IB" % (metric, key) for key in EVENT_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s PR" % (metric, key) for key in EVENT_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s diff" % (metric, key) for key in EVENT_KEYS]
+            ),
         )
         append_triplet_cell(
-        summary_header,
-        sum_numeric_values(results["total"], ['%s %s IB' % (metric, key) for key in EVENT_SETUP_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s PR' % (metric, key) for key in EVENT_SETUP_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in EVENT_SETUP_KEYS]),
+            summary_header,
+            sum_numeric_values(
+                results["total"], ["%s %s IB" % (metric, key) for key in EVENT_SETUP_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s PR" % (metric, key) for key in EVENT_SETUP_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s diff" % (metric, key) for key in EVENT_SETUP_KEYS]
+            ),
         )
         append_triplet_cell(
-        summary_header,
-        sum_numeric_values(results["total"], ['%s %s IB' % (metric, key) for key in TOTAL_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s PR' % (metric, key) for key in TOTAL_KEYS]),
-        sum_numeric_values(results["total"], ['%s %s diff' % (metric, key) for key in TOTAL_KEYS]),
+            summary_header,
+            sum_numeric_values(
+                results["total"], ["%s %s IB" % (metric, key) for key in TOTAL_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s PR" % (metric, key) for key in TOTAL_KEYS]
+            ),
+            sum_numeric_values(
+                results["total"], ["%s %s diff" % (metric, key) for key in TOTAL_KEYS]
+            ),
         )
     summary_header += [
         "</tr></table>",
@@ -288,6 +331,7 @@ def append_module_rows(summary_lines, moduleib, modulepr, moduleres):
     transitions_diff = transitions_diff_value(transitions_ib, transitions_pr)
     append_triplet_cell(summary_lines, transitions_ib, transitions_pr, transitions_diff)
     summary_lines += ["</tr>"]
+
 
 def append_sorted_module_rows(summary_lines, datamapib, datamappr, datamapres):
     for item in sorted(

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -437,7 +437,8 @@ for item in sorted(
             % (
                 moduleib.get("transitions", float("nan")),
                 modulepr.get("transitions", float("nan")),
-                moduleres.get("transitions diff", float("nan")),
+                moduleib.get("transitions", float("nan"))
+                - modulepr.get("transitions", float("nan")),
             ),
             "</tr>",
         ]

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -7,30 +7,24 @@ import os
 threshold = 5000.0
 error_threshold = 20000.0
 
-ADDED_BEGIN_RUN_KEYS = ["added global begin run", "added stream begin run"]
-ADDED_BEGIN_LUMI_KEYS = [
-    "added global begin luminosity block",
-    "added stream begin luminosity block",
+BEGIN_RUN_KEYS = ["global begin run", "stream begin run"]
+BEGIN_LUMI_KEYS = [
+    "global begin luminosity block",
+    "stream begin luminosity block",
 ]
-ADDED_TOTAL_KEYS = [
-    "added construction",
-    "added event",
-    "added event setup",
-    *ADDED_BEGIN_RUN_KEYS,
-    *ADDED_BEGIN_LUMI_KEYS,
+CONSTRUCTION_KEYS = ["construction"]
+EVENT_KEYS = ["event"]
+EVENT_SETUP_KEYS = ["event setup"]
+TOTAL_KEYS = [
+    *CONSTRUCTION_KEYS,
+    *EVENT_KEYS,
+    *EVENT_SETUP_KEYS,
+    *BEGIN_LUMI_KEYS,
+    *BEGIN_RUN_KEYS,
+    *BEGIN_LUMI_KEYS,
 ]
-NALLOC_BEGIN_RUN_KEYS = ["nAlloc global begin run", "nAlloc stream begin run"]
-NALLOC_BEGIN_LUMI_KEYS = [
-    "nAlloc global begin luminosity block",
-    "nAlloc stream begin luminosity block",
-]
-NALLOC_TOTAL_KEYS = [
-    "nAlloc construction",
-    "nAlloc event",
-    "nAlloc event setup",
-    *NALLOC_BEGIN_RUN_KEYS,
-    *NALLOC_BEGIN_LUMI_KEYS,
-]
+
+METRICS_KEYS = ["added", "nAlloc", "nDealloc", "maxTemp", "max1Alloc"]
 
 
 def module_key(module):
@@ -47,9 +41,9 @@ def sum_numeric_values(data, keys, default="N/A"):
     return sum(values) if all(isinstance(value, (int, float)) for value in values) else default
 
 
-def sum_with_suffix(data, metric_keys, suffix, default="N/A"):
+def sum_with_prefix_suffix(data, metric_keys, prefix="added", suffix="", default="N/A"):
     return sum_numeric_values(
-        data, ["%s %s" % (metric, suffix) for metric in metric_keys], default
+        data, ["%s %s %s" % (prefix, metric, suffix) for metric in metric_keys], default
     )
 
 
@@ -97,9 +91,16 @@ def update_added_totals(datamapres):
         key = module_key(module)
         if not is_valid_module_key(key):
             continue
-        module["added total PR"] = sum_with_suffix(module, ADDED_TOTAL_KEYS, "PR")
-        module["added total IB"] = sum_with_suffix(module, ADDED_TOTAL_KEYS, "IB")
-        module["added total diff"] = sum_with_suffix(module, ADDED_TOTAL_KEYS, "diff")
+        for metric in METRICS_KEYS:
+            module[f"{metric} total PR"] = sum_with_prefix_suffix(
+                module, TOTAL_KEYS, prefix=metric, suffix="PR"
+            )
+            module[f"{metric} total IB"] = sum_with_prefix_suffix(
+                module, TOTAL_KEYS, prefix=metric, suffix="IB"
+            )
+            module[f"{metric} total diff"] = sum_with_prefix_suffix(
+                module, TOTAL_KEYS, prefix=metric, suffix="diff"
+            )
 
 
 def build_summary_header(ibdata, prdata, results):
@@ -206,109 +207,95 @@ def build_summary_header(ibdata, prdata, results):
         ),
         "</tr></table>",
         '<table><tr><td align="center">Module label<BR>Module type<BR>Module record</td>',
-        '<td align="center">added construction (kB)</td>',
-        '<td align="center">added begin run (kB)</td>',
-        '<td align="center">added begin luminosity block (kB)</td>',
-        '<td align="center">added event (kB)</td>',
-        '<td align="center">added event setup (kB)</td>',
-        '<td align="center">added total (kB)</td>',
+        '<td align="center">added construction</td>',
+        '<td align="center">added begin run</td>',
+        '<td align="center">added begin luminosity block</td>',
+        '<td align="center">added event</td>',
+        '<td align="center">added event setup</td>',
+        '<td align="center">added total</td>',
         '<td align="center">nAlloc construction</td>',
         '<td align="center">nAlloc begin run</td>',
         '<td align="center">nAlloc begin luminosity block</td>',
         '<td align="center">nAlloc event</td>',
         '<td align="center">nAlloc event setup</td>',
         '<td align="center">nAlloc total</td>',
+        '<td align="center">nDealloc construction</td>',
+        '<td align="center">nDealloc begin run</td>',
+        '<td align="center">nDealloc begin luminosity block</td>',
+        '<td align="center">nDealloc event</td>',
+        '<td align="center">nDealloc event setup</td>',
+        '<td align="center">nDealloc total</td>',
+        '<td align="center">maxTemp construction</td>',
+        '<td align="center">maxTemp begin run</td>',
+        '<td align="center">maxTemp begin luminosity block</td>',
+        '<td align="center">maxTemp event</td>',
+        '<td align="center">maxTemp event setup</td>',
+        '<td align="center">maxTemp total</td>',
+        '<td align="center">max1Alloc construction</td>',
+        '<td align="center">max1Alloc begin run</td>',
+        '<td align="center">max1Alloc begin luminosity block</td>',
+        '<td align="center">max1Alloc event</td>',
+        '<td align="center">max1Alloc event setup</td>',
+        '<td align="center">max1Alloc total</td>',
         '<td align="center">transitions</td>',
         "</tr>",
     ]
 
 
-def append_module_row(summary_lines, moduleib, modulepr, moduleres):
+def append_module_columns_prefix(summary_lines, moduleres, prefix):
     addedtotaldiff = numeric_value(moduleres, "added total diff", float("-inf"))
     color = added_total_color(addedtotaldiff)
     cell_attrs = 'align="right"'
     if color:
         cell_attrs += " " + color
 
+    append_triplet_cell(
+        summary_lines,
+        sum_with_prefix_suffix(moduleres, CONSTRUCTION_KEYS, prefix=prefix, suffix="IB"),
+        sum_with_prefix_suffix(moduleres, CONSTRUCTION_KEYS, prefix=prefix, suffix="PR"),
+        sum_with_prefix_suffix(moduleres, CONSTRUCTION_KEYS, prefix=prefix, suffix="diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_with_prefix_suffix(moduleres, BEGIN_RUN_KEYS, prefix=prefix, suffix="IB"),
+        sum_with_prefix_suffix(moduleres, BEGIN_RUN_KEYS, prefix=prefix, suffix="PR"),
+        sum_with_prefix_suffix(moduleres, BEGIN_RUN_KEYS, prefix=prefix, suffix="diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_with_prefix_suffix(moduleres, BEGIN_LUMI_KEYS, prefix=prefix, suffix="IB"),
+        sum_with_prefix_suffix(moduleres, BEGIN_LUMI_KEYS, prefix=prefix, suffix="PR"),
+        sum_with_prefix_suffix(moduleres, BEGIN_LUMI_KEYS, prefix=prefix, suffix="diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_with_prefix_suffix(moduleres, EVENT_KEYS, prefix=prefix, suffix="IB"),
+        sum_with_prefix_suffix(moduleres, EVENT_KEYS, prefix=prefix, suffix="PR"),
+        sum_with_prefix_suffix(moduleres, EVENT_KEYS, prefix=prefix, suffix="diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_with_prefix_suffix(moduleres, EVENT_SETUP_KEYS, prefix=prefix, suffix="IB"),
+        sum_with_prefix_suffix(moduleres, EVENT_SETUP_KEYS, prefix=prefix, suffix="PR"),
+        sum_with_prefix_suffix(moduleres, EVENT_SETUP_KEYS, prefix=prefix, suffix="diff"),
+    )
+    append_triplet_cell(
+        summary_lines,
+        sum_with_prefix_suffix(moduleres, TOTAL_KEYS, prefix=prefix, suffix="IB"),
+        sum_with_prefix_suffix(moduleres, TOTAL_KEYS, prefix=prefix, suffix="PR"),
+        sum_with_prefix_suffix(moduleres, TOTAL_KEYS, prefix=prefix, suffix="diff"),
+        attrs=cell_attrs,
+    )
+
+
+def append_module_rows(summary_lines, moduleib, modulepr, moduleres):
     summary_lines += [
         "<tr>",
         '<td align="center">%s<BR>%s<BR> %s</td>'
         % (moduleres.get("label", ""), moduleres.get("type", ""), moduleres.get("record", "")),
     ]
-    append_triplet_cell(
-        summary_lines,
-        numeric_value(moduleres, "added construction IB"),
-        numeric_value(moduleres, "added construction PR"),
-        numeric_value(moduleres, "added construction diff"),
-    )
-    append_triplet_cell(
-        summary_lines,
-        sum_numeric_values(moduleib, ADDED_BEGIN_RUN_KEYS),
-        sum_numeric_values(modulepr, ADDED_BEGIN_RUN_KEYS),
-        sum_with_suffix(moduleres, ADDED_BEGIN_RUN_KEYS, "diff"),
-    )
-    append_triplet_cell(
-        summary_lines,
-        sum_numeric_values(moduleib, ADDED_BEGIN_LUMI_KEYS),
-        sum_numeric_values(modulepr, ADDED_BEGIN_LUMI_KEYS),
-        sum_with_suffix(moduleres, ADDED_BEGIN_LUMI_KEYS, "diff"),
-    )
-    append_triplet_cell(
-        summary_lines,
-        numeric_value(moduleib, "added event"),
-        numeric_value(modulepr, "added event"),
-        numeric_value(moduleres, "added event diff"),
-    )
-    append_triplet_cell(
-        summary_lines,
-        numeric_value(moduleib, "added event setup"),
-        numeric_value(modulepr, "added event setup"),
-        numeric_value(moduleres, "added event setup diff"),
-    )
-    append_triplet_cell(
-        summary_lines,
-        sum_numeric_values(moduleib, ADDED_TOTAL_KEYS),
-        sum_numeric_values(modulepr, ADDED_TOTAL_KEYS),
-        sum_with_suffix(moduleres, ADDED_TOTAL_KEYS, "diff"),
-        attrs=cell_attrs,
-    )
-
-    append_triplet_cell(
-        summary_lines,
-        numeric_value(moduleres, "nAlloc construction IB"),
-        numeric_value(moduleres, "nAlloc construction PR"),
-        numeric_value(moduleres, "nAlloc construction diff"),
-    )
-    append_triplet_cell(
-        summary_lines,
-        sum_with_suffix(moduleres, NALLOC_BEGIN_RUN_KEYS, "IB"),
-        sum_with_suffix(moduleres, NALLOC_BEGIN_RUN_KEYS, "PR"),
-        sum_with_suffix(moduleres, NALLOC_BEGIN_RUN_KEYS, "diff"),
-    )
-    append_triplet_cell(
-        summary_lines,
-        sum_with_suffix(moduleres, NALLOC_BEGIN_LUMI_KEYS, "IB"),
-        sum_with_suffix(moduleres, NALLOC_BEGIN_LUMI_KEYS, "PR"),
-        sum_with_suffix(moduleres, NALLOC_BEGIN_LUMI_KEYS, "diff"),
-    )
-    append_triplet_cell(
-        summary_lines,
-        numeric_value(moduleres, "nAlloc event IB"),
-        numeric_value(moduleres, "nAlloc event PR"),
-        numeric_value(moduleres, "nAlloc event diff"),
-    )
-    append_triplet_cell(
-        summary_lines,
-        numeric_value(moduleres, "nAlloc event setup IB"),
-        numeric_value(moduleres, "nAlloc event setup PR"),
-        numeric_value(moduleres, "nAlloc event setup diff"),
-    )
-    append_triplet_cell(
-        summary_lines,
-        sum_with_suffix(moduleres, NALLOC_TOTAL_KEYS, "IB"),
-        sum_with_suffix(moduleres, NALLOC_TOTAL_KEYS, "PR"),
-        sum_with_suffix(moduleres, NALLOC_TOTAL_KEYS, "diff"),
-    )
+    for metric in METRICS_KEYS:
+        append_module_columns_prefix(summary_lines, moduleres, metric)
 
     transitions_ib = numeric_value(moduleib, "transitions")
     transitions_pr = numeric_value(modulepr, "transitions")
@@ -328,7 +315,7 @@ def append_sorted_module_rows(summary_lines, datamapib, datamappr, datamapres):
         moduleib = datamapib.get(key, {})
         modulepr = datamappr.get(key, {})
         moduleres = datamapres.get(key, {})
-        append_module_row(summary_lines, moduleib, modulepr, moduleres)
+        append_module_rows(summary_lines, moduleib, modulepr, moduleres)
 
 
 def build_summary_lines(ibdata, prdata, results, datamapib, datamappr, datamapres):

--- a/comparisons/moduleAllocMonitor-circles-diff.py
+++ b/comparisons/moduleAllocMonitor-circles-diff.py
@@ -3,30 +3,20 @@
 import sys
 import json
 import os
+import math
 
 
-def diff_from(metrics, data, data_total, dest, dest_total, res):
+def diff_from(metrics, data, dest, res):
     for metric in metrics:
-        dmetric = dest[metric] - data[metric]
-        dkey = "%s diff" % metric
-        res[dkey] = dmetric
-        pdmetric = 0.0
-        pdmetric = dmetric
-        pdkey = "%s pdiff" % metric
-        res[pdkey] = pdmetric
-        fkey = "%s frac" % metric
-        fdest = 100 * dest[metric] / dest_total[metric] if dest_total[metric] != 0 else 0.0
-        dest[fkey] = fdest
-        fdata = 100 * data[metric] / data_total[metric] if data_total[metric] != 0 else 0.0
-        data[fkey] = fdata
-        dfmetric = fdest - fdata
-        dfkey = "%s frac diff" % metric
-        res[dfkey] = dfmetric
-        pdfmetric = 0.0
-        pdfmetric = dfmetric
-        dkpkey = "%s frac diff" % metric
-        res[dkpkey] = pdfmetric
-
+        ibkey = "%s IB" % metric
+        res[ibkey] = data.get(metric, float("nan"))
+        prkey = "%s PR" % metric
+        res[prkey] = dest.get(metric, float("nan"))
+        if math.isnan(res[ibkey]) or math.isnan(res[prkey]):
+            res[metric + " diff"] = float("nan")
+        else:
+            dmetric = dest.get(metric) - data.get(metric)
+            res[metric + " diff"] = dmetric
 
 if len(sys.argv) == 1:
     print("""Usage: resources-diff.py IB_FILE PR_FILE
@@ -95,40 +85,55 @@ if ibdata["total"]["label"] != prdata["total"]["label"]:
 results = {}
 results["resources"] = []
 for resource in prdata["resources"]:
+    resourcediff = resource.copy()
+    resourceib = resource.copy()
+    resourcepr = resource.copy()
     for k, v in resource.items():
-        dkey = "%s diff" % k
-        results["resources"].append({k: "%s" % v})
-        results["resources"].append({dkey: "%s diff" % v})
+        resourcediff[k] = "%s diff" % v
+        resourceib[k] = "%s IB" % v
+        resourcepr[k] = "%s PR" % v
+    results["resources"].append(resourcediff)
+    results["resources"].append(resourceib)
+    results["resources"].append(resourcepr)
 
 results["total"] = {}
 results["total"]["type"] = prdata["total"]["type"]
 results["total"]["label"] = prdata["total"]["label"]
 
 diff_from(
-    metrics, ibdata["total"], ibdata["total"], prdata["total"], prdata["total"], results["total"]
+    metrics, ibdata["total"], prdata["total"], results["total"]
 )
 
 results["modules"] = []
+keys = set()
 for module in prdata["modules"]:
     key = module["label"] + "|" + module["type"] + "|" + module["record"]
+    keys.add(key)
+for module in ibdata["modules"]:
+    key = module["label"] + "|" + module["type"] + "|" + module["record"]
+    keys.add(key)
+for key in sorted(keys):
     result = {}
-    result["type"] = module["type"]
-    result["label"] = module["label"]
-    result["record"] = module["record"]
-    result["transitions"] = module["transitions"]
-    if key in datamapib:
-        diff_from(metrics, datamapib[key], ibdata["total"], module, prdata["total"], result)
-        results["modules"].append(result)
+    if key in datamapib and key not in datamappr:
+        result["type"] = datamapib.get(key).get("type")
+        result["label"] = datamapib.get(key).get("label")
+        result["record"] = datamapib.get(key).get("record")
+        diff_from(metrics, datamapib.get(key, {}), {}, result)
+    elif key in datamappr and key not in datamapib:
+        result["type"] = datamappr.get(key).get("type")
+        result["label"] = datamappr.get(key).get("label")
+        result["record"] = datamappr.get(key).get("record")
+        diff_from(metrics, {}, datamappr.get(key, {}), result)
     else:
-        datamapib[key] = module
-        diff_from(metrics, datamapib[key], ibdata["total"], module, prdata["total"], result)
-        results["modules"].append(result)
+        result["type"] = datamappr.get(key).get("type")
+        result["label"] = datamappr.get(key).get("label")
+        result["record"] = datamappr.get(key).get("record")
+        diff_from(metrics, datamapib.get(key, {}), datamappr.get(key, {}), result)
+    results["modules"].append(result)
 
-datamapres = {
-    module["label"] + "|" + module["type"] + "|" + module["record"]: module
-    for module in results["modules"]
-}
-
+datamapres = {}
+for module in results["modules"]:
+    datamapres["%s|%s|%s" % (module.get("label", ""), module.get("type", ""), module.get("record", ""))] = module
 threshold = 5000.0
 error_threshold = 20000.0
 
@@ -252,153 +257,181 @@ summaryLines += [
 ]
 
 for item in datamapres.items():
-    key = item[1]["label"] + "|" + item[1]["type"] + "|" + item[1]["record"]
-    if not key == "||":
-        moduleib = datamapib[key]
-        modulepr = datamappr[key]
-        moduleres = datamapres[key]
+    key = "%s|%s|%s" % (item[1].get("label", ""), item[1].get("type", ""), item[1].get("record", ""))
+    if not key == "None|None|None" and not key == "||":
+        moduleib = datamapib.get(key, {})
+        modulepr = datamappr.get(key, {})
+        moduleres = datamapres.get(key, {})
         added_total_pr = (
-            modulepr.get("added event setup", 0)
-            + modulepr.get("added event", 0)
-            + modulepr.get("added construction", 0)
-            + modulepr.get("added global begin run", 0)
-            + modulepr.get("added stream begin run", 0)
-            + modulepr.get("added global begin luminosity block", 0)
-            + modulepr.get("added stream begin luminosity block", 0)
+            modulepr.get("added event setup", float("nan"))
+            + modulepr.get("added event", float("nan"))
+            + modulepr.get("added construction", float("nan"))
+            + modulepr.get("added global begin run", float("nan"))
+            + modulepr.get("added stream begin run", float("nan"))
+            + modulepr.get("added global begin luminosity block", float("nan"))
+            + modulepr.get("added stream begin luminosity block", float("nan"))
         )
-        modulepr["added total"] = added_total_pr
         added_total_ib = (
-            moduleib.get("added event setup", 0)
-            + moduleib.get("added event", 0)
-            + moduleib.get("added construction", 0)
-            + moduleib.get("added global begin run", 0)
-            + moduleib.get("added stream begin run", 0)
-            + moduleib.get("added global begin luminosity block", 0)
-            + moduleib.get("added stream begin luminosity block", 0)
+            moduleib.get("added event setup", float("nan"))
+            + moduleib.get("added event", float("nan"))
+            + moduleib.get("added construction", float("nan"))
+            + moduleib.get("added global begin run", float("nan"))
+            + moduleib.get("added stream begin run", float("nan"))
+            + moduleib.get("added global begin luminosity block", float("nan"))
+            + moduleib.get("added stream begin luminosity block", float("nan"))
         )
-        moduleib["added total"] = added_total_ib
         added_total_diff = (
-            moduleres.get("added event setup diff", 0)
-            + moduleres.get("added event diff", 0)
-            + moduleres.get("added construction diff", 0)
-            + moduleres.get("added global begin run diff", 0)
-            + moduleres.get("added stream begin run diff", 0)
-            + moduleres.get("added global begin luminosity block diff", 0)
-            + moduleres.get("added stream begin luminosity block diff", 0)
+            moduleres.get("added event setup diff", float("nan"))
+            + moduleres.get("added event diff", float("nan"))
+            + moduleres.get("added construction diff", float("nan"))
+            + moduleres.get("added global begin run diff", float("nan"))
+            + moduleres.get("added stream begin run diff", float("nan"))
+            + moduleres.get("added global begin luminosity block diff", float("nan"))
+            + moduleres.get("added stream begin luminosity block diff", float("nan"))
         )
         moduleres["added total diff"] = added_total_diff
+dumpfile = os.path.dirname(sys.argv[2]) + "/diff-" + os.path.basename(sys.argv[2])
+with open(dumpfile, "w") as f:
+    json.dump(results, f, indent=2)
 
 for item in sorted(
     datamapres.items(),
-    key=lambda x: x[1]["added total diff"],
+    key=lambda x: x[1].get("added total diff", float("nan")),
     reverse=True,
 ):
-    key = item[1]["label"] + "|" + item[1]["type"] + "|" + item[1]["record"]
-    if not key == "||":
-        moduleib = datamapib[key]
-        modulepr = datamappr[key]
-        moduleres = datamapres[key]
+    key = "%s|%s|%s" % (item[1].get("label", ""), item[1].get("type", ""), item[1].get("record", ""))
+    if not key == "None|None|None" and not key == "||":
+        moduleib = datamapib.get(key, {})
+        modulepr = datamappr.get(key, {})
+        moduleres = datamapres.get(key, {})
+        if moduleres.get("added total diff", float("nan")) == math.nan:
+            print("Error: module %s is not in diff results" % key)
+            continue
         cellString = '<td align="right" '
         color = ""
-        if moduleres["added total diff"] > threshold:
+        addedtotaldiff = moduleres.get("added total diff", float("nan"))
+        if addedtotaldiff > threshold:
             color = 'bgcolor="orange"'
-        if moduleres["added total diff"] > error_threshold:
+        if addedtotaldiff > error_threshold:
             color = 'bgcolor="red"'
-        if moduleres["added total diff"] < -1.0 * threshold:
+        if addedtotaldiff < -1.0 * threshold:
             color = 'bgcolor="cyan"'
-        if moduleres["added total diff"] < -1.0 * error_threshold:
+        if addedtotaldiff < -1.0 * error_threshold:
             color = 'bgcolor="green"'
         cellString += color
         cellString += ">"
         summaryLines += [
             "<tr>",
             '<td align="center">%s<BR>%s<BR> %s</td>'
-            % (moduleres["label"], moduleres["type"], moduleres["record"]),
+            % (moduleres.get("label", ""), moduleres.get("type", ""), moduleres.get("record", "")),
             '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
             % (
-                moduleib["added construction"],
-                modulepr["added construction"],
-                moduleres["added construction diff"],
+                moduleib.get("added construction",float("nan")),
+                modulepr.get("added construction",float("nan")),
+                moduleres.get("added construction diff", float("nan")),
             ),
             '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
             % (
-                moduleib["added global begin run"] + moduleib["added stream begin run"],
-                modulepr["added global begin run"] + modulepr["added stream begin run"],
-                moduleres["added global begin run diff"]
-                + moduleres["added stream begin run diff"],
+                moduleib.get("added global begin run", float("nan"))
+                + moduleib.get("added stream begin run", float("nan")),
+                modulepr.get("added global begin run", float("nan"))
+                + modulepr.get("added stream begin run", float("nan")),
+                moduleres.get("added global begin run diff", float("nan"))
+                + moduleres.get("added stream begin run diff", float("nan"))
             ),
             '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
             % (
-                moduleib["added global begin luminosity block"]
-                + moduleib["added stream begin luminosity block"],
-                modulepr["added global begin luminosity block"]
-                + modulepr["added stream begin luminosity block"],
-                moduleres["added global begin luminosity block diff"]
-                + moduleres["added stream begin luminosity block diff"],
+                moduleib.get("added global begin luminosity block", float("nan"))
+                + moduleib.get("added stream begin luminosity block", float("nan")),
+                modulepr.get("added global begin luminosity block", float("nan"))
+                + modulepr.get("added stream begin luminosity block", float("nan")),
+                moduleres.get("added global begin luminosity block diff", float("nan"))
+                + moduleres.get("added stream begin luminosity block diff", float("nan"))
             ),
             '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
             % (
-                moduleib["added event"],
-                modulepr["added event"],
-                moduleres["added event diff"],
+                moduleib.get("added event", float("nan")),
+                modulepr.get("added event", float("nan")),
+                moduleres.get("added event diff", float("nan"))
             ),
             '<td align="right"> %0.2f<br> %0.2f<br> %0.2f</td>'
             % (
-                moduleib["added event setup"],
-                modulepr["added event setup"],
-                moduleres["added event setup diff"],
+                moduleib.get("added event setup", float("nan")),
+                modulepr.get("added event setup", float("nan")),
+                moduleres.get("added event setup diff", float("nan"))
             ),
             cellString
             + "%0.2f<br> %0.2f<br> %0.2f</td>"
-            % (
-                moduleib["added total"],
-                modulepr["added total"],
-                moduleres["added total diff"],
+            % ( moduleib.get("added event setup", float("nan"))
+            + moduleib.get("added event", float("nan")) 
+            + moduleib.get("added construction", float("nan"))
+            + moduleib.get("added global begin run", float("nan"))
+            + moduleib.get("added stream begin run", float("nan"))
+            + moduleib.get("added global begin luminosity block", float("nan"))
+            + moduleib.get("added stream begin luminosity block", float("nan")),
+            modulepr.get("added event setup", float("nan"))
+            + modulepr.get("added event", float("nan"))
+            + modulepr.get("added construction", float("nan"))
+            + modulepr.get("added global begin run", float("nan"))
+            + modulepr.get("added stream begin run", float("nan"))
+            + modulepr.get("added global begin luminosity block", float("nan"))
+            + modulepr.get("added stream begin luminosity block", float("nan")),
+            moduleres.get("added event setup diff", float("nan"))
+            + moduleres.get("added event diff", float("nan"))
+            + moduleres.get("added construction diff", float("nan"))
+            + moduleres.get("added global begin run diff", float("nan"))
+            + moduleres.get("added stream begin run diff", float("nan"))
+            + moduleres.get("added global begin luminosity block diff", float("nan"))
+            + moduleres.get("added stream begin luminosity block diff", float("nan"))
             ),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
             % (
-                moduleib["nAlloc construction"],
-                modulepr["nAlloc construction"],
-                moduleres["nAlloc construction diff"],
+                moduleib.get("nAlloc construction", float("nan")),
+                modulepr.get("nAlloc construction", float("nan")),
+                moduleres.get("nAlloc construction diff", float("nan")  ),
             ),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
             % (
-                moduleib["nAlloc global begin run"] + moduleib["nAlloc stream begin run"],
-                modulepr["nAlloc global begin run"] + modulepr["nAlloc stream begin run"],
-                moduleres["nAlloc global begin run diff"]
-                + moduleres["nAlloc stream begin run diff"],
+                moduleib.get("nAlloc global begin run", float("nan"))
+                + moduleib.get("nAlloc stream begin run", float("nan")),
+                modulepr.get("nAlloc global begin run", float("nan"))
+                + modulepr.get("nAlloc stream begin run", float("nan")),
+                moduleres.get("nAlloc global begin run diff", float("nan"))
+                + moduleres.get("nAlloc stream begin run diff", float("nan")),
             ),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
             % (
-                moduleib["nAlloc global begin luminosity block"]
-                + moduleib["nAlloc stream begin luminosity block"],
-                modulepr["nAlloc global begin luminosity block"]
-                + modulepr["nAlloc stream begin luminosity block"],
-                moduleres["nAlloc global begin luminosity block diff"]
-                + moduleres["nAlloc stream begin luminosity block diff"],
+                moduleib.get("nAlloc global begin luminosity block", float("nan")) 
+                + moduleib.get("nAlloc stream begin luminosity block", float("nan")),
+                modulepr.get("nAlloc global begin luminosity block", float("nan"))
+                + modulepr.get("nAlloc stream begin luminosity block", float("nan")),
+                moduleres.get("nAlloc global begin luminosity block diff", float("nan"))
+                + moduleres.get("nAlloc stream begin luminosity block diff", float("nan")),
             ),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-            % (moduleib["nAlloc event"], modulepr["nAlloc event"], moduleres["nAlloc event diff"]),
-            '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
-            % (
-                moduleib["nAlloc event setup"],
-                modulepr["nAlloc event setup"],
-                moduleres["nAlloc event setup diff"],
-            ),
+            % (moduleib.get("nAlloc event", float("nan")),
+                modulepr.get("nAlloc event", float("nan")),
+                moduleres.get("nAlloc event diff", float("nan"))),
             '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
             % (
-                moduleib["nAlloc event setup"]
-                + moduleib["nAlloc event"]
-                + moduleib["nAlloc construction"],
-                modulepr["nAlloc event setup"]
-                + modulepr["nAlloc event"]
-                + modulepr["nAlloc construction"],
-                moduleres["nAlloc event setup diff"]
-                + moduleres["nAlloc event diff"]
-                + moduleres["nAlloc construction diff"],
+                moduleib.get("nAlloc event setup", float("nan")),
+                modulepr.get("nAlloc event setup", float("nan")),
+                moduleres.get("nAlloc event setup diff", float("nan")),
             ),
-            "<td>%i<br>%i<br>%i</td>"
-            % (moduleib["transitions"], modulepr["transitions"], moduleres["transitions"]),
+            '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
+            % (
+                moduleib.get("nAlloc event setup", float("nan"))
+                + moduleib.get("nAlloc event", float("nan"))
+                + moduleib.get("nAlloc construction", float("nan")),
+                modulepr.get("nAlloc event setup", float("nan"))
+                + modulepr.get("nAlloc event", float("nan"))
+                + modulepr.get("nAlloc construction", float("nan")),
+                moduleres.get("nAlloc event setup diff", float("nan"))
+                + moduleres.get("nAlloc event diff", float("nan"))
+                + moduleres.get("nAlloc construction diff", float("nan")),
+            ),
+            '<td align="right">%0.f<br>%0.f<br>%0.f</td>'
+             % ( moduleib.get("transitions", float("nan")), modulepr.get("transitions", float("nan")), moduleres.get("transitions diff", float("nan"))),
             "</tr>",
         ]
 


### PR DESCRIPTION
Removed module zmumugammaAnalysis from IB data and module zmumugammaOldAnalysis from PR data and verified that missing data and diff data is show as nan in diff table.

<img width="1694" height="259" alt="image" src="https://github.com/user-attachments/assets/cd1b4611-ab12-46fc-a260-beabdb52a987" />
