### PR TITLE
Release build: Use cms-talk link to create new topoic

### DIFF
--- a/process-build-release-request.py
+++ b/process-build-release-request.py
@@ -145,9 +145,8 @@ ANNOUNCEMENT_TEMPLATE = (
     "cms-bot"
 )
 
-HN_REL_ANNOUNCE_EMAIL = "hn-cms-relAnnounce@cern.ch"
 ANNOUNCEMENT_EMAIL_SUBJECT = "{rel_type} {is_patch}Release {rel_name} Now Available "
-MAILTO_TEMPLATE = '<a href="mailto:{destinatary}?subject={sub}&amp;body={body}">here</a>'
+CMSTALK_TEMPLATE = '<a href="https://cms-talk.web.cern.ch/new-topic?category_id=157&amp;title={sub}&amp;body={body}">here</a>'
 
 # -------------------------------------------------------------------------------
 # Statuses
@@ -842,7 +841,7 @@ def generate_announcement_link(announcement, release_name):
     )
 
     msg = quote(announcement)
-    link = MAILTO_TEMPLATE.format(destinatary=HN_REL_ANNOUNCE_EMAIL, sub=subject, body=msg)
+    link = CMSTALK_TEMPLATE.format(sub=subject, body=msg)
     return link
 
 


### PR DESCRIPTION
@cms-sw/orp-l2 this PR changes the release announcement link from old HN to cms-talk. As an example , I changes the link at https://github.com/cms-sw/cmssw/issues/50836#issuecomment-4361638610 to create new topic for release announcement

fixes #2483