### PR TITLE
[Do not merge] Make EVOLUTION_X setup the default for testing purposes

### DIFF
--- a/cmssw-pr-test-config
+++ b/cmssw-pr-test-config
@@ -23,6 +23,7 @@ if [ "${IS_EVOLUTION}" = "0" ]; then
   # COMMENT: excluded workflows read old format file that is not supported in EVOLUTION_X branch
   PR_TEST_MATRIX_EXTRAS=1306.0,101.0,9.0
 fi
+PR_TEST_MATRIX_EXTRAS=1306.0,101.0,9.0
 
 if [ "$CMSSW_VER" -ge 1601 ] ; then
   PR_TEST_MATRIX_EXTRAS_GPU=18634.402,18634.403,18634.406,18634.412,18634.422,18634.423 #2026 Wfs

--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -99,6 +99,7 @@ DAS_NON_CONSISTENT_WFS_FILE=wf_non_consistent_das.txt
 MAPPING_FILE=wf_mapping.txt
 ERRORS_FILE=wf_errors.txt
 [ $(echo ${RELEASE_FORMAT} | grep 'EVOLUTION_X'   | wc -l) -gt 0 ] && RUN_JR_COMP=false
+RUN_JR_COMP=false
 
 #Make sure Release baseline has been deployed
 echo -n "Waiting for baseline .."


### PR DESCRIPTION
This PR is to allow testing of the CMSSW PRs that integration the changes from the `EVOLUTION_X` branch into the `master` branch that will be tested using 17_0_X IBs. 