### PR TITLE
override docker image date to avoid latest buggy installed image

### DIFF
--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -86,8 +86,9 @@ if [ "X$DOCKER_IMG" != X -a "X$RUN_NATIVE" = "X" ]; then
       export DOCKER_IMG="${DOCKER_IMG}:${IMG_ARCH}"
     fi
   fi
-  case $IMG_ARCH in
-    aarch64|x86_64 ) DOCKER_IMG="${DOCKER_IMG}-d20260506" ;;
+  case $DOCKER_IMG in
+    cmssw/*:aarch64) DOCKER_IMG="${DOCKER_IMG}-d20260506" ;;
+    cmssw/*:x86_64) DOCKER_IMG="${DOCKER_IMG}-d20260506" ;;
     * )
   esac
   BUILD_BASEDIR=$(dirname $WORKSPACE)

--- a/docker_launcher.sh
+++ b/docker_launcher.sh
@@ -86,6 +86,10 @@ if [ "X$DOCKER_IMG" != X -a "X$RUN_NATIVE" = "X" ]; then
       export DOCKER_IMG="${DOCKER_IMG}:${IMG_ARCH}"
     fi
   fi
+  case $IMG_ARCH in
+    aarch64|x86_64 ) DOCKER_IMG="${DOCKER_IMG}-d20260506" ;;
+    * )
+  esac
   BUILD_BASEDIR=$(dirname $WORKSPACE)
   export KRB5CCNAME=$(klist | grep 'Ticket cache: FILE:' | sed 's|.* ||')
   MOUNT_POINTS="/cvmfs,/tmp,$(echo $WORKSPACE | cut -d/ -f1,2),/var/run/user,/run/user,${EXTRA_MOUNTS}"


### PR DESCRIPTION
the latest images deployed under /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el8:aarch64 and /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el8:x86_64 are broken as looks like during the unpacking the /.singularity directory was not created. This breaks NVIDIA env as aptainer fails to link system nvidia drivers in to /singularity/libs directory.

For now we force use the old images for IB/sPR tests. We shall revert this change once imgaes are fixed on unpacked cvmfs repostiory