### PR TITLE
Fixing trigger results in el9 [issue #2795]

### DIFF
--- a/compareTriggerResults.py
+++ b/compareTriggerResults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Script to compare the content of edm::TriggerResults collections in EDM files across multiple workflows
  - CMSSW dependencies: edmDumpEventContent, hltDiff
@@ -152,6 +152,9 @@ def compareTriggerResults(**kwargs):
         if verbosity >= 0:
             WARNING(
                 "compareTriggerResults -- found zero inputs to be compared (no outputs produced)"
+            )
+            print(
+                "SUMMARY TriggerResults: WARNING - found zero edm::TriggerResults collections to compare (no outputs produced)"
             )
         return -1
 

--- a/compareTriggerResults.py
+++ b/compareTriggerResults.py
@@ -20,14 +20,14 @@ def WARNING(message):
 
 
 def get_output(cmds, permissive=False):
-    prc = subprocess.Popen(cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    prc = subprocess.Popen(cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     out, err = prc.communicate()
     if (not permissive) and prc.returncode:
         KILL(
             "get_output -- shell command failed (execute command to reproduce the error):\n"
             + " " * 14
             + "> "
-            + cmd
+            + " ".join(cmds)
         )
     return (out, err)
 

--- a/compareTriggerResultsSummary.py
+++ b/compareTriggerResultsSummary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Script to summarise the outputs of compareTriggerResults
 (i.e. the outputs of hltDiff in .json format)
@@ -75,6 +75,9 @@ def compareTriggerResultsSummary(**kwargs):
         if verbosity >= 0:
             WARNING(
                 "compareTriggerResultsSummary -- found zero inputs to be compared (no outputs produced)"
+            )
+            print(
+                "SUMMARY TriggerResults: WARNING - found zero valid hltDiff JSON outputs to summarise (no outputs produced)"
             )
         return -1
 

--- a/pr_testing/run-pr-comparisons
+++ b/pr_testing/run-pr-comparisons
@@ -378,7 +378,7 @@ if [ "X$RUN_TR_COMP" = Xtrue ]; then
     wait_dqm_comp 0.5
     WF_DIR=`echo ${WF} | cut -d "/" -f1`
     echo "Running: edm::TriggerResults ${WF_DIR}"
-    (${CMS_BOT_DIR}/compareTriggerResults.py -r ${WORKSPACE}/data/${COMPARISON_RELEASE} -t ${WORKSPACE}/data/PR-${PR_NUM} \
+    (${CMSBOT_PYTHON_CMD} ${CMS_BOT_DIR}/compareTriggerResults.py -r ${WORKSPACE}/data/${COMPARISON_RELEASE} -t ${WORKSPACE}/data/PR-${PR_NUM} \
       -f "*/${WF_DIR}/step*.root" -o ${WORKSPACE}/upload/triggerResults > ${WORKSPACE}/upload/triggerResults/${WF_DIR}.log 2>&1 || true) &
   done
 fi
@@ -562,7 +562,7 @@ wait || true
 
 if [ "X$RUN_TR_COMP" = Xtrue ]; then
   echo "[`date`] Done comparisons of edm::TriggerResults"
-  ${CMS_BOT_DIR}/compareTriggerResultsSummary.py -i ${WORKSPACE}/upload/triggerResults -f "*/*.json" -o ${WORKSPACE}/upload/triggerResults/index.html -F html > ${WORKSPACE}/upload/triggerResults.log 2>&1 || true
+  ${CMSBOT_PYTHON_CMD} ${CMS_BOT_DIR}/compareTriggerResultsSummary.py -i ${WORKSPACE}/upload/triggerResults -f "*/*.json" -o ${WORKSPACE}/upload/triggerResults/index.html -F html > ${WORKSPACE}/upload/triggerResults.log 2>&1 || true
   echo "[`date`] Summary of TriggerResults comparisons saved in ${WORKSPACE}/upload/triggerResults.log"
   echo "HLT_TRIGGER_COMPARISON${TEST_FLAVOR_STR};OK,HLT Trigger ${UC_TEST_FLAVOR} comparison,See results,/SDT/jenkins-artifacts/${COMP_UPLOAD_DIR}/triggerResults/" >> ${RESULTS_FILE}
   if [ -f ${JR_COMP_DIR}/qaResultsSummary.log ]; then


### PR DESCRIPTION
## Summary
- Fix `compareTriggerResults.py` / `compareTriggerResultsSummary.py` to use
  `#!/usr/bin/env python3` instead of the old `#!/usr/bin/env python` shebang,
  and wrap both invocations in `pr_testing/run-pr-comparisons` with
  `${CMSBOT_PYTHON_CMD}`, matching every other Python call in that script.
- On el9 (CMSSW_20_1_X) there is no bare `python` binary, so these two
  scripts previously failed immediately with
  `env: 'python': No such file or directory`, and the failure was swallowed
  silently (`|| true`), causing the entire `edm::TriggerResults` comparison
  section to disappear from PR bot comments with no visible error.
- Added a `SUMMARY TriggerResults: WARNING ...` print on the existing
  "zero inputs" early-return path in both scripts, so any future cause of
  "comparison produced nothing" is surfaced in the PR comment instead of
  vanishing silently.

Fixes cms-sw/cms-bot#2795.

## Test plan
- [x] `python3 -m py_compile compareTriggerResults.py compareTriggerResultsSummary.py`
- [x] `bash -n pr_testing/run-pr-comparisons`
- [x] Ran `compareTriggerResultsSummary.py` against an empty input directory and confirmed the new `SUMMARY TriggerResults: WARNING ...` line is printed
- [ ] Confirm `edm::TriggerResults` comparisons reappear in a real CMSSW_20_1_X (el9) PR-bot comment