### PR TITLE
TruthInfo package

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -799,8 +799,10 @@ CMSSW_CATEGORIES = {
         "GeneratorInterface/TauolaInterface",
         "GeneratorInterface/ThePEGInterface",
         "IOMC/ParticleGuns",
+        "PhysicsTools/TruthInfo",
         "SimDataFormats/GeneratorProducts",
         "SimDataFormats/HTXS",
+        "SimDataFormats/TruthInfo",
         "Validation/EventGenerator",
     ],
     "geometry": [


### PR DESCRIPTION
The MC-truth-graph PR cms-sw/cmssw#51213 adds two new packages, PhysicsTools/TruthInfo and SimDataFormats/TruthInfo, that have no category. As  this development was planned together with the GEN group, assign both to the generators category