### PR TITLE
re-enabled nvidia t4 for GPU tests

### DIFF
--- a/gpu_flavors.txt
+++ b/gpu_flavors.txt
@@ -1,4 +1,5 @@
 nvidia_h100
 nvidia_l40s
+nvidia_t4
 amd_w7900
 amd_mi300x

--- a/gpu_flavors_ondemand.txt
+++ b/gpu_flavors_ondemand.txt
@@ -1,2 +1,1 @@
-nvidia_t4
 nvidia_l4


### PR DESCRIPTION
As T4 GPU host is not used by HLT P2 timing jobs so we can re-enable for PR tests. HLT P2 timing IBs/PRs jobs now use host with L4 GPU