### PR TITLE
Remove git clone of patatrack-scripts

### DIFF
--- a/pr_testing/run-pr-hlt-p2-timing.sh
+++ b/pr_testing/run-pr-hlt-p2-timing.sh
@@ -17,9 +17,7 @@ rm -rf $WORKSPACE/rundir/__pycache__
 
 pushd $WORKSPACE/rundir
   export LOCALRT=${WORKSPACE}/${CMSSW_VERSION}
-  git clone https://github.com/cms-externals/patatrack-scripts -b fix-imp --depth 1
   timeout $TIMEOUT bash -ex ${HLT_BASEDIR}/${HLT_P2_SCRIPT}/runHLTTiming.sh 2>&1 | tee -a ${WORKSPACE}/hlt-p2-timing.log
-  rm -rf patatrack-scripts
 popd
 
 # Upload results


### PR DESCRIPTION
Removed cloning of patatrack-scripts repository to streamline the script.