### PR TITLE
Testing 4 GPU relvals in parallel

### DIFF
--- a/run-ib-pr-matrix.sh
+++ b/run-ib-pr-matrix.sh
@@ -94,7 +94,7 @@ pushd "$WORKSPACE/matrix-results"
   if is_in_array "${TEST_FLAVOR}" "${ALL_GPU_TYPES[@]}" ; then
     NJOBS=$(grep 'GPU no' $WORKSPACE/runTheMatrix.log | wc -l)
     if [ $NJOBS -eq 0 ] ; then NJOBS=1 ; fi
-    [ $NJOBS -lt 2 ] && NJOBS=2
+    [ $NJOBS -lt 4 ] && NJOBS=4
   fi
   rm -f $WORKSPACE/runTheMatrix.log
 

--- a/run-ib-pr-matrix.sh
+++ b/run-ib-pr-matrix.sh
@@ -94,6 +94,7 @@ pushd "$WORKSPACE/matrix-results"
   if is_in_array "${TEST_FLAVOR}" "${ALL_GPU_TYPES[@]}" ; then
     NJOBS=$(grep 'GPU no' $WORKSPACE/runTheMatrix.log | wc -l)
     if [ $NJOBS -eq 0 ] ; then NJOBS=1 ; fi
+    [ $NJOBS -lt 2 ] && NJOBS=2
   fi
   rm -f $WORKSPACE/runTheMatrix.log
 


### PR DESCRIPTION
By default we run N jobs in parallel for GPU relvals (where N is number of GPU available mostly 1). This PR s to test if we can run multiple relvals in parallel