### PR TITLE
Remove amd_w7900 for now as rocmComputeCapabilities hangs

### DIFF
--- a/gpu_flavors.txt
+++ b/gpu_flavors.txt
@@ -1,5 +1,4 @@
 nvidia_h100
 nvidia_l40s
 nvidia_t4
-amd_w7900
 amd_mi300x


### PR DESCRIPTION
IB/PRs AMD GPU w7900 jobs hangs forever as `rocmComputeCapabilities ` test hangs for this GPU. For now I propose to disable it and first debug the issue locally