### PR TITLE
Increase MaxMemoryPreload error threshold to 30 MB for >= 17_0_X

### DIFF
--- a/comparisons/maxmem_threshold.py
+++ b/comparisons/maxmem_threshold.py
@@ -11,4 +11,4 @@ if CMSSW_VERSION != "":
     minor = int(parts[2]) if parts[2].isdigit() else 0
     CMSSW_VER = major * 100 + minor * 10
     if CMSSW_VER >= 1700:
-        ERROR_THRESHOLD = 10.0
+        ERROR_THRESHOLD = 30.0


### PR DESCRIPTION
Following https://github.com/cms-sw/cmssw/issues/46966#issuecomment-4565013883

One-two workflows show random variations up to 25.4 MB. It is frequent enough to be annoying, so let's silence the warnings until the cause is understood.

Resolves https://github.com/cms-sw/framework-team/issues/2256