### PR TITLE
Update PR test workflows for 20_0_X

### DIFF
--- a/cmssw-pr-test-config
+++ b/cmssw-pr-test-config
@@ -24,7 +24,12 @@ if [ "${IS_EVOLUTION}" = "0" ]; then
   PR_TEST_MATRIX_EXTRAS=1306.0,101.0,9.0
 fi
 
-if [ "$CMSSW_VER" -ge 1601 ] ; then
+if [ "$CMSSW_VER" -ge 2000 ] ; then
+  # COMMENT: excluded workflows read non-RAW files produced with CMSSW < 20_0_X
+  PR_TEST_MATRIX_EXTRAS=1306.0,101.0,9.0
+  # COMMENT: use no-pileup workflow until first 20_X_Y MinBias files become available
+  PR_TEST_MATRIX_EXTRAS_GPU=34434.402,34434.403,34434.404,34434.712,34434.713,34634.7503,34634.751 #Phase2 Wfs (D121)
+elif [ "$CMSSW_VER" -ge 1601 ] ; then
   PR_TEST_MATRIX_EXTRAS_GPU=18634.402,18634.403,18634.406,18634.412,18634.422,18634.423 #2026 Wfs
   PR_TEST_MATRIX_EXTRAS_GPU=${PR_TEST_MATRIX_EXTRAS_GPU},34634.402,34634.403,34634.404,34634.712,34634.713,34634.7503,34634.751 #Phase2 Wfs (D121)
 elif [ "$CMSSW_VER" -ge 1600 ] ; then
@@ -49,7 +54,10 @@ if [ X"$PR_TEST_MATRIX_EXTRAS_GPU" != X"" ]; then
   done
 fi
 
-if [ "$CMSSW_VER" -ge 1601 ] ; then
+if [ "$CMSSW_VER" -ge 2000 ] ; then
+  # COMMENT: use no-pileup workflow until first 20_X_Y MinBias files become available
+  PR_TEST_MATRIX_EXTRAS_PROFILING=34434.21
+elif [ "$CMSSW_VER" -ge 1601 ] ; then
   PR_TEST_MATRIX_EXTRAS_PROFILING=34634.21,18634.21
 elif [ "$CMSSW_VER" -ge 1600 ] ; then
   PR_TEST_MATRIX_EXTRAS_PROFILING=34634.21,18634.21


### PR DESCRIPTION
This PR updates the PR test workflow settings for 20_0_X that will break the backwards compatibility for non-RAW files. This means that workflows reading non-RAW files produced with <= 17_0_X will likely fail, so this PR disables those.

The profiling tests use workflows with pileup, so until new MinBias files become available, the best we can do is to use no-pileup workflow. Given the 20_0_X focus on phase 2, I think it is not worth of running Run 3 workflow for profiling by default there.

The GPU workflows have similar problem. We could use no-pileup workflows there too, but I want to confirm that explicitly first.

I _believe_ this PR can be merged already before the 20_0_X is opened.

Resolves https://github.com/cms-sw/framework-team/issues/2229