### PR TITLE
Update forward porting for ROOT 6.40

### DIFF
--- a/forward_ports_map.py
+++ b/forward_ports_map.py
@@ -122,7 +122,7 @@ GIT_REPO_FWPORTS["cmssw"]["CMSSW_17_0_X"] = []
 GIT_REPO_FWPORTS["cmssw"]["CMSSW_17_0_X"].append("CMSSW_17_0_EVOLUTION_X")
 GIT_REPO_FWPORTS["cmsdist"]["IB/CMSSW_17_0_X/master"] = []
 GIT_REPO_FWPORTS["cmsdist"]["IB/CMSSW_17_0_X/master"].append("IB/CMSSW_17_0_X/rootmaster")
-GIT_REPO_FWPORTS["cmsdist"]["IB/CMSSW_17_0_X/master"].append("IB/CMSSW_17_0_X/root638")
+GIT_REPO_FWPORTS["cmsdist"]["IB/CMSSW_17_0_X/master"].append("IB/CMSSW_17_0_X/root640")
 GIT_REPO_FWPORTS["cmsdist"]["IB/CMSSW_17_0_X/master"].append("IB/CMSSW_17_0_X/fp")
 GIT_REPO_FWPORTS["cmsdist"]["IB/CMSSW_17_0_X/master"].append("IB/CMSSW_17_0_X/rocm")
 GIT_REPO_FWPORTS["cmsdist"]["IB/CMSSW_17_0_X/master"].append("IB/CMSSW_17_0_X/clang")


### PR DESCRIPTION
FYI @akritkbehera , I think when you created cmsdist root640 branch then you missed to update the forward porting map. This PR fixes this and should fix the failing RelVals in ROOT 6.40 IBs