### PR TITLE
only add prefix option if not --maxmem_profile

### DIFF
--- a/run-ib-pr-matrix.sh
+++ b/run-ib-pr-matrix.sh
@@ -102,6 +102,7 @@ pushd "$WORKSPACE/matrix-results"
       *" --maxmem_profile "*|*" --prefix "*) MATRIX_ARGS="${MATRIX_ARGS} --command ' ${CMD_OPTS}'" ;;
       * ) MATRIX_ARGS="${MATRIX_ARGS} --command ' --prefix \"timeout --signal SIGTERM 9000\" ${CMD_OPTS}'"
     esac
+  fi
   if [ "X$CMS_SITE_OVERRIDE" == "X" ]; then
     CMS_SITE_OVERRIDE="local"
   fi

--- a/run-ib-pr-matrix.sh
+++ b/run-ib-pr-matrix.sh
@@ -99,7 +99,7 @@ pushd "$WORKSPACE/matrix-results"
 
   if [ "${CMD_OPTS}" != "" ] ; then
     case " ${CMD_OPTS} " in
-      *" --maxmem_profile "*) MATRIX_ARGS="${MATRIX_ARGS} --command ' ${CMD_OPTS}'" ;;
+      *" --maxmem_profile "*|*" --prefix "*) MATRIX_ARGS="${MATRIX_ARGS} --command ' ${CMD_OPTS}'" ;;
       * ) MATRIX_ARGS="${MATRIX_ARGS} --command ' --prefix \"timeout --signal SIGTERM 9000\" ${CMD_OPTS}'"
     esac
   if [ "X$CMS_SITE_OVERRIDE" == "X" ]; then

--- a/run-ib-pr-matrix.sh
+++ b/run-ib-pr-matrix.sh
@@ -100,7 +100,7 @@ pushd "$WORKSPACE/matrix-results"
   if [ "${CMD_OPTS}" != "" ] ; then
     case " ${CMD_OPTS} " in
       *" --maxmem_profile "*|*" --prefix "*) MATRIX_ARGS="${MATRIX_ARGS} --command ' ${CMD_OPTS}'" ;;
-      * ) MATRIX_ARGS="${MATRIX_ARGS} --command ' --prefix \"timeout --signal SIGTERM 9000\" ${CMD_OPTS}'"
+      * ) MATRIX_ARGS="${MATRIX_ARGS} --command ' --prefix \"timeout --signal SIGTERM 9000\" ${CMD_OPTS}'" ;;
     esac
   fi
   if [ "X$CMS_SITE_OVERRIDE" == "X" ]; then

--- a/run-ib-pr-matrix.sh
+++ b/run-ib-pr-matrix.sh
@@ -97,7 +97,11 @@ pushd "$WORKSPACE/matrix-results"
   fi
   rm -f $WORKSPACE/runTheMatrix.log
 
-  [ "${CMD_OPTS}" != "" ] && MATRIX_ARGS="${MATRIX_ARGS} --command ' ${CMD_OPTS}'"
+  if [ "${CMD_OPTS}" != "" ] ; then
+    case " ${CMD_OPTS} " in
+      *" --maxmem_profile "*) MATRIX_ARGS="${MATRIX_ARGS} --command ' ${CMD_OPTS}'" ;;
+      * ) MATRIX_ARGS="${MATRIX_ARGS} --command ' --prefix \"timeout --signal SIGTERM 9000\" ${CMD_OPTS}'"
+    esac
   if [ "X$CMS_SITE_OVERRIDE" == "X" ]; then
     CMS_SITE_OVERRIDE="local"
   fi


### PR DESCRIPTION
Only added timeput prefix if command option does not contain `--mammem-profile`. This is mostly true for baseline relvals