### PR TITLE
Add the new truth-graph packages

### DIFF
--- a/categories_map.py
+++ b/categories_map.py
@@ -720,6 +720,7 @@ CMSSW_CATEGORIES = {
         "Validation/TrackerHits",
         "Validation/TrackerRecHits",
         "Validation/TrackingMCTruth",
+        "Validation/TruthInfo",
     ],
     "externals": [
         "",
@@ -806,7 +807,9 @@ CMSSW_CATEGORIES = {
         "SimDataFormats/GeneratorProducts",
         "SimDataFormats/HTXS",
         "SimDataFormats/TruthInfo",
+        "SimGeneral/TruthGraphAssociatorProducers",
         "Validation/EventGenerator",
+        "Validation/TruthInfo",
     ],
     "geometry": [
         "Configuration/Geometry",


### PR DESCRIPTION
Two packages of the MC-truth graph work are not yet in the map: https://github.com/cms-sw/cmssw/pull/51829

`SimGeneral/TruthGraphAssociatorProducers` holds the associators that match reconstructed objects to the truth graph. `Validation/TruthInfo` holds their DQM validation. Both come from the same development as `PhysicsTools/TruthInfo` and `SimDataFormats/TruthInfo`, which are already under `generators`, so they join the same category.

`Validation/TruthInfo` is also listed under `dqm`.

