### PR TITLE
`run-pr-hlt-p2-timing`: support plotting resource usage when baseline failed

### DIFF
--- a/pr_testing/run-pr-hlt-p2-timing.sh
+++ b/pr_testing/run-pr-hlt-p2-timing.sh
@@ -59,39 +59,50 @@ if which compareMemoryProfiles.py >/dev/null 2>&1; then
     # get the csv files for the baseline
     get_jenkins_artifacts hlt-p2-timing/${COMPARISON_RELEASE}/${COMPARISON_ARCH}/ $WORKSPACE/baseline-hlt-p2-timing/
 
-    # first check if the baseline job succeeded
-    if grep -q "passed" $WORKSPACE/baseline-hlt-p2-timing/status.txt; then
-	  # run the GPU comparison job for the HLT timing menu
-	  compareMemoryProfiles.py $WORKSPACE/baseline-hlt-p2-timing/gpu_memory_ph2_hlt.csv $WORKSPACE/rundir/logs.Phase2_L1P2GT_HLT/gpu_memory.csv \
-	    --label1 ${COMPARISON_RELEASE} --label2 "${PULL_REQUEST}"  --cms-label "cmssw integration" \
-	    --no-show --gpu --output hlt_memory_comparison || ERR=1
-	  # run the GPU comparison job for the NGT menu
-	  compareMemoryProfiles.py $WORKSPACE/baseline-hlt-p2-timing/gpu_memory_ph2_ngt.csv $WORKSPACE/rundir/logs.NGTScouting_L1P2GT_HLT/gpu_memory.csv \
-	    --label1 ${COMPARISON_RELEASE} --label2 "${PULL_REQUEST}"  --cms-label "cmssw integration" \
-	    --no-show --gpu --output ngt_memory_comparison  || ERR=1
-	  # run the CPU comparison job for the HLT timing menu
-	  compareMemoryProfiles.py $WORKSPACE/baseline-hlt-p2-timing/cpu_memory_ph2_hlt.csv $WORKSPACE/rundir/logs.Phase2_L1P2GT_HLT/cpu_memory.csv \
-	    --label1 ${COMPARISON_RELEASE} --label2 "${PULL_REQUEST}"  --cms-label "cmssw integration" \
-	    --no-show --output hlt_memory_comparison || ERR=1
-	  # run the CPU comparison job for the NGT menu
-	  compareMemoryProfiles.py $WORKSPACE/baseline-hlt-p2-timing/cpu_memory_ph2_ngt.csv $WORKSPACE/rundir/logs.NGTScouting_L1P2GT_HLT/cpu_memory.csv \
-	    --label1 ${COMPARISON_RELEASE} --label2 "${PULL_REQUEST}"  --cms-label "cmssw integration" \
-	    --no-show --output ngt_memory_comparison  || ERR=1
-	  # run the CPU comparison job for the HL timing menu (on CPU)
-	  compareMemoryProfiles.py $WORKSPACE/baseline-hlt-p2-timing/cpu_memory_ph2_hlt_onCPU.csv $WORKSPACE/rundir/logs.Phase2_L1P2GT_HLT_OnCPU/cpu_memory.csv \
-	    --label1 ${COMPARISON_RELEASE} --label2 "${PULL_REQUEST}"  --cms-label "cmssw integration" \
-	    --no-show --output hltOnCPU_memory_comparison  || ERR=1
-
-	  # copy back the png figures on the output folder
-	  cp gpu_hlt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
-	  cp gpu_ngt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
-
-	  cp cpu_hlt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
-	  cp cpu_ngt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
-	  cp cpu_hltOnCPU_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
+    BASELINE_DIR=$WORKSPACE/baseline-hlt-p2-timing
+    PR_DIR=$WORKSPACE/rundir
+    if grep -q "passed" $BASELINE_DIR/status.txt; then
+        BASELINE_ARGS_GPU_HLT="$BASELINE_DIR/gpu_memory_ph2_hlt.csv --label1 ${COMPARISON_RELEASE}"
+        BASELINE_ARGS_GPU_NGT="$BASELINE_DIR/gpu_memory_ph2_ngt.csv --label1 ${COMPARISON_RELEASE}"
+        BASELINE_ARGS_CPU_HLT="$BASELINE_DIR/cpu_memory_ph2_hlt.csv --label1 ${COMPARISON_RELEASE}"
+        BASELINE_ARGS_CPU_NGT="$BASELINE_DIR/cpu_memory_ph2_ngt.csv --label1 ${COMPARISON_RELEASE}"
+        BASELINE_ARGS_CPU_HLTONCPU="$BASELINE_DIR/cpu_memory_ph2_hlt_onCPU.csv --label1 ${COMPARISON_RELEASE}"
     else
-	  echo "Baseline job didn't pass, not executing any comparison"
+        echo "Baseline job didn't pass, plotting current job only"
+        BASELINE_ARGS_GPU_HLT=""
+        BASELINE_ARGS_GPU_NGT=""
+        BASELINE_ARGS_CPU_HLT=""
+        BASELINE_ARGS_CPU_NGT=""
+        BASELINE_ARGS_CPU_HLTONCPU=""
     fi
+
+    # run the GPU comparison job for the HLT timing menu
+    compareMemoryProfiles.py $PR_DIR/logs.Phase2_L1P2GT_HLT/gpu_memory.csv $BASELINE_ARGS_GPU_HLT \
+			     --label2 "${PULL_REQUEST}" --cms-label "cmssw integration" \
+			     --no-show --gpu --output hlt_memory_comparison || ERR=1
+    # run the GPU comparison job for the NGT menu
+    compareMemoryProfiles.py $PR_DIR/logs.NGTScouting_L1P2GT_HLT/gpu_memory.csv $BASELINE_ARGS_GPU_NGT \
+			     --label2 "${PULL_REQUEST}" --cms-label "cmssw integration" \
+			     --no-show --gpu --output ngt_memory_comparison || ERR=1
+    # run the CPU comparison job for the HLT timing menu
+    compareMemoryProfiles.py $PR_DIR/logs.Phase2_L1P2GT_HLT/cpu_memory.csv $BASELINE_ARGS_CPU_HLT \
+			     --label2 "${PULL_REQUEST}" --cms-label "cmssw integration" \
+			     --no-show --output hlt_memory_comparison || ERR=1
+    # run the CPU comparison job for the NGT menu
+    compareMemoryProfiles.py $PR_DIR/logs.NGTScouting_L1P2GT_HLT/cpu_memory.csv $BASELINE_ARGS_CPU_NGT \
+			     --label2 "${PULL_REQUEST}" --cms-label "cmssw integration" \
+			     --no-show --output ngt_memory_comparison || ERR=1
+    # run the CPU comparison job for the HLT timing menu (on CPU)
+    compareMemoryProfiles.py $PR_DIR/logs.Phase2_L1P2GT_HLT_OnCPU/cpu_memory.csv $BASELINE_ARGS_CPU_HLTONCPU \
+			     --label2 "${PULL_REQUEST}" --cms-label "cmssw integration" \
+			     --no-show --output hltOnCPU_memory_comparison || ERR=1
+    
+    # copy back the png figures to the output folder
+    cp gpu_hlt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
+    cp gpu_ngt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
+    cp cpu_hlt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
+    cp cpu_ngt_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
+    cp cpu_hltOnCPU_memory_comparison.png $JENKINS_UPLOAD_DIR/hlt-p2-timing/ || ERR=1
 else
     echo "compareMemoryProfiles.py is NOT available"
 fi


### PR DESCRIPTION
To mitigate lack of input files for the baseline: see https://github.com/cms-sw/cms-bot/issues/2799