### PR TITLE
Old bot: fix parsing of test command (use empty-string instead of None)

### DIFF
--- a/process_pr.py
+++ b/process_pr.py
@@ -843,8 +843,8 @@ def parse_test_cmd(first_line: str) -> ParseResult:
         ),
     ]
 
-    t = None
-    prev_t = None
+    t = ""
+    prev_t = ""
 
     while tokens:
         prev_t = t


### PR DESCRIPTION
* Command: `test full cmssw`
* Exception:
```
Traceback (most recent call last):
  File "/data/sdt/cms-bot/process-pull-request.py", line 102, in <module>
    process_pr(repo_config, gh, repo, repo.get_issue(prId), opts.dryRun, force=opts.force)
  File "/data/sdt/cms-bot/process_pr.py", line 1882, in process_pr
    ok, v2, v3, v4, v5 = check_test_cmd(first_line, repository, global_test_params)
  File "/data/sdt/cms-bot/process_pr.py", line 888, in check_test_cmd
    res = parse_test_cmd(first_line)
  File "/data/sdt/cms-bot/process_pr.py", line 859, in parse_test_cmd
    if p.prev_keyword and not p.prev_keyword.fullmatch(prev_t):
TypeError: expected string or bytes-like object
```

Will forward-port to new bot.
