### PR TITLE
`run-pr-hlt-p2-timing`: add CPU memory comparisons and HTML summary page

### DIFF
--- a/pr_testing/run-pr-hlt-p2-timing.sh
+++ b/pr_testing/run-pr-hlt-p2-timing.sh
@@ -61,17 +61,34 @@ if which compareMemoryProfiles.py >/dev/null 2>&1; then
 
     # first check if the baseline job succeeded
     if grep -q "passed" $WORKSPACE/baseline-hlt-p2-timing/status.txt; then
-	  # run the comparison job for the HLT timing menu
+	  # run the GPU comparison job for the HLT timing menu
 	  compareMemoryProfiles.py $WORKSPACE/baseline-hlt-p2-timing/gpu_memory_ph2_hlt.csv $WORKSPACE/rundir/logs.Phase2_L1P2GT_HLT/gpu_memory.csv \
 	    --label1 ${COMPARISON_RELEASE} --label2 "${PULL_REQUEST}"  --cms-label "cmssw integration" \
 	    --no-show --gpu --output hlt_memory_comparison || ERR=1
-	  # run the comparison job for the NGT menu
+	  # run the GPU comparison job for the NGT menu
 	  compareMemoryProfiles.py $WORKSPACE/baseline-hlt-p2-timing/gpu_memory_ph2_ngt.csv $WORKSPACE/rundir/logs.NGTScouting_L1P2GT_HLT/gpu_memory.csv \
 	    --label1 ${COMPARISON_RELEASE} --label2 "${PULL_REQUEST}"  --cms-label "cmssw integration" \
 	    --no-show --gpu --output ngt_memory_comparison  || ERR=1
+	  # run the CPU comparison job for the HLT timing menu
+	  compareMemoryProfiles.py $WORKSPACE/baseline-hlt-p2-timing/cpu_memory_ph2_hlt.csv $WORKSPACE/rundir/logs.Phase2_L1P2GT_HLT/cpu_memory.csv \
+	    --label1 ${COMPARISON_RELEASE} --label2 "${PULL_REQUEST}"  --cms-label "cmssw integration" \
+	    --no-show --output hlt_memory_comparison || ERR=1
+	  # run the CPU comparison job for the NGT menu
+	  compareMemoryProfiles.py $WORKSPACE/baseline-hlt-p2-timing/cpu_memory_ph2_ngt.csv $WORKSPACE/rundir/logs.NGTScouting_L1P2GT_HLT/cpu_memory.csv \
+	    --label1 ${COMPARISON_RELEASE} --label2 "${PULL_REQUEST}"  --cms-label "cmssw integration" \
+	    --no-show --output ngt_memory_comparison  || ERR=1
+	  # run the CPU comparison job for the HL timing menu (on CPU)
+	  compareMemoryProfiles.py $WORKSPACE/baseline-hlt-p2-timing/cpu_memory_ph2_hlt_onCPU.csv $WORKSPACE/rundir/logs.Phase2_L1P2GT_HLT_OnCPU/cpu_memory.csv \
+	    --label1 ${COMPARISON_RELEASE} --label2 "${PULL_REQUEST}"  --cms-label "cmssw integration" \
+	    --no-show --output hltOnCPU_memory_comparison  || ERR=1
+
 	  # copy back the png figures on the output folder
 	  cp gpu_hlt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
 	  cp gpu_ngt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
+
+	  cp cpu_hlt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
+	  cp cpu_ngt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
+	  cp cpu_hltOnCPU_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
     else
 	  echo "Baseline job didn't pass, not executing any comparison"
     fi

--- a/pr_testing/run-pr-hlt-p2-timing.sh
+++ b/pr_testing/run-pr-hlt-p2-timing.sh
@@ -127,7 +127,7 @@ if [ $missing -eq 0 ]; then
   echo "HLT_P2_TIMING;SUCCESS,HLT Phase 2 timing Test,See Chart,${CHART_URL}" >> ${RESULTS_DIR}/hlt-p2-timing.txt
   echo "HLT_P2_TIMING_LOG;OK,HLT Phase 2 timing Test Log,See Logs,hlt-p2-timing.log" >> ${RESULTS_DIR}/hlt-p2-timing.txt
   if [ "$CMSSW_VERSION_NUMBER" -ge 1700 ]; then
-      echo "HLT_P2_TIMING_CSV;OK,HLT Phase 2 hardware usage,See Logs,hlt-p2-timing" >> ${RESULTS_DIR}/hlt-p2-timing.txt
+      echo "HLT_P2_TIMING_CSV;OK,HLT Phase 2 hardware usage,See summary,hlt-p2-timing" >> ${RESULTS_DIR}/hlt-p2-timing.txt
   fi
   echo -e "**HLT P2 Timing**: [chart](${CHART_URL})" > ${RESULTS_DIR}/11-hlt-p2-timing-report.res
 
