### PR TITLE
reduce verbosity of runHLTTiming in PR tests

### DIFF
--- a/pr_testing/run-pr-hlt-p2-timing.sh
+++ b/pr_testing/run-pr-hlt-p2-timing.sh
@@ -17,7 +17,7 @@ rm -rf $WORKSPACE/rundir/__pycache__
 
 pushd $WORKSPACE/rundir
   export LOCALRT=${WORKSPACE}/${CMSSW_VERSION}
-  timeout $TIMEOUT bash -ex ${HLT_BASEDIR}/${HLT_P2_SCRIPT}/runHLTTiming.sh 2>&1 | tee -a ${WORKSPACE}/hlt-p2-timing.log
+  timeout $TIMEOUT bash -e ${HLT_BASEDIR}/${HLT_P2_SCRIPT}/runHLTTiming.sh 2>&1 | tee -a ${WORKSPACE}/hlt-p2-timing.log
 popd
 
 # Upload results


### PR DESCRIPTION
Title says it all, to avoid having too much output in the log file (needed by https://github.com/cms-sw/cmssw/pull/50479)