### PR TITLE
Introducing PPD real-time dataset L2s for the pdmv category for Skim related PRs

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -66,6 +66,8 @@ CMSSW_L2 = {
     "antoniovagnerini": ["pdmv"],
     "DickyChant": ["pdmv"],
     "miquork": ["pdmv", "jetmet-pog"],
+    "kfjack": ["pdmv"],
+    "sroychow": ["pdmv"],
     "alja": ["visualization"],
     "civanch": ["simulation", "geometry", "fastsim"],
     "bsunanda": ["geometry"],


### PR DESCRIPTION
In order to reflect https://github.com/cms-sw/cms-bot/issues/2666 changes, this PR introduces a temporary solution that adds Real-time Dataset (RD) L2s, after discussing with @vlimant. 

Hope this helps to (but not limited to the need to) address two new PRs on skims for the upcoming data-taking: https://github.com/cms-sw/cmssw/pull/50763 and https://github.com/cms-sw/cmssw/pull/50747 