@@ -139,5 +139,105 @@ else
   echo "HLTP2Timing" > ${RESULTS_DIR}/11-hlt-p2-timing-failed.res
   mark_commit_status_all_prs 'hlt-p2-timing' 'error' -u "${BUILD_URL}" -d "HLT Phase2 timing script failed"
 fi
+
+# Generate summary index.html
+BUILD_TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
+
+# Decide per-menu status based on presence of required output files
+HLT_STATUS="&#10003; ok";       HLT_STATUS_CLASS="ok"
+HLT_ONCPU_STATUS="&#10003; ok"; HLT_ONCPU_STATUS_CLASS="ok"
+NGT_STATUS="&#10003; ok";       NGT_STATUS_CLASS="ok"
+[ ! -f "$WORKSPACE/json_upload/Phase2Timing_resources.json" ]       && HLT_STATUS="&#10007; missing"       && HLT_STATUS_CLASS="err"
+[ ! -f "$WORKSPACE/json_upload/Phase2Timing_resources_OnCPU.json" ] && HLT_ONCPU_STATUS="&#10007; missing" && HLT_ONCPU_STATUS_CLASS="err"
+[ ! -f "$WORKSPACE/json_upload/Phase2Timing_resources_NGT.json" ]   && NGT_STATUS="&#10007; missing"       && NGT_STATUS_CLASS="err"
+
+# Build optional CSV section for CMSSW >= 17
+CSV_SECTION=""
+if [ "$CMSSW_VERSION_NUMBER" -ge 1700 ]; then
+  CSV_SECTION='<div class="section"><div class="section-title">Hardware usage CSVs</div><div class="links">
+    <a href="cpu_memory_ph2_hlt.csv">cpu_memory_ph2_hlt.csv</a>
+    <a href="gpu_memory_ph2_hlt.csv">gpu_memory_ph2_hlt.csv</a>
+    <a href="gpu_usage_ph2_hlt.csv">gpu_usage_ph2_hlt.csv</a>
+    <a href="cpu_memory_ph2_hlt_onCPU.csv">cpu_memory_ph2_hlt_onCPU.csv</a>
+    <a href="cpu_memory_ph2_ngt.csv">cpu_memory_ph2_ngt.csv</a>
+    <a href="gpu_memory_ph2_ngt.csv">gpu_memory_ph2_ngt.csv</a>
+    <a href="gpu_usage_ph2_ngt.csv">gpu_usage_ph2_ngt.csv</a>
+  </div></div>'
+fi
+
+cat > $JENKINS_UPLOAD_DIR/hlt-p2-timing/index.html << EOF
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>HLT Phase-2 Timing &mdash; ${CMSSW_VERSION} #${BUILD_NUMBER}</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,sans-serif;background:#f5f5f5;color:#222;padding:2rem;max-width:1100px;margin:0 auto}
+h1{font-size:1.4rem;font-weight:500;margin-bottom:.25rem}
+.meta{font-size:.85rem;color:#666;margin-bottom:2rem}
+.status-bar{display:flex;gap:2rem;background:#fff;border:1px solid #e0e0e0;border-radius:8px;padding:1rem 1.5rem;margin-bottom:2rem;flex-wrap:wrap}
+.stat{display:flex;flex-direction:column;gap:2px}
+.stat-label{font-size:.75rem;color:#888}
+.stat-value{font-size:1rem;font-weight:500}
+.ok{color:#2a7a2a}.err{color:#c0392b}
+.section{margin-bottom:2.5rem}
+.section-title{font-size:1rem;font-weight:500;color:#444;margin-bottom:1rem;padding-bottom:.5rem;border-bottom:1px solid #ddd}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:1rem}
+.card{background:#fff;border:1px solid #e0e0e0;border-radius:8px;overflow:hidden}
+.card a{display:block;text-decoration:none;color:inherit}
+.card img{width:100%;display:block;background:#eee;transition:opacity .2s}
+.card:hover img{opacity:.88}
+.placeholder{width:100%;height:140px;background:#f0f0f0;display:flex;align-items:center;justify-content:center;font-size:.8rem;color:#aaa}
+.card-body{padding:.75rem 1rem}
+.card-title{font-size:.9rem;font-weight:500;margin-bottom:.25rem}
+.card-sub{font-size:.8rem;color:#888}
+.badge{display:inline-block;font-size:.7rem;padding:2px 7px;border-radius:4px;margin-left:.5rem;font-weight:500;vertical-align:middle}
+.badge-gpu{background:#e8eeff;color:#2a47b0}
+.badge-cpu{background:#eaf5ea;color:#2a7a2a}
+.links{display:flex;flex-direction:column;gap:.5rem;font-size:.9rem}
+.links a{color:#1a56db;text-decoration:none}
+.links a:hover{text-decoration:underline}
+</style>
+</head>
+<body>
+<h1>HLT Phase-2 Timing &mdash; Summary</h1>
+<p class="meta">Build <strong>${BUILD_NUMBER}</strong> &nbsp;&middot;&nbsp; <strong>${CMSSW_VERSION}</strong> &nbsp;&middot;&nbsp; Architecture: <strong>${ARCHITECTURE}</strong> &nbsp;&middot;&nbsp; ${BUILD_TIMESTAMP}</p>
+<div class="status-bar">
+  <div class="stat"><span class="stat-label">Overall</span><span class="stat-value ${ERR:+err}${ERR:-ok}">$([ $ERR -eq 0 ] && echo '&#10003; passed' || echo '&#10007; failed')</span></div>
+  <div class="stat"><span class="stat-label">HLT menu</span><span class="stat-value ${HLT_STATUS_CLASS}">${HLT_STATUS}</span></div>
+  <div class="stat"><span class="stat-label">HLT on CPU</span><span class="stat-value ${HLT_ONCPU_STATUS_CLASS}">${HLT_ONCPU_STATUS}</span></div>
+  <div class="stat"><span class="stat-label">NGT Scouting</span><span class="stat-value ${NGT_STATUS_CLASS}">${NGT_STATUS}</span></div>
+  <div class="stat"><span class="stat-label">Baseline</span><span class="stat-value">${COMPARISON_RELEASE}</span></div>
+</div>
+<div class="section">
+  <div class="section-title">Memory comparisons &mdash; HLT Phase-2 menu</div>
+  <div class="grid">
+    <div class="card"><a href="gpu_hlt_memory_comparison.png"><img src="gpu_hlt_memory_comparison.png" alt="GPU memory - HLT menu" onerror="this.outerHTML='<div class=\'placeholder\'>gpu_hlt_memory_comparison.png not found</div>'"></a><div class="card-body"><div class="card-title">GPU memory <span class="badge badge-gpu">GPU</span></div><div class="card-sub">Phase2_L1P2GT_HLT</div></div></div>
+    <div class="card"><a href="cpu_hlt_memory_comparison.png"><img src="cpu_hlt_memory_comparison.png" alt="CPU memory - HLT menu" onerror="this.outerHTML='<div class=\'placeholder\'>cpu_hlt_memory_comparison.png not found</div>'"></a><div class="card-body"><div class="card-title">CPU memory <span class="badge badge-cpu">CPU</span></div><div class="card-sub">Phase2_L1P2GT_HLT</div></div></div>
+    <div class="card"><a href="cpu_hltOnCPU_memory_comparison.png"><img src="cpu_hltOnCPU_memory_comparison.png" alt="CPU memory - HLT on CPU" onerror="this.outerHTML='<div class=\'placeholder\'>cpu_hltOnCPU_memory_comparison.png not found</div>'"></a><div class="card-body"><div class="card-title">CPU memory (on CPU run) <span class="badge badge-cpu">CPU</span></div><div class="card-sub">Phase2_L1P2GT_HLT_OnCPU</div></div></div>
+  </div>
+</div>
+<div class="section">
+  <div class="section-title">Memory comparisons &mdash; NGT Scouting menu</div>
+  <div class="grid">
+    <div class="card"><a href="gpu_ngt_memory_comparison.png"><img src="gpu_ngt_memory_comparison.png" alt="GPU memory - NGT Scouting" onerror="this.outerHTML='<div class=\'placeholder\'>gpu_ngt_memory_comparison.png not found</div>'"></a><div class="card-body"><div class="card-title">GPU memory <span class="badge badge-gpu">GPU</span></div><div class="card-sub">NGTScouting_L1P2GT_HLT</div></div></div>
+    <div class="card"><a href="cpu_ngt_memory_comparison.png"><img src="cpu_ngt_memory_comparison.png" alt="CPU memory - NGT Scouting" onerror="this.outerHTML='<div class=\'placeholder\'>cpu_ngt_memory_comparison.png not found</div>'"></a><div class="card-body"><div class="card-title">CPU memory <span class="badge badge-cpu">CPU</span></div><div class="card-sub">NGTScouting_L1P2GT_HLT</div></div></div>
+  </div>
+</div>
+${CSV_SECTION}
+<div class="section">
+  <div class="section-title">Links</div>
+  <div class="links">
+    <a href="${CHART_URL}">&#9651; Pie chart &mdash; HLT Phase-2 timing (time_thread)</a>
+    <a href="../hlt-p2-timing.log">&#128196; Full timing log</a>
+    <a href="${BUILD_URL}">&#128296; Jenkins build</a>
+  </div>
+</div>
+</body>
+</html>
+EOF
+
 rm -rf $WORKSPACE/json_upload $WORKSPACE/rundir
 prepare_upload_results


### PR DESCRIPTION
This is a quick follow-up to https://github.com/cms-sw/cms-bot/pull/2761. 
Extends the HLT Phase-2 timing PR test with these additions:

- CPU memory profile comparisons for the HLT menu, HLT-on-CPU, and NGT Scouting menus (previously only GPU comparisons were run), with the resulting PNGs copied to the upload directory.
- An `index.html` summary page generated at the end of the job, showing all comparison plots in a card layout with per-menu status indicators, links to the timing chart, log, and Jenkins build, and an optional CSV section for CMSSW ≥ 17.
